### PR TITLE
feat: implement offline progression with report dialog (Milestone 9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -210,13 +210,13 @@ New game flow with starting items.
 Catch up on missed time when returning.
 
 ### 9.1 Offline Logic
-- [ ] Update GameManager - Calculate elapsed ticks on load
-- [ ] Process batch ticks for offline catch-up
-- [ ] Implement time cap (7 days max)
+- [x] Update GameManager - Calculate elapsed ticks on load
+- [x] Process batch ticks for offline catch-up
+- [x] Implement time cap (7 days max)
 
 ### 9.2 Offline UI
-- [ ] Create `src/components/game/OfflineReport.tsx` - Show what happened while away
-- [ ] Display on return if significant time passed
+- [x] Create `src/components/game/OfflineReport.tsx` - Show what happened while away
+- [x] Display on return if significant time passed
 
 **✓ Testable:** Close browser, wait, reopen → See stats have changed, optional report
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState } from "react";
-import { Layout, type NavigationTab } from "@/components/game";
+import { Layout, type NavigationTab, OfflineReport } from "@/components/game";
 import {
   CareScreen,
   InventoryScreen,
@@ -38,7 +38,8 @@ function GameContent({
   activeTab: NavigationTab;
   onTabChange: (tab: NavigationTab) => void;
 }) {
-  const { state, isLoading, loadError, actions } = useGameState();
+  const { state, isLoading, loadError, offlineReport, actions } =
+    useGameState();
 
   // Show loading state
   if (isLoading) {
@@ -89,6 +90,12 @@ function GameContent({
   return (
     <Layout activeTab={activeTab} onTabChange={onTabChange}>
       <div className="pb-20">{renderScreen()}</div>
+      {offlineReport && (
+        <OfflineReport
+          report={offlineReport}
+          onDismiss={actions.dismissOfflineReport}
+        />
+      )}
     </Layout>
   );
 }

--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -92,15 +92,16 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
     petName,
     beforeStats,
     afterStats,
+    maxStats,
     poopBefore,
     poopAfter,
   } = report;
 
   const poopChange = poopAfter - poopBefore;
 
-  // Get max values for display (using adult stage values as approximation)
-  const maxCareStat = 200_000;
-  const maxEnergy = 200_000;
+  // Use max values from report, with fallback for safety
+  const maxCareStat = maxStats?.careStatMax ?? 200_000;
+  const maxEnergy = maxStats?.energyMax ?? 200_000;
 
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
@@ -158,7 +159,8 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
 
             {(afterStats.satiety === 0 ||
               afterStats.hydration === 0 ||
-              afterStats.happiness === 0) && (
+              afterStats.happiness === 0 ||
+              afterStats.energy === 0) && (
               <p className="text-destructive text-sm">
                 ⚠️ Some needs are critical! Take care of your pet immediately.
               </p>

--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -1,0 +1,181 @@
+/**
+ * Offline report dialog showing what happened while the player was away.
+ */
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toDisplay } from "@/game/types/common";
+import type { OfflineReport as OfflineReportType } from "@/game/types/offline";
+
+interface OfflineReportProps {
+  report: OfflineReportType;
+  onDismiss: () => void;
+}
+
+/**
+ * Format elapsed time in a human-readable way.
+ */
+function formatElapsedTime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    const remainingHours = hours % 24;
+    return remainingHours > 0
+      ? `${days} day${days > 1 ? "s" : ""} and ${remainingHours} hour${remainingHours > 1 ? "s" : ""}`
+      : `${days} day${days > 1 ? "s" : ""}`;
+  }
+  if (hours > 0) {
+    const remainingMinutes = minutes % 60;
+    return remainingMinutes > 0
+      ? `${hours} hour${hours > 1 ? "s" : ""} and ${remainingMinutes} minute${remainingMinutes > 1 ? "s" : ""}`
+      : `${hours} hour${hours > 1 ? "s" : ""}`;
+  }
+  if (minutes > 0) {
+    return `${minutes} minute${minutes > 1 ? "s" : ""}`;
+  }
+  return "less than a minute";
+}
+
+/**
+ * Stat change indicator showing the difference between before and after values.
+ */
+function StatChange({
+  label,
+  before,
+  after,
+  max,
+}: {
+  label: string;
+  before: number;
+  after: number;
+  max: number;
+}) {
+  const beforeDisplay = toDisplay(before);
+  const afterDisplay = toDisplay(after);
+  const maxDisplay = toDisplay(max);
+  const change = afterDisplay - beforeDisplay;
+
+  return (
+    <div className="flex justify-between items-center py-1">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="flex items-center gap-2">
+        <span>
+          {afterDisplay}/{maxDisplay}
+        </span>
+        {change !== 0 && (
+          <span className={change < 0 ? "text-destructive" : "text-green-500"}>
+            ({change > 0 ? "+" : ""}
+            {change})
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Display the offline report as a dialog.
+ */
+export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
+  const {
+    elapsedMs,
+    wasCapped,
+    petName,
+    beforeStats,
+    afterStats,
+    poopBefore,
+    poopAfter,
+  } = report;
+
+  const poopChange = poopAfter - poopBefore;
+
+  // Get max values for display (using adult stage values as approximation)
+  const maxCareStat = 200_000;
+  const maxEnergy = 200_000;
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onDismiss()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Welcome Back!</DialogTitle>
+          <DialogDescription>
+            You were away for {formatElapsedTime(elapsedMs)}
+            {wasCapped && " (capped at 7 days)"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {petName && beforeStats && afterStats && (
+          <div className="space-y-4">
+            <p className="text-sm">
+              While you were away, <strong>{petName}</strong> experienced the
+              following changes:
+            </p>
+
+            <div className="space-y-1 text-sm">
+              <StatChange
+                label="Satiety"
+                before={beforeStats.satiety}
+                after={afterStats.satiety}
+                max={maxCareStat}
+              />
+              <StatChange
+                label="Hydration"
+                before={beforeStats.hydration}
+                after={afterStats.hydration}
+                max={maxCareStat}
+              />
+              <StatChange
+                label="Happiness"
+                before={beforeStats.happiness}
+                after={afterStats.happiness}
+                max={maxCareStat}
+              />
+              <StatChange
+                label="Energy"
+                before={beforeStats.energy}
+                after={afterStats.energy}
+                max={maxEnergy}
+              />
+
+              {poopChange > 0 && (
+                <div className="flex justify-between items-center py-1">
+                  <span className="text-muted-foreground">Poop</span>
+                  <span className="text-amber-500">
+                    +{poopChange} poop{poopChange > 1 ? "s" : ""} accumulated
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {(afterStats.satiety === 0 ||
+              afterStats.hydration === 0 ||
+              afterStats.happiness === 0) && (
+              <p className="text-destructive text-sm">
+                ⚠️ Some needs are critical! Take care of your pet immediately.
+              </p>
+            )}
+          </div>
+        )}
+
+        {!petName && (
+          <p className="text-sm text-muted-foreground">
+            Time has passed but you don&apos;t have a pet yet.
+          </p>
+        )}
+
+        <div className="flex justify-end mt-4">
+          <Button onClick={onDismiss}>Continue</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -5,3 +5,4 @@
 export { Header } from "./Header";
 export { Layout } from "./Layout";
 export { Navigation, type NavigationTab } from "./Navigation";
+export { OfflineReport } from "./OfflineReport";

--- a/src/game/context/GameContext.tsx
+++ b/src/game/context/GameContext.tsx
@@ -120,7 +120,10 @@ export function GameProvider({ children }: GameProviderProps) {
 
       const currentTime = Date.now();
       const elapsedMs = currentTime - gameState.lastSaveTime;
-      const ticksElapsed = calculateElapsedTicks(gameState.lastSaveTime);
+      const ticksElapsed = calculateElapsedTicks(
+        gameState.lastSaveTime,
+        currentTime,
+      );
 
       if (ticksElapsed <= 0) return { state: gameState, report: null };
 

--- a/src/game/core/petStats.test.ts
+++ b/src/game/core/petStats.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for pet stats calculation utilities.
+ */
+
+import { expect, test } from "bun:test";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
+import type { Pet } from "@/game/types/pet";
+import { calculatePetMaxStats } from "./petStats";
+
+function createTestPet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    identity: {
+      id: "test_pet",
+      name: "Test Pet",
+      speciesId: "florabit",
+    },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 0,
+    },
+    careStats: {
+      satiety: 40_000,
+      hydration: 40_000,
+      happiness: 40_000,
+    },
+    energyStats: {
+      energy: 40_000,
+    },
+    careLifeStats: {
+      careLife: 72_000,
+    },
+    battleStats: {
+      strength: 10,
+      endurance: 10,
+      agility: 10,
+      precision: 10,
+      fortitude: 10,
+      cunning: 10,
+    },
+    resistances: {
+      slashing: 0,
+      piercing: 0,
+      crushing: 0,
+      chemical: 0,
+      thermal: 0,
+      electric: 0,
+    },
+    poop: {
+      count: 0,
+      ticksUntilNext: 480,
+    },
+    sleep: {
+      isSleeping: false,
+      sleepStartTime: null,
+      sleepTicksToday: 0,
+    },
+    activityState: "idle",
+    ...overrides,
+  };
+}
+
+test("calculatePetMaxStats returns correct values for baby florabit", () => {
+  const pet = createTestPet({
+    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+  });
+  const maxStats = calculatePetMaxStats(pet);
+
+  expect(maxStats).not.toBeNull();
+
+  const species = getSpeciesById("florabit");
+  expect(species).toBeDefined();
+  const stageDef = GROWTH_STAGE_DEFINITIONS.baby;
+
+  const expectedCareMax = Math.floor(
+    stageDef.baseCareStatMax * (species?.careCapMultiplier ?? 1),
+  );
+  const expectedEnergyMax = Math.floor(
+    stageDef.baseEnergyMax * (species?.careCapMultiplier ?? 1),
+  );
+
+  expect(maxStats?.careStatMax).toBe(expectedCareMax);
+  expect(maxStats?.energyMax).toBe(expectedEnergyMax);
+});
+
+test("calculatePetMaxStats returns correct values for adult stage", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "adult",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 1_000_000,
+    },
+  });
+  const maxStats = calculatePetMaxStats(pet);
+
+  expect(maxStats).not.toBeNull();
+
+  const species = getSpeciesById("florabit");
+  expect(species).toBeDefined();
+  const stageDef = GROWTH_STAGE_DEFINITIONS.adult;
+
+  const expectedCareMax = Math.floor(
+    stageDef.baseCareStatMax * (species?.careCapMultiplier ?? 1),
+  );
+  const expectedEnergyMax = Math.floor(
+    stageDef.baseEnergyMax * (species?.careCapMultiplier ?? 1),
+  );
+
+  expect(maxStats?.careStatMax).toBe(expectedCareMax);
+  expect(maxStats?.energyMax).toBe(expectedEnergyMax);
+});
+
+test("calculatePetMaxStats returns null for invalid species", () => {
+  const pet = createTestPet();
+  pet.identity.speciesId = "invalid_species";
+
+  const maxStats = calculatePetMaxStats(pet);
+  expect(maxStats).toBeNull();
+});
+
+test("calculatePetMaxStats values differ between growth stages", () => {
+  const babyPet = createTestPet({
+    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+  });
+  const adultPet = createTestPet({
+    growth: {
+      stage: "adult",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 1_000_000,
+    },
+  });
+
+  const babyStats = calculatePetMaxStats(babyPet);
+  const adultStats = calculatePetMaxStats(adultPet);
+
+  expect(babyStats).not.toBeNull();
+  expect(adultStats).not.toBeNull();
+
+  // Use nullish coalescing to satisfy linter while tests verify non-null above
+  expect(adultStats?.careStatMax ?? 0).toBeGreaterThan(
+    babyStats?.careStatMax ?? 0,
+  );
+  expect(adultStats?.energyMax ?? 0).toBeGreaterThan(babyStats?.energyMax ?? 0);
+});

--- a/src/game/core/petStats.ts
+++ b/src/game/core/petStats.ts
@@ -1,0 +1,37 @@
+/**
+ * Utilities for calculating pet stats based on growth stage and species.
+ */
+
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
+import type { MicroValue } from "@/game/types/common";
+import type { Pet } from "@/game/types/pet";
+
+/**
+ * Maximum stat values for a pet based on growth stage and species.
+ */
+export interface PetMaxStats {
+  /** Maximum care stat value (satiety, hydration, happiness) */
+  careStatMax: MicroValue;
+  /** Maximum energy value */
+  energyMax: MicroValue;
+}
+
+/**
+ * Calculate the maximum stats for a pet based on their growth stage and species.
+ * Returns null if the pet's species or growth stage is invalid.
+ */
+export function calculatePetMaxStats(pet: Pet): PetMaxStats | null {
+  const species = getSpeciesById(pet.identity.speciesId);
+  if (!species) return null;
+
+  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
+  if (!stageDef) return null;
+
+  return {
+    careStatMax: Math.floor(
+      stageDef.baseCareStatMax * species.careCapMultiplier,
+    ),
+    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+  };
+}

--- a/src/game/core/tick.ts
+++ b/src/game/core/tick.ts
@@ -6,9 +6,8 @@ import { applyCareLifeChange } from "@/game/core/care/careLife";
 import { applyCareDecay } from "@/game/core/care/careStats";
 import { processPoopTick } from "@/game/core/care/poop";
 import { applyEnergyRegen } from "@/game/core/energy";
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { processSleepTick } from "@/game/core/sleep";
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
-import { getSpeciesById } from "@/game/data/species";
 import type { Pet } from "@/game/types/pet";
 
 /**
@@ -25,11 +24,9 @@ import type { Pet } from "@/game/types/pet";
  * 7. Activity timers (placeholder for now)
  */
 export function processPetTick(pet: Pet): Pet {
-  const species = getSpeciesById(pet.identity.speciesId);
-  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
-  const careCapMultiplier = species?.careCapMultiplier ?? 1.0;
-  const maxCareStat = Math.floor(stageDef.baseCareStatMax * careCapMultiplier);
-  const maxEnergy = Math.floor(stageDef.baseEnergyMax * careCapMultiplier);
+  const maxStats = calculatePetMaxStats(pet);
+  const maxCareStat = maxStats?.careStatMax ?? 0;
+  const maxEnergy = maxStats?.energyMax ?? 0;
 
   // 1. Care Life drain/recovery (evaluated on current care stat state)
   const newCareLife = applyCareLifeChange(pet, maxCareStat);

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -3,10 +3,16 @@
  */
 
 import { processPetTick } from "@/game/core/tick";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
-import { now } from "@/game/types/common";
+import { now, TICK_DURATION_MS } from "@/game/types/common";
 import type { GameState } from "@/game/types/gameState";
-import type { CareStatsSnapshot, OfflineReport } from "@/game/types/offline";
+import type {
+  CareStatsSnapshot,
+  MaxStatsSnapshot,
+  OfflineReport,
+} from "@/game/types/offline";
 
 /**
  * Process a single game tick, updating the entire game state.
@@ -64,9 +70,9 @@ export interface OfflineCatchupResult {
 }
 
 /**
- * Extract care stats snapshot from game state.
+ * Create care stats snapshot from game state.
  */
-function extractCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
+function createCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
   if (!state.pet) return null;
   return {
     satiety: state.pet.careStats.satiety,
@@ -77,33 +83,58 @@ function extractCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
 }
 
 /**
+ * Create max stats snapshot from game state based on pet's growth stage and species.
+ */
+function createMaxStatsSnapshot(state: GameState): MaxStatsSnapshot | null {
+  if (!state.pet) return null;
+
+  const species = getSpeciesById(state.pet.identity.speciesId);
+  if (!species) return null;
+
+  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
+  if (!stageDef) return null;
+
+  return {
+    careStatMax: Math.floor(
+      stageDef.baseCareStatMax * species.careCapMultiplier,
+    ),
+    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+  };
+}
+
+/**
  * Process offline catch-up ticks.
  */
 export function processOfflineCatchup(
   state: GameState,
   ticksElapsed: Tick,
   maxOfflineTicks: Tick,
-  elapsedMs = 0,
+  elapsedMs?: number,
 ): OfflineCatchupResult {
   const cappedTicks = Math.min(ticksElapsed, maxOfflineTicks);
   const wasCapped = ticksElapsed > maxOfflineTicks;
 
-  const beforeStats = extractCareStatsSnapshot(state);
+  // Calculate elapsedMs from ticks if not provided
+  const reportElapsedMs = elapsedMs ?? ticksElapsed * TICK_DURATION_MS;
+
+  const beforeStats = createCareStatsSnapshot(state);
+  const maxStats = createMaxStatsSnapshot(state);
   const poopBefore = state.pet?.poop.count ?? 0;
   const petName = state.pet?.identity.name ?? null;
 
   const newState = processMultipleTicks(state, cappedTicks);
 
-  const afterStats = extractCareStatsSnapshot(newState);
+  const afterStats = createCareStatsSnapshot(newState);
   const poopAfter = newState.pet?.poop.count ?? 0;
 
   const report: OfflineReport = {
-    elapsedMs,
+    elapsedMs: reportElapsedMs,
     ticksProcessed: cappedTicks,
     wasCapped,
     petName,
     beforeStats,
     afterStats,
+    maxStats,
     poopBefore,
     poopAfter,
   };

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -2,9 +2,8 @@
  * Tick processor for batch processing multiple ticks.
  */
 
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { processPetTick } from "@/game/core/tick";
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
-import { getSpeciesById } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
 import { now, TICK_DURATION_MS } from "@/game/types/common";
 import type { GameState } from "@/game/types/gameState";
@@ -87,18 +86,11 @@ function createCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
  */
 function createMaxStatsSnapshot(state: GameState): MaxStatsSnapshot | null {
   if (!state.pet) return null;
-
-  const species = getSpeciesById(state.pet.identity.speciesId);
-  if (!species) return null;
-
-  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
-  if (!stageDef) return null;
-
+  const maxStats = calculatePetMaxStats(state.pet);
+  if (!maxStats) return null;
   return {
-    careStatMax: Math.floor(
-      stageDef.baseCareStatMax * species.careCapMultiplier,
-    ),
-    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+    careStatMax: maxStats.careStatMax,
+    energyMax: maxStats.energyMax,
   };
 }
 

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -6,6 +6,7 @@ export * from "./common";
 export * from "./constants";
 export * from "./gameState";
 export * from "./item";
+export * from "./offline";
 export * from "./pet";
 export * from "./species";
 export * from "./stats";

--- a/src/game/types/offline.ts
+++ b/src/game/types/offline.ts
@@ -1,0 +1,43 @@
+/**
+ * Types for offline progression reporting.
+ */
+
+import type { MicroValue, Tick } from "./common";
+
+/**
+ * Snapshot of care stats for comparison.
+ */
+export interface CareStatsSnapshot {
+  satiety: MicroValue;
+  hydration: MicroValue;
+  happiness: MicroValue;
+  energy: MicroValue;
+}
+
+/**
+ * Report of changes during offline time.
+ */
+export interface OfflineReport {
+  /** Total real-world time elapsed in milliseconds */
+  elapsedMs: number;
+  /** Number of ticks processed */
+  ticksProcessed: Tick;
+  /** Whether the maximum offline cap was reached */
+  wasCapped: boolean;
+  /** Pet name at time of report (null if no pet) */
+  petName: string | null;
+  /** Care stats before offline processing */
+  beforeStats: CareStatsSnapshot | null;
+  /** Care stats after offline processing */
+  afterStats: CareStatsSnapshot | null;
+  /** Poop count before offline processing */
+  poopBefore: number;
+  /** Poop count after offline processing */
+  poopAfter: number;
+}
+
+/**
+ * Minimum elapsed time (in ms) to show the offline report dialog.
+ * Set to 5 minutes.
+ */
+export const MIN_OFFLINE_REPORT_MS = 5 * 60 * 1000;

--- a/src/game/types/offline.ts
+++ b/src/game/types/offline.ts
@@ -15,6 +15,14 @@ export interface CareStatsSnapshot {
 }
 
 /**
+ * Maximum stat values for the pet at the time of the report.
+ */
+export interface MaxStatsSnapshot {
+  careStatMax: MicroValue;
+  energyMax: MicroValue;
+}
+
+/**
  * Report of changes during offline time.
  */
 export interface OfflineReport {
@@ -30,6 +38,8 @@ export interface OfflineReport {
   beforeStats: CareStatsSnapshot | null;
   /** Care stats after offline processing */
   afterStats: CareStatsSnapshot | null;
+  /** Maximum stat values for the pet */
+  maxStats: MaxStatsSnapshot | null;
   /** Poop count before offline processing */
   poopBefore: number;
   /** Poop count after offline processing */


### PR DESCRIPTION
- Add OfflineReport types for tracking stat changes during offline time
- Enhance processOfflineCatchup to generate detailed offline reports
- Update GameContext to track and expose offline reports
- Create OfflineReport dialog component to show changes while away
- Show report only when away for 5+ minutes
- Display stat changes (satiety, hydration, happiness, energy, poop)
- Include warning when needs are critical
- Implement 7-day cap on offline processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline progression report now displays upon returning to the game, showing elapsed time and pet stat changes during the absence
  * Offline progression is capped at 7 days maximum

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->