### PR TITLE
fix: address PR review feedback for offline progression

### DIFF
--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -92,15 +92,16 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
     petName,
     beforeStats,
     afterStats,
+    maxStats,
     poopBefore,
     poopAfter,
   } = report;
 
   const poopChange = poopAfter - poopBefore;
 
-  // Get max values for display (using adult stage values as approximation)
-  const maxCareStat = 200_000;
-  const maxEnergy = 200_000;
+  // Use max values from report, with fallback for safety
+  const maxCareStat = maxStats?.careStatMax ?? 200_000;
+  const maxEnergy = maxStats?.energyMax ?? 200_000;
 
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
@@ -158,7 +159,8 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
 
             {(afterStats.satiety === 0 ||
               afterStats.hydration === 0 ||
-              afterStats.happiness === 0) && (
+              afterStats.happiness === 0 ||
+              afterStats.energy === 0) && (
               <p className="text-destructive text-sm">
                 ⚠️ Some needs are critical! Take care of your pet immediately.
               </p>

--- a/src/game/context/GameContext.tsx
+++ b/src/game/context/GameContext.tsx
@@ -120,7 +120,10 @@ export function GameProvider({ children }: GameProviderProps) {
 
       const currentTime = Date.now();
       const elapsedMs = currentTime - gameState.lastSaveTime;
-      const ticksElapsed = calculateElapsedTicks(gameState.lastSaveTime);
+      const ticksElapsed = calculateElapsedTicks(
+        gameState.lastSaveTime,
+        currentTime,
+      );
 
       if (ticksElapsed <= 0) return { state: gameState, report: null };
 

--- a/src/game/core/petStats.test.ts
+++ b/src/game/core/petStats.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for pet stats calculation utilities.
+ */
+
+import { expect, test } from "bun:test";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
+import type { Pet } from "@/game/types/pet";
+import { calculatePetMaxStats } from "./petStats";
+
+function createTestPet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    identity: {
+      id: "test_pet",
+      name: "Test Pet",
+      speciesId: "florabit",
+    },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 0,
+    },
+    careStats: {
+      satiety: 40_000,
+      hydration: 40_000,
+      happiness: 40_000,
+    },
+    energyStats: {
+      energy: 40_000,
+    },
+    careLifeStats: {
+      careLife: 72_000,
+    },
+    battleStats: {
+      strength: 10,
+      endurance: 10,
+      agility: 10,
+      precision: 10,
+      fortitude: 10,
+      cunning: 10,
+    },
+    resistances: {
+      slashing: 0,
+      piercing: 0,
+      crushing: 0,
+      chemical: 0,
+      thermal: 0,
+      electric: 0,
+    },
+    poop: {
+      count: 0,
+      ticksUntilNext: 480,
+    },
+    sleep: {
+      isSleeping: false,
+      sleepStartTime: null,
+      sleepTicksToday: 0,
+    },
+    activityState: "idle",
+    ...overrides,
+  };
+}
+
+test("calculatePetMaxStats returns correct values for baby florabit", () => {
+  const pet = createTestPet({
+    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+  });
+  const maxStats = calculatePetMaxStats(pet);
+
+  expect(maxStats).not.toBeNull();
+
+  const species = getSpeciesById("florabit");
+  expect(species).toBeDefined();
+  const stageDef = GROWTH_STAGE_DEFINITIONS.baby;
+
+  const expectedCareMax = Math.floor(
+    stageDef.baseCareStatMax * (species?.careCapMultiplier ?? 1),
+  );
+  const expectedEnergyMax = Math.floor(
+    stageDef.baseEnergyMax * (species?.careCapMultiplier ?? 1),
+  );
+
+  expect(maxStats?.careStatMax).toBe(expectedCareMax);
+  expect(maxStats?.energyMax).toBe(expectedEnergyMax);
+});
+
+test("calculatePetMaxStats returns correct values for adult stage", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "adult",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 1_000_000,
+    },
+  });
+  const maxStats = calculatePetMaxStats(pet);
+
+  expect(maxStats).not.toBeNull();
+
+  const species = getSpeciesById("florabit");
+  expect(species).toBeDefined();
+  const stageDef = GROWTH_STAGE_DEFINITIONS.adult;
+
+  const expectedCareMax = Math.floor(
+    stageDef.baseCareStatMax * (species?.careCapMultiplier ?? 1),
+  );
+  const expectedEnergyMax = Math.floor(
+    stageDef.baseEnergyMax * (species?.careCapMultiplier ?? 1),
+  );
+
+  expect(maxStats?.careStatMax).toBe(expectedCareMax);
+  expect(maxStats?.energyMax).toBe(expectedEnergyMax);
+});
+
+test("calculatePetMaxStats returns null for invalid species", () => {
+  const pet = createTestPet();
+  pet.identity.speciesId = "invalid_species";
+
+  const maxStats = calculatePetMaxStats(pet);
+  expect(maxStats).toBeNull();
+});
+
+test("calculatePetMaxStats values differ between growth stages", () => {
+  const babyPet = createTestPet({
+    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+  });
+  const adultPet = createTestPet({
+    growth: {
+      stage: "adult",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 1_000_000,
+    },
+  });
+
+  const babyStats = calculatePetMaxStats(babyPet);
+  const adultStats = calculatePetMaxStats(adultPet);
+
+  expect(babyStats).not.toBeNull();
+  expect(adultStats).not.toBeNull();
+
+  // Use nullish coalescing to satisfy linter while tests verify non-null above
+  expect(adultStats?.careStatMax ?? 0).toBeGreaterThan(
+    babyStats?.careStatMax ?? 0,
+  );
+  expect(adultStats?.energyMax ?? 0).toBeGreaterThan(babyStats?.energyMax ?? 0);
+});

--- a/src/game/core/petStats.ts
+++ b/src/game/core/petStats.ts
@@ -1,0 +1,37 @@
+/**
+ * Utilities for calculating pet stats based on growth stage and species.
+ */
+
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
+import type { MicroValue } from "@/game/types/common";
+import type { Pet } from "@/game/types/pet";
+
+/**
+ * Maximum stat values for a pet based on growth stage and species.
+ */
+export interface PetMaxStats {
+  /** Maximum care stat value (satiety, hydration, happiness) */
+  careStatMax: MicroValue;
+  /** Maximum energy value */
+  energyMax: MicroValue;
+}
+
+/**
+ * Calculate the maximum stats for a pet based on their growth stage and species.
+ * Returns null if the pet's species or growth stage is invalid.
+ */
+export function calculatePetMaxStats(pet: Pet): PetMaxStats | null {
+  const species = getSpeciesById(pet.identity.speciesId);
+  if (!species) return null;
+
+  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
+  if (!stageDef) return null;
+
+  return {
+    careStatMax: Math.floor(
+      stageDef.baseCareStatMax * species.careCapMultiplier,
+    ),
+    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+  };
+}

--- a/src/game/core/tick.ts
+++ b/src/game/core/tick.ts
@@ -6,9 +6,8 @@ import { applyCareLifeChange } from "@/game/core/care/careLife";
 import { applyCareDecay } from "@/game/core/care/careStats";
 import { processPoopTick } from "@/game/core/care/poop";
 import { applyEnergyRegen } from "@/game/core/energy";
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { processSleepTick } from "@/game/core/sleep";
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
-import { getSpeciesById } from "@/game/data/species";
 import type { Pet } from "@/game/types/pet";
 
 /**
@@ -25,11 +24,9 @@ import type { Pet } from "@/game/types/pet";
  * 7. Activity timers (placeholder for now)
  */
 export function processPetTick(pet: Pet): Pet {
-  const species = getSpeciesById(pet.identity.speciesId);
-  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
-  const careCapMultiplier = species?.careCapMultiplier ?? 1.0;
-  const maxCareStat = Math.floor(stageDef.baseCareStatMax * careCapMultiplier);
-  const maxEnergy = Math.floor(stageDef.baseEnergyMax * careCapMultiplier);
+  const maxStats = calculatePetMaxStats(pet);
+  const maxCareStat = maxStats?.careStatMax ?? 0;
+  const maxEnergy = maxStats?.energyMax ?? 0;
 
   // 1. Care Life drain/recovery (evaluated on current care stat state)
   const newCareLife = applyCareLifeChange(pet, maxCareStat);

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -3,10 +3,16 @@
  */
 
 import { processPetTick } from "@/game/core/tick";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
-import { now } from "@/game/types/common";
+import { now, TICK_DURATION_MS } from "@/game/types/common";
 import type { GameState } from "@/game/types/gameState";
-import type { CareStatsSnapshot, OfflineReport } from "@/game/types/offline";
+import type {
+  CareStatsSnapshot,
+  MaxStatsSnapshot,
+  OfflineReport,
+} from "@/game/types/offline";
 
 /**
  * Process a single game tick, updating the entire game state.
@@ -64,9 +70,9 @@ export interface OfflineCatchupResult {
 }
 
 /**
- * Extract care stats snapshot from game state.
+ * Create care stats snapshot from game state.
  */
-function extractCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
+function createCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
   if (!state.pet) return null;
   return {
     satiety: state.pet.careStats.satiety,
@@ -77,33 +83,58 @@ function extractCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
 }
 
 /**
+ * Create max stats snapshot from game state based on pet's growth stage and species.
+ */
+function createMaxStatsSnapshot(state: GameState): MaxStatsSnapshot | null {
+  if (!state.pet) return null;
+
+  const species = getSpeciesById(state.pet.identity.speciesId);
+  if (!species) return null;
+
+  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
+  if (!stageDef) return null;
+
+  return {
+    careStatMax: Math.floor(
+      stageDef.baseCareStatMax * species.careCapMultiplier,
+    ),
+    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+  };
+}
+
+/**
  * Process offline catch-up ticks.
  */
 export function processOfflineCatchup(
   state: GameState,
   ticksElapsed: Tick,
   maxOfflineTicks: Tick,
-  elapsedMs = 0,
+  elapsedMs?: number,
 ): OfflineCatchupResult {
   const cappedTicks = Math.min(ticksElapsed, maxOfflineTicks);
   const wasCapped = ticksElapsed > maxOfflineTicks;
 
-  const beforeStats = extractCareStatsSnapshot(state);
+  // Calculate elapsedMs from ticks if not provided
+  const reportElapsedMs = elapsedMs ?? ticksElapsed * TICK_DURATION_MS;
+
+  const beforeStats = createCareStatsSnapshot(state);
+  const maxStats = createMaxStatsSnapshot(state);
   const poopBefore = state.pet?.poop.count ?? 0;
   const petName = state.pet?.identity.name ?? null;
 
   const newState = processMultipleTicks(state, cappedTicks);
 
-  const afterStats = extractCareStatsSnapshot(newState);
+  const afterStats = createCareStatsSnapshot(newState);
   const poopAfter = newState.pet?.poop.count ?? 0;
 
   const report: OfflineReport = {
-    elapsedMs,
+    elapsedMs: reportElapsedMs,
     ticksProcessed: cappedTicks,
     wasCapped,
     petName,
     beforeStats,
     afterStats,
+    maxStats,
     poopBefore,
     poopAfter,
   };

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -2,9 +2,8 @@
  * Tick processor for batch processing multiple ticks.
  */
 
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { processPetTick } from "@/game/core/tick";
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
-import { getSpeciesById } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
 import { now, TICK_DURATION_MS } from "@/game/types/common";
 import type { GameState } from "@/game/types/gameState";
@@ -87,18 +86,11 @@ function createCareStatsSnapshot(state: GameState): CareStatsSnapshot | null {
  */
 function createMaxStatsSnapshot(state: GameState): MaxStatsSnapshot | null {
   if (!state.pet) return null;
-
-  const species = getSpeciesById(state.pet.identity.speciesId);
-  if (!species) return null;
-
-  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
-  if (!stageDef) return null;
-
+  const maxStats = calculatePetMaxStats(state.pet);
+  if (!maxStats) return null;
   return {
-    careStatMax: Math.floor(
-      stageDef.baseCareStatMax * species.careCapMultiplier,
-    ),
-    energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
+    careStatMax: maxStats.careStatMax,
+    energyMax: maxStats.energyMax,
   };
 }
 

--- a/src/game/types/offline.ts
+++ b/src/game/types/offline.ts
@@ -15,6 +15,14 @@ export interface CareStatsSnapshot {
 }
 
 /**
+ * Maximum stat values for the pet at the time of the report.
+ */
+export interface MaxStatsSnapshot {
+  careStatMax: MicroValue;
+  energyMax: MicroValue;
+}
+
+/**
  * Report of changes during offline time.
  */
 export interface OfflineReport {
@@ -30,6 +38,8 @@ export interface OfflineReport {
   beforeStats: CareStatsSnapshot | null;
   /** Care stats after offline processing */
   afterStats: CareStatsSnapshot | null;
+  /** Maximum stat values for the pet */
+  maxStats: MaxStatsSnapshot | null;
   /** Poop count before offline processing */
   poopBefore: number;
   /** Poop count after offline processing */


### PR DESCRIPTION
- Add MaxStatsSnapshot type and include in OfflineReport for accurate display
- Calculate max stats dynamically based on pet's growth stage and species
- Pass currentTime to calculateElapsedTicks for consistent time calculations
- Include energy === 0 in critical stats warning check
- Rename extractCareStatsSnapshot to createCareStatsSnapshot for clarity
- Calculate elapsedMs from ticksElapsed if not provided (backwards compatible)