### PR TITLE
feat: implement Milestone 5 - Toys & Happiness

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -140,16 +140,16 @@ Poop accumulates, requires cleaning items.
 Toys restore Happiness with durability.
 
 ### 5.1 Types & Data
-- [ ] Update `src/game/types/item.ts` - Toy interface with durability
-- [ ] Create `src/game/data/items/toys.ts` - Toy items
+- [x] Update `src/game/types/item.ts` - Toy interface with durability
+- [x] Create `src/game/data/items/toys.ts` - Toy items
 
 ### 5.2 Toy Logic
-- [ ] Update `src/game/core/items.ts` - Use toys, reduce durability
+- [x] Update `src/game/core/items.ts` - Use toys, reduce durability
 
 ### 5.3 Toy UI
-- [ ] Create `src/components/care/PlayButton.tsx` - Toy selection
-- [ ] Update ItemSelector to show durability for toys
-- [ ] Update CareScreen.tsx - Add play button
+- [x] Create `src/components/care/PlayButton.tsx` - Toy selection
+- [x] Update ItemSelector to show durability for toys
+- [x] Update CareScreen.tsx - Add play button
 
 **✓ Testable:** Use toy → Happiness increases, toy durability decreases
 

--- a/src/components/care/PlayButton.tsx
+++ b/src/components/care/PlayButton.tsx
@@ -1,0 +1,57 @@
+/**
+ * Play button component that opens toy selection.
+ */
+
+import { useState } from "react";
+import { ItemSelector } from "@/components/inventory/ItemSelector";
+import { Button } from "@/components/ui/button";
+import { ErrorDialog } from "@/components/ui/error-dialog";
+import { useGameState } from "@/game/hooks/useGameState";
+import { playWithPet } from "@/game/state/actions/care";
+
+/**
+ * Button to open toy selection and play with the pet.
+ */
+export function PlayButton() {
+  const [open, setOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { state, actions } = useGameState();
+
+  if (!state) return null;
+
+  const handleSelect = (itemId: string) => {
+    actions.updateState((currentState) => {
+      const result = playWithPet(currentState, itemId);
+      if (!result.success) {
+        setErrorMessage(result.message);
+      }
+      return result.state;
+    });
+  };
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 flex-1"
+      >
+        <span>🎾</span>
+        <span>Play</span>
+      </Button>
+      <ItemSelector
+        open={open}
+        onOpenChange={setOpen}
+        inventory={state.player.inventory}
+        category="toy"
+        title="Select Toy"
+        description="Choose a toy to play with your pet."
+        onSelect={handleSelect}
+      />
+      <ErrorDialog
+        open={errorMessage !== null}
+        onOpenChange={() => setErrorMessage(null)}
+        message={errorMessage ?? ""}
+      />
+    </>
+  );
+}

--- a/src/components/care/index.ts
+++ b/src/components/care/index.ts
@@ -4,5 +4,6 @@
 
 export { CleanButton } from "./CleanButton";
 export { FeedButton } from "./FeedButton";
+export { PlayButton } from "./PlayButton";
 export { PoopIndicator } from "./PoopIndicator";
 export { WaterButton } from "./WaterButton";

--- a/src/components/inventory/ItemSelector.tsx
+++ b/src/components/inventory/ItemSelector.tsx
@@ -13,7 +13,7 @@ import {
 import { getInventoryItemsByCategory } from "@/game/core/inventory";
 import { getItemById } from "@/game/data/items";
 import type { Inventory, InventoryItem } from "@/game/types/gameState";
-import type { Item, ToyItem } from "@/game/types/item";
+import type { Item } from "@/game/types/item";
 
 interface ItemSelectorProps {
   open: boolean;
@@ -32,10 +32,10 @@ interface ItemButtonProps {
 }
 
 function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
-  const isToy = itemDef.category === "toy";
-  const toyDef = isToy ? (itemDef as ToyItem) : null;
   const durability = inventoryItem.currentDurability;
-  const maxDurability = toyDef?.maxDurability;
+  // TypeScript narrows itemDef to ToyItem when category === "toy"
+  const maxDurability =
+    itemDef.category === "toy" ? itemDef.maxDurability : undefined;
 
   return (
     <Button
@@ -46,7 +46,7 @@ function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
     >
       <span className="text-2xl">{itemDef.icon}</span>
       <span className="text-sm font-medium">{itemDef.name}</span>
-      {isToy && durability !== null && maxDurability ? (
+      {durability !== null && maxDurability !== undefined ? (
         <span className="text-xs text-muted-foreground">
           {durability}/{maxDurability}
         </span>

--- a/src/components/inventory/ItemSelector.tsx
+++ b/src/components/inventory/ItemSelector.tsx
@@ -13,13 +13,13 @@ import {
 import { getInventoryItemsByCategory } from "@/game/core/inventory";
 import { getItemById } from "@/game/data/items";
 import type { Inventory, InventoryItem } from "@/game/types/gameState";
-import type { Item } from "@/game/types/item";
+import type { Item, ToyItem } from "@/game/types/item";
 
 interface ItemSelectorProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   inventory: Inventory;
-  category: "food" | "drink" | "cleaning";
+  category: "food" | "drink" | "cleaning" | "toy";
   title: string;
   description: string;
   onSelect: (itemId: string) => void;
@@ -32,6 +32,11 @@ interface ItemButtonProps {
 }
 
 function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
+  const isToy = itemDef.category === "toy";
+  const toyDef = isToy ? (itemDef as ToyItem) : null;
+  const durability = inventoryItem.currentDurability;
+  const maxDurability = toyDef?.maxDurability;
+
   return (
     <Button
       variant="outline"
@@ -41,9 +46,15 @@ function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
     >
       <span className="text-2xl">{itemDef.icon}</span>
       <span className="text-sm font-medium">{itemDef.name}</span>
-      <span className="text-xs text-muted-foreground">
-        ×{inventoryItem.quantity}
-      </span>
+      {isToy && durability !== null && maxDurability ? (
+        <span className="text-xs text-muted-foreground">
+          {durability}/{maxDurability}
+        </span>
+      ) : (
+        <span className="text-xs text-muted-foreground">
+          ×{inventoryItem.quantity}
+        </span>
+      )}
     </Button>
   );
 }

--- a/src/components/screens/CareScreen.tsx
+++ b/src/components/screens/CareScreen.tsx
@@ -5,6 +5,7 @@
 import {
   CleanButton,
   FeedButton,
+  PlayButton,
   PoopIndicator,
   WaterButton,
 } from "@/components/care";
@@ -110,6 +111,7 @@ export function CareScreen() {
           <div className="flex gap-2">
             <FeedButton />
             <WaterButton />
+            <PlayButton />
             <CleanButton />
           </div>
         </CardContent>

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -301,14 +301,22 @@ test("useToyItem reduces durability by 1", () => {
 });
 
 test("useToyItem destroys toy when durability reaches 0", () => {
-  const state = createTestState();
-  // Set rope to 1 durability so it breaks after use
-  const ropeItem = state.player.inventory.items.find(
+  const baseState = createTestState();
+  // Set rope to 1 durability so it breaks after use (immutable update)
+  const ropeIndex = baseState.player.inventory.items.findIndex(
     (i) => i.itemId === "toy_rope",
   );
-  if (ropeItem) {
-    ropeItem.currentDurability = 1;
-  }
+  const state = {
+    ...baseState,
+    player: {
+      ...baseState.player,
+      inventory: {
+        items: baseState.player.inventory.items.map((item, i) =>
+          i === ropeIndex ? { ...item, currentDurability: 1 } : item,
+        ),
+      },
+    },
+  };
 
   const result = useToyItem(state, "toy_rope");
 

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -6,13 +6,19 @@ import { expect, test } from "bun:test";
 import { createNewPet } from "@/game/data/starting";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
 import type { GameState } from "@/game/types/gameState";
-import { useCleaningItem, useDrinkItem, useFoodItem } from "./items";
+import {
+  useCleaningItem,
+  useDrinkItem,
+  useFoodItem,
+  useToyItem,
+} from "./items";
 
 function createTestState(): GameState {
   const pet = createNewPet("TestPet", "florabit");
   // Reduce stats to test restoration
   pet.careStats.satiety = 10_000;
   pet.careStats.hydration = 10_000;
+  pet.careStats.happiness = 10_000;
   pet.energyStats.energy = 10_000;
 
   return {
@@ -28,6 +34,8 @@ function createTestState(): GameState {
           { itemId: "drink_energy", quantity: 2, currentDurability: null },
           { itemId: "cleaning_tissue", quantity: 3, currentDurability: null },
           { itemId: "cleaning_sponge", quantity: 2, currentDurability: null },
+          { itemId: "toy_ball", quantity: 1, currentDurability: 10 },
+          { itemId: "toy_rope", quantity: 1, currentDurability: 3 },
         ],
       },
       currency: { coins: 100 },
@@ -270,4 +278,94 @@ test("useCleaningItem with sponge removes more poop than tissue", () => {
   expect(result.success).toBe(true);
   // Sponge removes 3 poop
   expect(result.state.pet?.poop.count).toBe(2);
+});
+
+// Toy tests
+test("useToyItem restores happiness", () => {
+  const state = createTestState();
+  const result = useToyItem(state, "toy_ball");
+
+  expect(result.success).toBe(true);
+  expect(result.state.pet?.careStats.happiness).toBeGreaterThan(10_000);
+});
+
+test("useToyItem reduces durability by 1", () => {
+  const state = createTestState();
+  const result = useToyItem(state, "toy_ball");
+
+  expect(result.success).toBe(true);
+  const toyItem = result.state.player.inventory.items.find(
+    (i) => i.itemId === "toy_ball",
+  );
+  expect(toyItem?.currentDurability).toBe(9);
+});
+
+test("useToyItem destroys toy when durability reaches 0", () => {
+  const state = createTestState();
+  // Set rope to 1 durability so it breaks after use
+  const ropeItem = state.player.inventory.items.find(
+    (i) => i.itemId === "toy_rope",
+  );
+  if (ropeItem) {
+    ropeItem.currentDurability = 1;
+  }
+
+  const result = useToyItem(state, "toy_rope");
+
+  expect(result.success).toBe(true);
+  expect(result.message).toContain("broke");
+  // Toy should be removed from inventory
+  const toyItem = result.state.player.inventory.items.find(
+    (i) => i.itemId === "toy_rope",
+  );
+  expect(toyItem).toBeUndefined();
+});
+
+test("useToyItem fails when pet is sleeping", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.sleep.isSleeping = true;
+  }
+
+  const result = useToyItem(state, "toy_ball");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("sleeping");
+});
+
+test("useToyItem fails when no pet exists", () => {
+  const state = createTestState();
+  state.pet = null;
+
+  const result = useToyItem(state, "toy_ball");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("No pet");
+});
+
+test("useToyItem fails when toy not in inventory", () => {
+  const state = createTestState();
+
+  const result = useToyItem(state, "toy_plush");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("inventory");
+});
+
+test("useToyItem fails with invalid toy item", () => {
+  const state = createTestState();
+
+  const result = useToyItem(state, "food_kibble");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("Invalid toy item");
+});
+
+test("useToyItem clamps happiness to max", () => {
+  const state = createTestState();
+  if (state.pet) {
+    // Set happiness near max
+    state.pet.careStats.happiness = 49_000;
+  }
+
+  const result = useToyItem(state, "toy_ball");
+  expect(result.success).toBe(true);
+  // Baby stage max with florabit multiplier is 50_000
+  expect(result.state.pet?.careStats.happiness).toBe(50_000);
 });

--- a/src/game/core/items.ts
+++ b/src/game/core/items.ts
@@ -1,5 +1,5 @@
 /**
- * Item usage logic for consuming food, drinks, and cleaning items.
+ * Item usage logic for consuming food, drinks, cleaning items, and toys.
  */
 
 import { removePoop } from "@/game/core/care/poop";
@@ -7,8 +7,13 @@ import { hasItem, removeItem } from "@/game/core/inventory";
 import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
 import { getItemById } from "@/game/data/items";
 import { getSpeciesById } from "@/game/data/species";
-import type { GameState } from "@/game/types/gameState";
-import { isCleaningItem, isDrinkItem, isFoodItem } from "@/game/types/item";
+import type { GameState, InventoryItem } from "@/game/types/gameState";
+import {
+  isCleaningItem,
+  isDrinkItem,
+  isFoodItem,
+  isToyItem,
+} from "@/game/types/item";
 
 /**
  * Result of using an item.
@@ -254,5 +259,109 @@ export function useCleaningItem(
     success: true,
     state: newState,
     message: `Cleaned ${cleaned} poop with ${itemDef.name}!`,
+  };
+}
+
+/**
+ * Find a toy inventory item by item ID with durability.
+ */
+function findToyInventoryItem(
+  inventory: InventoryItem[],
+  itemId: string,
+): { item: InventoryItem; index: number } | undefined {
+  const index = inventory.findIndex(
+    (item) => item.itemId === itemId && item.currentDurability !== null,
+  );
+  if (index === -1) return undefined;
+  const item = inventory[index];
+  if (!item) return undefined;
+  return { item, index };
+}
+
+/**
+ * Use a toy item to restore happiness. Reduces durability by 1.
+ * Destroys the toy when durability reaches 0.
+ */
+export function useToyItem(state: GameState, itemId: string): UseItemResult {
+  // Check if pet exists
+  if (!state.pet) {
+    return { success: false, state, message: "No pet to play with!" };
+  }
+
+  // Check if pet is sleeping
+  if (state.pet.sleep.isSleeping) {
+    return {
+      success: false,
+      state,
+      message: "Can't play with a sleeping pet!",
+    };
+  }
+
+  // Check if item exists and is a toy
+  const itemDef = getItemById(itemId);
+  if (!itemDef || !isToyItem(itemDef)) {
+    return { success: false, state, message: "Invalid toy item!" };
+  }
+
+  // Find the toy in inventory (with durability)
+  const toyResult = findToyInventoryItem(state.player.inventory.items, itemId);
+  if (!toyResult) {
+    return {
+      success: false,
+      state,
+      message: `No ${itemDef.name} in inventory!`,
+    };
+  }
+
+  const { item: toyItem, index: toyIndex } = toyResult;
+  const currentDurability = toyItem.currentDurability ?? itemDef.maxDurability;
+
+  // Calculate new happiness (clamped to max)
+  const maxCareStat = getMaxCareStat(state);
+  const newHappiness = Math.min(
+    state.pet.careStats.happiness + itemDef.happinessRestore,
+    maxCareStat,
+  );
+
+  // Calculate new durability
+  const newDurability = currentDurability - 1;
+
+  // Update inventory: either reduce durability or remove toy if broken
+  const newItems = [...state.player.inventory.items];
+  if (newDurability <= 0) {
+    // Toy is destroyed
+    newItems.splice(toyIndex, 1);
+  } else {
+    // Update durability
+    newItems[toyIndex] = {
+      ...toyItem,
+      currentDurability: newDurability,
+    };
+  }
+
+  const newState: GameState = {
+    ...state,
+    player: {
+      ...state.player,
+      inventory: { items: newItems },
+    },
+    pet: {
+      ...state.pet,
+      careStats: {
+        ...state.pet.careStats,
+        happiness: newHappiness,
+      },
+    },
+  };
+
+  const message =
+    newDurability <= 0
+      ? `Played with ${itemDef.name}! It broke!`
+      : `Played with ${itemDef.name}!`;
+
+  return {
+    success: true,
+    state: newState,
+    message,
   };
 }

--- a/src/game/core/items.ts
+++ b/src/game/core/items.ts
@@ -263,14 +263,17 @@ export function useCleaningItem(
 }
 
 /**
- * Find a toy inventory item by item ID with durability.
+ * Find a toy inventory item by item ID with positive durability.
  */
 function findToyInventoryItem(
   inventory: InventoryItem[],
   itemId: string,
 ): { item: InventoryItem; index: number } | undefined {
   const index = inventory.findIndex(
-    (item) => item.itemId === itemId && item.currentDurability !== null,
+    (item) =>
+      item.itemId === itemId &&
+      item.currentDurability !== null &&
+      item.currentDurability > 0,
   );
   if (index === -1) return undefined;
   const item = inventory[index];
@@ -314,7 +317,15 @@ export function useToyItem(state: GameState, itemId: string): UseItemResult {
   }
 
   const { item: toyItem, index: toyIndex } = toyResult;
-  const currentDurability = toyItem.currentDurability ?? itemDef.maxDurability;
+  // findToyInventoryItem guarantees currentDurability is non-null and > 0
+  if (toyItem.currentDurability === null) {
+    return {
+      success: false,
+      state,
+      message: `Corrupted inventory: ${itemDef.name} is missing durability!`,
+    };
+  }
+  const currentDurability = toyItem.currentDurability;
 
   // Calculate new happiness (clamped to max)
   const maxCareStat = getMaxCareStat(state);

--- a/src/game/data/items/index.ts
+++ b/src/game/data/items/index.ts
@@ -7,10 +7,12 @@ import type {
   DrinkItem,
   FoodItem,
   Item,
+  ToyItem,
 } from "@/game/types/item";
 import { CLEANING_ITEMS, getCleaningItemById } from "./cleaning";
 import { DRINK_ITEMS, getDrinkItemById } from "./drinks";
 import { FOOD_ITEMS, getFoodItemById } from "./food";
+import { getToyItemById, TOY_ITEMS } from "./toys";
 
 /**
  * All items in the game.
@@ -19,6 +21,7 @@ export const ALL_ITEMS: readonly Item[] = [
   ...FOOD_ITEMS,
   ...DRINK_ITEMS,
   ...CLEANING_ITEMS,
+  ...TOY_ITEMS,
 ] as const;
 
 /**
@@ -58,8 +61,20 @@ export function getAllCleaningItems(): CleaningItem[] {
   return [...CLEANING_ITEMS];
 }
 
+/**
+ * Get all toy items.
+ */
+export function getAllToyItems(): ToyItem[] {
+  return [...TOY_ITEMS];
+}
+
 // Re-export individual lookup functions
-export { getCleaningItemById, getDrinkItemById, getFoodItemById };
+export {
+  getCleaningItemById,
+  getDrinkItemById,
+  getFoodItemById,
+  getToyItemById,
+};
 
 // Re-export item arrays
-export { CLEANING_ITEMS, DRINK_ITEMS, FOOD_ITEMS };
+export { CLEANING_ITEMS, DRINK_ITEMS, FOOD_ITEMS, TOY_ITEMS };

--- a/src/game/data/items/toys.ts
+++ b/src/game/data/items/toys.ts
@@ -1,0 +1,84 @@
+/**
+ * Toy item definitions that restore Happiness with durability.
+ */
+
+import { toMicro } from "@/game/types/common";
+import type { ToyItem } from "@/game/types/item";
+
+/**
+ * Toy items available in the game.
+ */
+export const TOY_ITEMS: readonly ToyItem[] = [
+  {
+    id: "toy_ball",
+    name: "Rubber Ball",
+    description: "A bouncy rubber ball. Simple but fun!",
+    category: "toy",
+    rarity: "common",
+    stackable: false,
+    maxStack: 1,
+    sellValue: 10,
+    icon: "🏐",
+    happinessRestore: toMicro(15),
+    maxDurability: 10,
+  },
+  {
+    id: "toy_rope",
+    name: "Tug Rope",
+    description: "A sturdy rope for tugging and playing.",
+    category: "toy",
+    rarity: "common",
+    stackable: false,
+    maxStack: 1,
+    sellValue: 15,
+    icon: "🪢",
+    happinessRestore: toMicro(18),
+    maxDurability: 12,
+  },
+  {
+    id: "toy_plush",
+    name: "Plush Toy",
+    description: "A soft, cuddly plush companion.",
+    category: "toy",
+    rarity: "uncommon",
+    stackable: false,
+    maxStack: 1,
+    sellValue: 25,
+    icon: "🧸",
+    happinessRestore: toMicro(22),
+    maxDurability: 8,
+  },
+  {
+    id: "toy_squeaky",
+    name: "Squeaky Toy",
+    description: "A squeaky toy that makes amusing sounds!",
+    category: "toy",
+    rarity: "uncommon",
+    stackable: false,
+    maxStack: 1,
+    sellValue: 30,
+    icon: "🐤",
+    happinessRestore: toMicro(25),
+    maxDurability: 15,
+  },
+  {
+    id: "toy_puzzle",
+    name: "Puzzle Toy",
+    description: "A challenging puzzle toy for smart pets.",
+    category: "toy",
+    rarity: "rare",
+    stackable: false,
+    maxStack: 1,
+    sellValue: 50,
+    icon: "🧩",
+    happinessRestore: toMicro(35),
+    maxDurability: 20,
+  },
+] as const;
+
+/**
+ * Get a toy item by ID.
+ */
+export function getToyItemById(id: string): ToyItem | undefined {
+  return TOY_ITEMS.find((item) => item.id === id);
+}

--- a/src/game/state/actions/care.ts
+++ b/src/game/state/actions/care.ts
@@ -1,8 +1,13 @@
 /**
- * Care state actions for feeding, watering, and cleaning.
+ * Care state actions for feeding, watering, cleaning, and playing.
  */
 
-import { useCleaningItem, useDrinkItem, useFoodItem } from "@/game/core/items";
+import {
+  useCleaningItem,
+  useDrinkItem,
+  useFoodItem,
+  useToyItem,
+} from "@/game/core/items";
 import type { GameState } from "@/game/types/gameState";
 
 /**
@@ -33,4 +38,14 @@ export function waterPet(state: GameState, itemId: string): CareActionResult {
  */
 export function cleanPet(state: GameState, itemId: string): CareActionResult {
   return useCleaningItem(state, itemId);
+}
+
+/**
+ * Play with the pet using the specified toy item.
+ */
+export function playWithPet(
+  state: GameState,
+  itemId: string,
+): CareActionResult {
+  return useToyItem(state, itemId);
 }

--- a/src/game/state/initialState.ts
+++ b/src/game/state/initialState.ts
@@ -14,6 +14,7 @@ const STARTING_ITEMS: readonly InventoryItem[] = [
   { itemId: "food_apple", quantity: 5, currentDurability: null },
   { itemId: "drink_water", quantity: 10, currentDurability: null },
   { itemId: "drink_juice", quantity: 5, currentDurability: null },
+  { itemId: "toy_ball", quantity: 1, currentDurability: 10 },
 ] as const;
 
 /**


### PR DESCRIPTION
- Add toy item definitions (ball, rope, plush, squeaky, puzzle)
- Implement useToyItem function with durability tracking
- Create PlayButton component for toy selection
- Update ItemSelector to display durability for toys
- Add play action to CareScreen with all other care actions
- Include starter toy (rubber ball) in new game inventory
- Add comprehensive tests for toy usage mechanics

Toys restore happiness when used and reduce durability by 1 per use. When durability reaches 0, the toy is destroyed and removed from inventory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Five toy items now available: ball, rope, plush, squeaky, and puzzle
  * Play with your pet using toys to increase happiness via new Play button in the care screen
  * Toys have durability that decreases with each use and break when depleted
  * Starting inventory now includes a toy ball

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->