### PR TITLE
fix: address PR review feedback for toys feature

### DIFF
--- a/src/components/inventory/ItemSelector.tsx
+++ b/src/components/inventory/ItemSelector.tsx
@@ -13,7 +13,7 @@ import {
 import { getInventoryItemsByCategory } from "@/game/core/inventory";
 import { getItemById } from "@/game/data/items";
 import type { Inventory, InventoryItem } from "@/game/types/gameState";
-import type { Item, ToyItem } from "@/game/types/item";
+import type { Item } from "@/game/types/item";
 
 interface ItemSelectorProps {
   open: boolean;
@@ -32,10 +32,10 @@ interface ItemButtonProps {
 }
 
 function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
-  const isToy = itemDef.category === "toy";
-  const toyDef = isToy ? (itemDef as ToyItem) : null;
   const durability = inventoryItem.currentDurability;
-  const maxDurability = toyDef?.maxDurability;
+  // TypeScript narrows itemDef to ToyItem when category === "toy"
+  const maxDurability =
+    itemDef.category === "toy" ? itemDef.maxDurability : undefined;
 
   return (
     <Button
@@ -46,7 +46,7 @@ function ItemButton({ inventoryItem, itemDef, onSelect }: ItemButtonProps) {
     >
       <span className="text-2xl">{itemDef.icon}</span>
       <span className="text-sm font-medium">{itemDef.name}</span>
-      {isToy && durability !== null && maxDurability ? (
+      {durability !== null && maxDurability !== undefined ? (
         <span className="text-xs text-muted-foreground">
           {durability}/{maxDurability}
         </span>

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -301,14 +301,22 @@ test("useToyItem reduces durability by 1", () => {
 });
 
 test("useToyItem destroys toy when durability reaches 0", () => {
-  const state = createTestState();
-  // Set rope to 1 durability so it breaks after use
-  const ropeItem = state.player.inventory.items.find(
+  const baseState = createTestState();
+  // Set rope to 1 durability so it breaks after use (immutable update)
+  const ropeIndex = baseState.player.inventory.items.findIndex(
     (i) => i.itemId === "toy_rope",
   );
-  if (ropeItem) {
-    ropeItem.currentDurability = 1;
-  }
+  const state = {
+    ...baseState,
+    player: {
+      ...baseState.player,
+      inventory: {
+        items: baseState.player.inventory.items.map((item, i) =>
+          i === ropeIndex ? { ...item, currentDurability: 1 } : item,
+        ),
+      },
+    },
+  };
 
   const result = useToyItem(state, "toy_rope");
 

--- a/src/game/core/items.ts
+++ b/src/game/core/items.ts
@@ -263,14 +263,17 @@ export function useCleaningItem(
 }
 
 /**
- * Find a toy inventory item by item ID with durability.
+ * Find a toy inventory item by item ID with positive durability.
  */
 function findToyInventoryItem(
   inventory: InventoryItem[],
   itemId: string,
 ): { item: InventoryItem; index: number } | undefined {
   const index = inventory.findIndex(
-    (item) => item.itemId === itemId && item.currentDurability !== null,
+    (item) =>
+      item.itemId === itemId &&
+      item.currentDurability !== null &&
+      item.currentDurability > 0,
   );
   if (index === -1) return undefined;
   const item = inventory[index];
@@ -314,7 +317,15 @@ export function useToyItem(state: GameState, itemId: string): UseItemResult {
   }
 
   const { item: toyItem, index: toyIndex } = toyResult;
-  const currentDurability = toyItem.currentDurability ?? itemDef.maxDurability;
+  // findToyInventoryItem guarantees currentDurability is non-null and > 0
+  if (toyItem.currentDurability === null) {
+    return {
+      success: false,
+      state,
+      message: `Corrupted inventory: ${itemDef.name} is missing durability!`,
+    };
+  }
+  const currentDurability = toyItem.currentDurability;
 
   // Calculate new happiness (clamped to max)
   const maxCareStat = getMaxCareStat(state);


### PR DESCRIPTION
- Fix state mutation in test by using immutable update pattern
- Add durability > 0 check in findToyInventoryItem to prevent using broken toys
- Add explicit null check for corrupted inventory detection
- Remove unnecessary type assertion in ItemSelector (use TS narrowing)
- Simplify ItemButton by removing unused isToy variable

Addresses review comments from kiloconnect, gemini-code-assist, and copilot.