### PR TITLE
feat: add inventory screen with item grid and details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@
 
 import { useState } from "react";
 import { Layout, type NavigationTab } from "@/components/game";
-import { CareScreen } from "@/components/screens";
+import { CareScreen, InventoryScreen } from "@/components/screens";
 import { GameProvider } from "@/game/context/GameContext";
 import "./index.css";
 
@@ -37,7 +37,7 @@ function GameContent({
       case "care":
         return <CareScreen />;
       case "inventory":
-        return <PlaceholderScreen name="Inventory" />;
+        return <InventoryScreen />;
       case "map":
         return <PlaceholderScreen name="Map" />;
       case "training":

--- a/src/components/inventory/ItemDetail.tsx
+++ b/src/components/inventory/ItemDetail.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toDisplay } from "@/game/types/common";
 import type { InventoryItem } from "@/game/types/gameState";
 import type { Item } from "@/game/types/item";
 
@@ -13,6 +14,7 @@ interface ItemDetailProps {
 
 /**
  * Get display text for item category.
+ * Includes mappings for future item types (medicine, battle, equipment, material, key).
  */
 function getCategoryLabel(category: string): string {
   const labels: Record<string, string> = {
@@ -64,7 +66,7 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
     case "food":
       stats.push({
         label: "Satiety",
-        value: `+${(itemDef.satietyRestore / 1_000_000).toFixed(0)}%`,
+        value: `+${toDisplay(itemDef.satietyRestore)}%`,
       });
       if (itemDef.poopAcceleration) {
         stats.push({
@@ -76,19 +78,19 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
     case "drink":
       stats.push({
         label: "Hydration",
-        value: `+${(itemDef.hydrationRestore / 1_000_000).toFixed(0)}%`,
+        value: `+${toDisplay(itemDef.hydrationRestore)}%`,
       });
       if (itemDef.energyRestore) {
         stats.push({
           label: "Energy",
-          value: `+${(itemDef.energyRestore / 1_000_000).toFixed(0)}%`,
+          value: `+${toDisplay(itemDef.energyRestore)}%`,
         });
       }
       break;
     case "toy":
       stats.push({
         label: "Happiness",
-        value: `+${(itemDef.happinessRestore / 1_000_000).toFixed(0)}%`,
+        value: `+${toDisplay(itemDef.happinessRestore)}%`,
       });
       stats.push({
         label: "Durability",
@@ -100,6 +102,9 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
         label: "Poop Removed",
         value: `${itemDef.poopRemoved}`,
       });
+      break;
+    default:
+      // Future item types (medicine, battle, equipment, material, key) will be handled here
       break;
   }
 

--- a/src/components/inventory/ItemDetail.tsx
+++ b/src/components/inventory/ItemDetail.tsx
@@ -4,6 +4,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { toDisplay } from "@/game/types/common";
+import type { ItemCategory, Rarity } from "@/game/types/constants";
 import type { InventoryItem } from "@/game/types/gameState";
 import type { Item } from "@/game/types/item";
 
@@ -16,8 +17,8 @@ interface ItemDetailProps {
  * Get display text for item category.
  * Includes mappings for future item types (medicine, battle, equipment, material, key).
  */
-function getCategoryLabel(category: string): string {
-  const labels: Record<string, string> = {
+function getCategoryLabel(category: ItemCategory): string {
+  const labels: Record<ItemCategory, string> = {
     food: "Food",
     drink: "Drink",
     toy: "Toy",
@@ -28,21 +29,23 @@ function getCategoryLabel(category: string): string {
     material: "Material",
     key: "Key Item",
   };
-  return labels[category] ?? category;
+  return labels[category];
 }
 
 /**
  * Get display text for item rarity.
  */
-function getRarityLabel(rarity: string): string {
+function getRarityLabel(rarity: Rarity): string {
   return rarity.charAt(0).toUpperCase() + rarity.slice(1);
 }
 
 /**
  * Get CSS class for rarity text color.
  */
-function getRarityTextClass(rarity: string): string {
+function getRarityTextClass(rarity: Rarity): string {
   switch (rarity) {
+    case "common":
+      return "text-muted-foreground";
     case "uncommon":
       return "text-green-600 dark:text-green-400";
     case "rare":
@@ -51,8 +54,6 @@ function getRarityTextClass(rarity: string): string {
       return "text-purple-600 dark:text-purple-400";
     case "legendary":
       return "text-yellow-600 dark:text-yellow-400";
-    default:
-      return "text-muted-foreground";
   }
 }
 

--- a/src/components/inventory/ItemDetail.tsx
+++ b/src/components/inventory/ItemDetail.tsx
@@ -1,0 +1,179 @@
+/**
+ * Detail panel for displaying item information.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { InventoryItem } from "@/game/types/gameState";
+import type { Item } from "@/game/types/item";
+
+interface ItemDetailProps {
+  inventoryItem: InventoryItem;
+  itemDef: Item;
+}
+
+/**
+ * Get display text for item category.
+ */
+function getCategoryLabel(category: string): string {
+  const labels: Record<string, string> = {
+    food: "Food",
+    drink: "Drink",
+    toy: "Toy",
+    cleaning: "Cleaning",
+    medicine: "Medicine",
+    battle: "Battle Item",
+    equipment: "Equipment",
+    material: "Material",
+    key: "Key Item",
+  };
+  return labels[category] ?? category;
+}
+
+/**
+ * Get display text for item rarity.
+ */
+function getRarityLabel(rarity: string): string {
+  return rarity.charAt(0).toUpperCase() + rarity.slice(1);
+}
+
+/**
+ * Get CSS class for rarity text color.
+ */
+function getRarityTextClass(rarity: string): string {
+  switch (rarity) {
+    case "uncommon":
+      return "text-green-600 dark:text-green-400";
+    case "rare":
+      return "text-blue-600 dark:text-blue-400";
+    case "epic":
+      return "text-purple-600 dark:text-purple-400";
+    case "legendary":
+      return "text-yellow-600 dark:text-yellow-400";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+/**
+ * Get item-specific stat details.
+ */
+function getItemStats(itemDef: Item): { label: string; value: string }[] {
+  const stats: { label: string; value: string }[] = [];
+
+  switch (itemDef.category) {
+    case "food":
+      stats.push({
+        label: "Satiety",
+        value: `+${(itemDef.satietyRestore / 1_000_000).toFixed(0)}%`,
+      });
+      if (itemDef.poopAcceleration) {
+        stats.push({
+          label: "Poop Speed",
+          value: `+${itemDef.poopAcceleration} ticks`,
+        });
+      }
+      break;
+    case "drink":
+      stats.push({
+        label: "Hydration",
+        value: `+${(itemDef.hydrationRestore / 1_000_000).toFixed(0)}%`,
+      });
+      if (itemDef.energyRestore) {
+        stats.push({
+          label: "Energy",
+          value: `+${(itemDef.energyRestore / 1_000_000).toFixed(0)}%`,
+        });
+      }
+      break;
+    case "toy":
+      stats.push({
+        label: "Happiness",
+        value: `+${(itemDef.happinessRestore / 1_000_000).toFixed(0)}%`,
+      });
+      stats.push({
+        label: "Durability",
+        value: `${itemDef.maxDurability} uses`,
+      });
+      break;
+    case "cleaning":
+      stats.push({
+        label: "Poop Removed",
+        value: `${itemDef.poopRemoved}`,
+      });
+      break;
+  }
+
+  return stats;
+}
+
+/**
+ * Display detailed information about a selected item.
+ */
+export function ItemDetail({ inventoryItem, itemDef }: ItemDetailProps) {
+  const durability = inventoryItem.currentDurability;
+  const maxDurability =
+    itemDef.category === "toy" ? itemDef.maxDurability : undefined;
+  const stats = getItemStats(itemDef);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-3">
+          <span className="text-4xl">{itemDef.icon}</span>
+          <div>
+            <CardTitle className="text-lg">{itemDef.name}</CardTitle>
+            <div className="flex gap-2 text-sm">
+              <span className="text-muted-foreground">
+                {getCategoryLabel(itemDef.category)}
+              </span>
+              <span className={getRarityTextClass(itemDef.rarity)}>
+                {getRarityLabel(itemDef.rarity)}
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">{itemDef.description}</p>
+
+        {/* Quantity/Durability */}
+        <div className="flex gap-4 text-sm">
+          {durability !== null && maxDurability !== undefined ? (
+            <div>
+              <span className="text-muted-foreground">Durability: </span>
+              <span className="font-medium">
+                {durability}/{maxDurability}
+              </span>
+            </div>
+          ) : (
+            <div>
+              <span className="text-muted-foreground">Quantity: </span>
+              <span className="font-medium">{inventoryItem.quantity}</span>
+            </div>
+          )}
+          <div>
+            <span className="text-muted-foreground">Sell: </span>
+            <span className="font-medium">{itemDef.sellValue} coins</span>
+          </div>
+        </div>
+
+        {/* Item Stats */}
+        {stats.length > 0 && (
+          <div className="border-t pt-3">
+            <h4 className="text-sm font-medium mb-2">Effects</h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {stats.map((stat) => (
+                <div key={stat.label}>
+                  <span className="text-muted-foreground">{stat.label}: </span>
+                  <span className="font-medium text-green-600 dark:text-green-400">
+                    {stat.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/inventory/ItemGrid.tsx
+++ b/src/components/inventory/ItemGrid.tsx
@@ -1,0 +1,49 @@
+/**
+ * Grid display for inventory items.
+ */
+
+import { getItemById } from "@/game/data/items";
+import type { InventoryItem } from "@/game/types/gameState";
+import { ItemSlot } from "./ItemSlot";
+
+interface ItemGridProps {
+  items: InventoryItem[];
+  selectedIndex: number | null;
+  onSelectItem: (index: number) => void;
+}
+
+/**
+ * Display inventory items in a responsive grid.
+ */
+export function ItemGrid({
+  items,
+  selectedIndex,
+  onSelectItem,
+}: ItemGridProps) {
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 text-muted-foreground">
+        No items in inventory
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 gap-2">
+      {items.map((invItem, index) => {
+        const itemDef = getItemById(invItem.itemId);
+        if (!itemDef) return null;
+
+        return (
+          <ItemSlot
+            key={`${invItem.itemId}-${index}`}
+            inventoryItem={invItem}
+            itemDef={itemDef}
+            isSelected={selectedIndex === index}
+            onClick={() => onSelectItem(index)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/inventory/ItemSlot.tsx
+++ b/src/components/inventory/ItemSlot.tsx
@@ -2,6 +2,7 @@
  * Single item slot displaying an item with count or durability.
  */
 
+import type { Rarity } from "@/game/types/constants";
 import type { InventoryItem } from "@/game/types/gameState";
 import type { Item } from "@/game/types/item";
 import { cn } from "@/lib/utils";
@@ -16,7 +17,7 @@ interface ItemSlotProps {
 /**
  * Get the CSS class for rarity styling.
  */
-function getRarityClass(rarity: string): string {
+function getRarityClass(rarity: Rarity): string {
   switch (rarity) {
     case "common":
       // Common items use the default border intentionally
@@ -29,8 +30,6 @@ function getRarityClass(rarity: string): string {
       return "border-purple-500";
     case "legendary":
       return "border-yellow-500";
-    default:
-      return "border-border";
   }
 }
 

--- a/src/components/inventory/ItemSlot.tsx
+++ b/src/components/inventory/ItemSlot.tsx
@@ -1,0 +1,74 @@
+/**
+ * Single item slot displaying an item with count or durability.
+ */
+
+import type { InventoryItem } from "@/game/types/gameState";
+import type { Item } from "@/game/types/item";
+import { cn } from "@/lib/utils";
+
+interface ItemSlotProps {
+  inventoryItem: InventoryItem;
+  itemDef: Item;
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * Get the CSS class for rarity styling.
+ */
+function getRarityClass(rarity: string): string {
+  switch (rarity) {
+    case "uncommon":
+      return "border-green-500";
+    case "rare":
+      return "border-blue-500";
+    case "epic":
+      return "border-purple-500";
+    case "legendary":
+      return "border-yellow-500";
+    default:
+      return "border-border";
+  }
+}
+
+/**
+ * Display a single item slot with icon, quantity/durability, and selection state.
+ */
+export function ItemSlot({
+  inventoryItem,
+  itemDef,
+  isSelected = false,
+  onClick,
+}: ItemSlotProps) {
+  const durability = inventoryItem.currentDurability;
+  const maxDurability =
+    itemDef.category === "toy" ? itemDef.maxDurability : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "relative flex flex-col items-center justify-center gap-1 p-2 rounded-lg border-2 transition-all hover:bg-accent",
+        getRarityClass(itemDef.rarity),
+        isSelected && "ring-2 ring-primary bg-primary/10",
+      )}
+    >
+      <span className="text-2xl">{itemDef.icon}</span>
+      <span className="text-xs font-medium truncate max-w-full">
+        {itemDef.name}
+      </span>
+
+      {/* Quantity or Durability indicator */}
+      {durability !== null && maxDurability !== undefined ? (
+        <span className="absolute top-1 right-1 text-xs bg-background/80 px-1 rounded">
+          {durability}/{maxDurability}
+        </span>
+      ) : inventoryItem.quantity > 1 ? (
+        <span className="absolute top-1 right-1 text-xs bg-background/80 px-1 rounded">
+          ×{inventoryItem.quantity}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/inventory/ItemSlot.tsx
+++ b/src/components/inventory/ItemSlot.tsx
@@ -18,6 +18,9 @@ interface ItemSlotProps {
  */
 function getRarityClass(rarity: string): string {
   switch (rarity) {
+    case "common":
+      // Common items use the default border intentionally
+      return "border-border";
     case "uncommon":
       return "border-green-500";
     case "rare":
@@ -48,6 +51,7 @@ export function ItemSlot({
     <button
       type="button"
       onClick={onClick}
+      aria-label={`Select ${itemDef.name}`}
       className={cn(
         "relative flex flex-col items-center justify-center gap-1 p-2 rounded-lg border-2 transition-all hover:bg-accent",
         getRarityClass(itemDef.rarity),

--- a/src/components/screens/InventoryScreen.tsx
+++ b/src/components/screens/InventoryScreen.tsx
@@ -46,10 +46,7 @@ export function InventoryScreen() {
           ? inventoryItems
           : inventoryItems.filter((invItem) => {
               const itemDef = getItemById(invItem.itemId);
-              return (
-                itemDef?.category ===
-                ItemCategory[categoryFilter as keyof typeof ItemCategory]
-              );
+              return itemDef?.category === ItemCategory[categoryFilter];
             }),
     [inventoryItems, categoryFilter],
   );

--- a/src/components/screens/InventoryScreen.tsx
+++ b/src/components/screens/InventoryScreen.tsx
@@ -1,0 +1,134 @@
+/**
+ * Inventory screen for viewing and managing items.
+ */
+
+import { useState } from "react";
+import { ItemDetail } from "@/components/inventory/ItemDetail";
+import { ItemGrid } from "@/components/inventory/ItemGrid";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getItemById } from "@/game/data/items";
+import { useGameState } from "@/game/hooks/useGameState";
+import { ItemCategory } from "@/game/types/constants";
+import type { InventoryItem } from "@/game/types/gameState";
+
+/**
+ * Category filter options for inventory.
+ */
+const CATEGORY_FILTERS: {
+  id: "all" | keyof typeof ItemCategory;
+  label: string;
+  icon: string;
+}[] = [
+  { id: "all", label: "All", icon: "📦" },
+  { id: "Food", label: "Food", icon: "🍎" },
+  { id: "Drink", label: "Drink", icon: "🥤" },
+  { id: "Toy", label: "Toys", icon: "🧸" },
+  { id: "Cleaning", label: "Clean", icon: "🧹" },
+];
+
+/**
+ * Main inventory screen showing all items with filtering and details.
+ */
+export function InventoryScreen() {
+  const { state, isLoading } = useGameState();
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<
+    "all" | keyof typeof ItemCategory
+  >("all");
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!state) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-muted-foreground">No game state found.</p>
+      </div>
+    );
+  }
+
+  const inventory = state.player.inventory;
+
+  // Filter items by category
+  const filteredItems: InventoryItem[] =
+    categoryFilter === "all"
+      ? inventory.items
+      : inventory.items.filter((invItem) => {
+          const itemDef = getItemById(invItem.itemId);
+          return (
+            itemDef?.category ===
+            ItemCategory[categoryFilter as keyof typeof ItemCategory]
+          );
+        });
+
+  // Get selected item details
+  const selectedItem =
+    selectedIndex !== null ? filteredItems[selectedIndex] : null;
+  const selectedItemDef = selectedItem
+    ? getItemById(selectedItem.itemId)
+    : null;
+
+  // Reset selection when filter changes and selected item is no longer visible
+  const handleFilterChange = (filter: "all" | keyof typeof ItemCategory) => {
+    setCategoryFilter(filter);
+    setSelectedIndex(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header with coin display */}
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">Inventory</CardTitle>
+            <div className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400">
+              <span className="text-lg">🪙</span>
+              <span className="font-medium">{state.player.currency.coins}</span>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Category Filters */}
+          <div className="flex gap-1 overflow-x-auto pb-2">
+            {CATEGORY_FILTERS.map((filter) => (
+              <button
+                type="button"
+                key={filter.id}
+                onClick={() => handleFilterChange(filter.id)}
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors whitespace-nowrap ${
+                  categoryFilter === filter.id
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted hover:bg-accent"
+                }`}
+              >
+                <span>{filter.icon}</span>
+                <span>{filter.label}</span>
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Item Grid */}
+      <Card>
+        <CardContent className="pt-4">
+          <ItemGrid
+            items={filteredItems}
+            selectedIndex={selectedIndex}
+            onSelectItem={setSelectedIndex}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Item Detail Panel */}
+      {selectedItem && selectedItemDef && (
+        <ItemDetail inventoryItem={selectedItem} itemDef={selectedItemDef} />
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/InventoryScreen.tsx
+++ b/src/components/screens/InventoryScreen.tsx
@@ -2,14 +2,14 @@
  * Inventory screen for viewing and managing items.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ItemDetail } from "@/components/inventory/ItemDetail";
 import { ItemGrid } from "@/components/inventory/ItemGrid";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getItemById } from "@/game/data/items";
 import { useGameState } from "@/game/hooks/useGameState";
 import { ItemCategory } from "@/game/types/constants";
-import type { InventoryItem } from "@/game/types/gameState";
+import { cn } from "@/lib/utils";
 
 /**
  * Category filter options for inventory.
@@ -36,6 +36,30 @@ export function InventoryScreen() {
     "all" | keyof typeof ItemCategory
   >("all");
 
+  // Filter items by category (memoized to avoid recalculating on every render)
+  const inventoryItems = state?.player.inventory.items;
+  const filteredItems = useMemo(
+    () =>
+      inventoryItems === undefined
+        ? []
+        : categoryFilter === "all"
+          ? inventoryItems
+          : inventoryItems.filter((invItem) => {
+              const itemDef = getItemById(invItem.itemId);
+              return (
+                itemDef?.category ===
+                ItemCategory[categoryFilter as keyof typeof ItemCategory]
+              );
+            }),
+    [inventoryItems, categoryFilter],
+  );
+
+  // Reset selection when filter changes
+  const handleFilterChange = (filter: "all" | keyof typeof ItemCategory) => {
+    setCategoryFilter(filter);
+    setSelectedIndex(null);
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -52,32 +76,12 @@ export function InventoryScreen() {
     );
   }
 
-  const inventory = state.player.inventory;
-
-  // Filter items by category
-  const filteredItems: InventoryItem[] =
-    categoryFilter === "all"
-      ? inventory.items
-      : inventory.items.filter((invItem) => {
-          const itemDef = getItemById(invItem.itemId);
-          return (
-            itemDef?.category ===
-            ItemCategory[categoryFilter as keyof typeof ItemCategory]
-          );
-        });
-
   // Get selected item details
   const selectedItem =
     selectedIndex !== null ? filteredItems[selectedIndex] : null;
   const selectedItemDef = selectedItem
     ? getItemById(selectedItem.itemId)
     : null;
-
-  // Reset selection when filter changes and selected item is no longer visible
-  const handleFilterChange = (filter: "all" | keyof typeof ItemCategory) => {
-    setCategoryFilter(filter);
-    setSelectedIndex(null);
-  };
 
   return (
     <div className="space-y-4">
@@ -100,11 +104,13 @@ export function InventoryScreen() {
                 type="button"
                 key={filter.id}
                 onClick={() => handleFilterChange(filter.id)}
-                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors whitespace-nowrap ${
+                aria-label={`Filter by ${filter.label}`}
+                className={cn(
+                  "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors whitespace-nowrap",
                   categoryFilter === filter.id
                     ? "bg-primary text-primary-foreground"
-                    : "bg-muted hover:bg-accent"
-                }`}
+                    : "bg-muted hover:bg-accent",
+                )}
               >
                 <span>{filter.icon}</span>
                 <span>{filter.label}</span>

--- a/src/components/screens/index.ts
+++ b/src/components/screens/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { CareScreen } from "./CareScreen";
+export { InventoryScreen } from "./InventoryScreen";


### PR DESCRIPTION
Milestone 7 implementation:
- Create InventoryScreen with category filtering and coin display
- Create ItemGrid for responsive item display
- Create ItemSlot with rarity borders and quantity/durability
- Create ItemDetail panel showing item effects and stats
- Wire up inventory tab in navigation to new screen
- Update screens index to export InventoryScreen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented functional inventory interface with item browsing and detailed item views.
  * Added category filtering system (All, Food, Drink, Toy, Cleaning) for streamlined inventory browsing.
  * Item details now display rarity level, effects/stats, durability or quantity, and sell values.
  * Visual item selection with rarity-based styling indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->