### PR TITLE
feat: Implement Milestone 10 - Growth & Stage Transitions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -227,13 +227,13 @@ Catch up on missed time when returning.
 Pet ages and grows through stages.
 
 ### 10.1 Growth Logic
-- [ ] Create `src/game/core/growth.ts` - Age accumulation, stage checks
-- [ ] Update tickProcessor - Include growth processing
-- [ ] Stage transition stat updates
+- [x] Create `src/game/core/growth.ts` - Age accumulation, stage checks
+- [x] Update tickProcessor - Include growth processing
+- [x] Stage transition stat updates
 
 ### 10.2 Growth UI
-- [ ] Update PetInfo.tsx - Show age, stage, substage
-- [ ] Create `src/components/pet/GrowthProgress.tsx` - Progress to next stage
+- [x] Update PetInfo.tsx - Show age, stage, substage
+- [x] Create `src/components/pet/GrowthProgress.tsx` - Progress to next stage
 - [ ] Add stage transition notification/animation
 
 **✓ Testable:** See age increase, progress bar to next stage (can test by adjusting time)

--- a/src/components/pet/GrowthProgress.tsx
+++ b/src/components/pet/GrowthProgress.tsx
@@ -1,0 +1,86 @@
+/**
+ * Growth progress component showing progress toward next stage.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { GrowthProgressDisplay } from "@/game/state/selectors";
+
+interface GrowthProgressProps {
+  progress: GrowthProgressDisplay;
+}
+
+/**
+ * Progress bar component for growth.
+ */
+function ProgressBar({
+  percent,
+  className = "",
+}: {
+  percent: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`h-2 bg-secondary rounded-full overflow-hidden ${className}`}
+    >
+      <div
+        className="h-full bg-primary transition-all duration-300"
+        style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+      />
+    </div>
+  );
+}
+
+/**
+ * Displays growth progress toward next stage and substage.
+ */
+export function GrowthProgress({ progress }: GrowthProgressProps) {
+  const isFullyGrown = progress.nextStage === null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium">Growth Progress</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Stage progress */}
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">{progress.currentStage}</span>
+            {isFullyGrown ? (
+              <span className="text-muted-foreground">Fully grown</span>
+            ) : (
+              <span className="text-muted-foreground">
+                → {progress.nextStage}
+              </span>
+            )}
+          </div>
+          <ProgressBar percent={progress.stageProgressPercent} />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{progress.stageProgressPercent}%</span>
+            {progress.timeUntilNextStage && (
+              <span>{progress.timeUntilNextStage} remaining</span>
+            )}
+          </div>
+        </div>
+
+        {/* Substage info */}
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            Substage {progress.substage}/{progress.substageCount}
+          </span>
+          {progress.timeUntilNextSubstage && (
+            <span className="text-xs text-muted-foreground">
+              Next substage: {progress.timeUntilNextSubstage}
+            </span>
+          )}
+        </div>
+
+        {/* Age */}
+        <div className="text-xs text-muted-foreground text-center pt-2 border-t">
+          Total age: {progress.ageDays} day{progress.ageDays !== 1 ? "s" : ""}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pet/GrowthProgress.tsx
+++ b/src/components/pet/GrowthProgress.tsx
@@ -19,13 +19,18 @@ function ProgressBar({
   percent: number;
   className?: string;
 }) {
+  const clampedPercent = Math.min(100, Math.max(0, percent));
   return (
     <div
       className={`h-2 bg-secondary rounded-full overflow-hidden ${className}`}
+      role="progressbar"
+      aria-valuenow={clampedPercent}
+      aria-valuemin={0}
+      aria-valuemax={100}
     >
       <div
         className="h-full bg-primary transition-all duration-300"
-        style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+        style={{ width: `${clampedPercent}%` }}
       />
     </div>
   );

--- a/src/components/pet/PetInfo.tsx
+++ b/src/components/pet/PetInfo.tsx
@@ -25,7 +25,7 @@ export function PetInfo({ info }: PetInfoProps) {
           </div>
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">
-              {info.stage} (Stage {info.substage})
+              {info.stage} {info.substage}/{info.substageCount}
             </span>
             <span className="text-muted-foreground">
               {info.ageDays} day{info.ageDays !== 1 ? "s" : ""} old

--- a/src/components/pet/index.ts
+++ b/src/components/pet/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { EnergyBar } from "./EnergyBar";
+export { GrowthProgress } from "./GrowthProgress";
 export { PetInfo } from "./PetInfo";
 export { PetSprite } from "./PetSprite";
 export { PetStatus } from "./PetStatus";

--- a/src/components/screens/CareScreen.tsx
+++ b/src/components/screens/CareScreen.tsx
@@ -10,12 +10,19 @@ import {
   SleepToggle,
   WaterButton,
 } from "@/components/care";
-import { EnergyBar, PetInfo, PetSprite, PetStatus } from "@/components/pet";
+import {
+  EnergyBar,
+  GrowthProgress,
+  PetInfo,
+  PetSprite,
+  PetStatus,
+} from "@/components/pet";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useGameState } from "@/game/hooks/useGameState";
 import {
   selectCareStats,
   selectEnergy,
+  selectGrowthProgress,
   selectPetInfo,
   selectPetSpecies,
   selectPoop,
@@ -48,8 +55,16 @@ export function CareScreen() {
   const energy = selectEnergy(state);
   const species = selectPetSpecies(state);
   const poop = selectPoop(state);
+  const growthProgress = selectGrowthProgress(state);
 
-  if (!petInfo || !careStats || !energy || !species || !poop) {
+  if (
+    !petInfo ||
+    !careStats ||
+    !energy ||
+    !species ||
+    !poop ||
+    !growthProgress
+  ) {
     return (
       <div className="flex items-center justify-center h-64">
         <p className="text-muted-foreground">Error loading pet data.</p>
@@ -70,6 +85,9 @@ export function CareScreen() {
 
       {/* Pet Info */}
       <PetInfo info={petInfo} />
+
+      {/* Growth Progress */}
+      <GrowthProgress progress={growthProgress} />
 
       {/* Care Stats */}
       <PetStatus careStats={careStats} />

--- a/src/components/screens/CareScreen.tsx
+++ b/src/components/screens/CareScreen.tsx
@@ -57,6 +57,7 @@ export function CareScreen() {
   const poop = selectPoop(state);
   const growthProgress = selectGrowthProgress(state);
 
+  // Check all required data is available
   if (
     !petInfo ||
     !careStats ||

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for growth logic.
+ */
+
+import { expect, test } from "bun:test";
+import type { Pet } from "@/game/types/pet";
+import {
+  applyStatGains,
+  calculateStageTransitionStatGains,
+  formatTicksDuration,
+  getNextStage,
+  getStageProgressPercent,
+  getStatGainForRate,
+  getTicksUntilNextStage,
+  getTicksUntilNextSubstage,
+  processGrowthTick,
+} from "./growth";
+
+function createTestPet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    identity: {
+      id: "test_pet",
+      name: "Test Pet",
+      speciesId: "florabit",
+    },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 0,
+    },
+    careStats: {
+      satiety: 40_000,
+      hydration: 40_000,
+      happiness: 40_000,
+    },
+    energyStats: {
+      energy: 40_000,
+    },
+    careLifeStats: {
+      careLife: 72_000,
+    },
+    battleStats: {
+      strength: 10,
+      endurance: 10,
+      agility: 10,
+      precision: 10,
+      fortitude: 10,
+      cunning: 10,
+    },
+    resistances: {
+      slashing: 0,
+      piercing: 0,
+      crushing: 0,
+      chemical: 0,
+      thermal: 0,
+      electric: 0,
+    },
+    poop: {
+      count: 0,
+      ticksUntilNext: 480,
+    },
+    sleep: {
+      isSleeping: false,
+      sleepStartTime: null,
+      sleepTicksToday: 0,
+    },
+    activityState: "idle",
+    ...overrides,
+  };
+}
+
+// getStatGainForRate tests
+test("getStatGainForRate returns 1 for low growth rate", () => {
+  expect(getStatGainForRate("low")).toBe(1);
+});
+
+test("getStatGainForRate returns 3 for medium growth rate", () => {
+  expect(getStatGainForRate("medium")).toBe(3);
+});
+
+test("getStatGainForRate returns 5 for high growth rate", () => {
+  expect(getStatGainForRate("high")).toBe(5);
+});
+
+// calculateStageTransitionStatGains tests
+test("calculateStageTransitionStatGains returns correct gains for florabit", () => {
+  const gains = calculateStageTransitionStatGains("florabit");
+  expect(gains).not.toBeNull();
+  // Florabit has all medium growth rates
+  expect(gains?.strength).toBe(3);
+  expect(gains?.endurance).toBe(3);
+  expect(gains?.agility).toBe(3);
+  expect(gains?.precision).toBe(3);
+  expect(gains?.fortitude).toBe(3);
+  expect(gains?.cunning).toBe(3);
+});
+
+test("calculateStageTransitionStatGains returns correct gains for sparkfin", () => {
+  const gains = calculateStageTransitionStatGains("sparkfin");
+  expect(gains).not.toBeNull();
+  // Sparkfin has high agility/precision, low endurance/fortitude
+  expect(gains?.agility).toBe(5);
+  expect(gains?.precision).toBe(5);
+  expect(gains?.endurance).toBe(1);
+  expect(gains?.fortitude).toBe(1);
+});
+
+test("calculateStageTransitionStatGains returns null for unknown species", () => {
+  const gains = calculateStageTransitionStatGains("unknown_species");
+  expect(gains).toBeNull();
+});
+
+// applyStatGains tests
+test("applyStatGains correctly adds gains to stats", () => {
+  const current = {
+    strength: 10,
+    endurance: 10,
+    agility: 10,
+    precision: 10,
+    fortitude: 10,
+    cunning: 10,
+  };
+  const gains = {
+    strength: 3,
+    endurance: 3,
+    agility: 3,
+    precision: 3,
+    fortitude: 3,
+    cunning: 3,
+  };
+
+  const result = applyStatGains(current, gains);
+
+  expect(result.strength).toBe(13);
+  expect(result.endurance).toBe(13);
+  expect(result.agility).toBe(13);
+  expect(result.precision).toBe(13);
+  expect(result.fortitude).toBe(13);
+  expect(result.cunning).toBe(13);
+});
+
+// processGrowthTick tests
+test("processGrowthTick increments ageTicks", () => {
+  const pet = createTestPet();
+  const result = processGrowthTick(pet);
+
+  expect(result.growth.ageTicks).toBe(1);
+});
+
+test("processGrowthTick does not transition when within same stage", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 100,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(false);
+  expect(result.growth.stage).toBe("baby");
+});
+
+test("processGrowthTick transitions stage when reaching threshold", () => {
+  // Child stage starts at 172_800 ticks
+  const pet = createTestPet({
+    growth: {
+      stage: "baby",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: 172_799,
+    },
+    battleStats: {
+      strength: 10,
+      endurance: 10,
+      agility: 10,
+      precision: 10,
+      fortitude: 10,
+      cunning: 10,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("child");
+  expect(result.previousStage).toBe("baby");
+  // Should have gained stats (florabit has medium growth = +3)
+  expect(result.battleStats.strength).toBe(13);
+});
+
+test("processGrowthTick transitions substage within stage", () => {
+  // Baby has 3 substages over 172_800 ticks = ~57_600 ticks per substage
+  // Substage 2 starts at tick 57_600
+  const pet = createTestPet({
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 57_599,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.substageTransitioned).toBe(true);
+  expect(result.stageTransitioned).toBe(false);
+  expect(result.growth.substage).toBe(2);
+  expect(result.previousSubstage).toBe(1);
+});
+
+test("processGrowthTick does not modify battle stats on substage transition", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: Date.now(),
+      ageTicks: 57_599,
+    },
+    battleStats: {
+      strength: 10,
+      endurance: 10,
+      agility: 10,
+      precision: 10,
+      fortitude: 10,
+      cunning: 10,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.substageTransitioned).toBe(true);
+  expect(result.battleStats.strength).toBe(10);
+});
+
+// getNextStage tests
+test("getNextStage returns child for baby", () => {
+  expect(getNextStage("baby")).toBe("child");
+});
+
+test("getNextStage returns teen for child", () => {
+  expect(getNextStage("child")).toBe("teen");
+});
+
+test("getNextStage returns youngAdult for teen", () => {
+  expect(getNextStage("teen")).toBe("youngAdult");
+});
+
+test("getNextStage returns adult for youngAdult", () => {
+  expect(getNextStage("youngAdult")).toBe("adult");
+});
+
+test("getNextStage returns null for adult", () => {
+  expect(getNextStage("adult")).toBeNull();
+});
+
+// getTicksUntilNextStage tests
+test("getTicksUntilNextStage returns correct ticks for baby at start", () => {
+  const ticks = getTicksUntilNextStage("baby", 0);
+  expect(ticks).toBe(172_800); // Child stage starts at 172_800
+});
+
+test("getTicksUntilNextStage returns correct ticks for baby halfway", () => {
+  const ticks = getTicksUntilNextStage("baby", 86_400);
+  expect(ticks).toBe(86_400); // Half way to child
+});
+
+test("getTicksUntilNextStage returns null for adult", () => {
+  const ticks = getTicksUntilNextStage("adult", 1_036_800);
+  expect(ticks).toBeNull();
+});
+
+// getTicksUntilNextSubstage tests
+test("getTicksUntilNextSubstage returns ticks for substage 1", () => {
+  const ticks = getTicksUntilNextSubstage("baby", 1, 0);
+  // Baby has 3 substages over 172_800 ticks = 57_600 per substage
+  expect(ticks).toBe(57_600);
+});
+
+test("getTicksUntilNextSubstage returns null at max substage", () => {
+  const ticks = getTicksUntilNextSubstage("baby", 3, 172_000);
+  expect(ticks).toBeNull();
+});
+
+// getStageProgressPercent tests
+test("getStageProgressPercent returns 0 at stage start", () => {
+  expect(getStageProgressPercent("baby", 0)).toBe(0);
+});
+
+test("getStageProgressPercent returns 50 halfway through stage", () => {
+  expect(getStageProgressPercent("baby", 86_400)).toBe(50);
+});
+
+test("getStageProgressPercent returns 100 at stage end", () => {
+  expect(getStageProgressPercent("baby", 172_800)).toBe(100);
+});
+
+// formatTicksDuration tests
+test("formatTicksDuration formats minutes", () => {
+  expect(formatTicksDuration(2)).toBe("1m"); // 2 ticks = 60 seconds = 1 minute
+});
+
+test("formatTicksDuration formats hours", () => {
+  expect(formatTicksDuration(120)).toBe("1h"); // 120 ticks = 1 hour
+});
+
+test("formatTicksDuration formats hours and minutes", () => {
+  expect(formatTicksDuration(150)).toBe("1h 15m"); // 150 ticks = 1h 15m
+});
+
+test("formatTicksDuration formats days", () => {
+  expect(formatTicksDuration(2880)).toBe("1d"); // 2880 ticks = 1 day
+});
+
+test("formatTicksDuration formats days and hours", () => {
+  expect(formatTicksDuration(3000)).toBe("1d 1h"); // 1 day + 1 hour
+});

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { expect, test } from "bun:test";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
 import type { Pet } from "@/game/types/pet";
 import {
   applyStatGains,
@@ -164,13 +165,12 @@ test("processGrowthTick does not transition when within same stage", () => {
 });
 
 test("processGrowthTick transitions stage when reaching threshold", () => {
-  // Child stage starts at 172_800 ticks
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 3,
       birthTime: Date.now(),
-      ageTicks: 172_799,
+      ageTicks: GROWTH_STAGE_DEFINITIONS.child.minAgeTicks - 1,
     },
     battleStats: {
       strength: 10,
@@ -190,15 +190,93 @@ test("processGrowthTick transitions stage when reaching threshold", () => {
   expect(result.battleStats.strength).toBe(13);
 });
 
+test("processGrowthTick transitions child to teen", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "child",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.teen.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 13,
+      endurance: 13,
+      agility: 13,
+      precision: 13,
+      fortitude: 13,
+      cunning: 13,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("teen");
+  expect(result.previousStage).toBe("child");
+  expect(result.battleStats.strength).toBe(16);
+});
+
+test("processGrowthTick transitions teen to youngAdult", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "teen",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.youngAdult.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 16,
+      endurance: 16,
+      agility: 16,
+      precision: 16,
+      fortitude: 16,
+      cunning: 16,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("youngAdult");
+  expect(result.previousStage).toBe("teen");
+  expect(result.battleStats.strength).toBe(19);
+});
+
+test("processGrowthTick transitions youngAdult to adult", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "youngAdult",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.adult.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 19,
+      endurance: 19,
+      agility: 19,
+      precision: 19,
+      fortitude: 19,
+      cunning: 19,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("adult");
+  expect(result.previousStage).toBe("youngAdult");
+  expect(result.battleStats.strength).toBe(22);
+});
+
 test("processGrowthTick transitions substage within stage", () => {
-  // Baby has 3 substages over 172_800 ticks = ~57_600 ticks per substage
-  // Substage 2 starts at tick 57_600
+  // Baby has 3 substages, calculate tick for substage transition
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const substageLength = Math.floor(stageDuration / babyDef.substageCount);
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 1,
       birthTime: Date.now(),
-      ageTicks: 57_599,
+      ageTicks: substageLength - 1,
     },
   });
   const result = processGrowthTick(pet);
@@ -210,12 +288,16 @@ test("processGrowthTick transitions substage within stage", () => {
 });
 
 test("processGrowthTick does not modify battle stats on substage transition", () => {
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const substageLength = Math.floor(stageDuration / babyDef.substageCount);
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 1,
       birthTime: Date.now(),
-      ageTicks: 57_599,
+      ageTicks: substageLength - 1,
     },
     battleStats: {
       strength: 10,
@@ -256,28 +338,41 @@ test("getNextStage returns null for adult", () => {
 // getTicksUntilNextStage tests
 test("getTicksUntilNextStage returns correct ticks for baby at start", () => {
   const ticks = getTicksUntilNextStage("baby", 0);
-  expect(ticks).toBe(172_800); // Child stage starts at 172_800
+  expect(ticks).toBe(GROWTH_STAGE_DEFINITIONS.child.minAgeTicks);
 });
 
 test("getTicksUntilNextStage returns correct ticks for baby halfway", () => {
-  const ticks = getTicksUntilNextStage("baby", 86_400);
-  expect(ticks).toBe(86_400); // Half way to child
+  const halfwayTicks = GROWTH_STAGE_DEFINITIONS.child.minAgeTicks / 2;
+  const ticks = getTicksUntilNextStage("baby", halfwayTicks);
+  expect(ticks).toBe(halfwayTicks);
 });
 
 test("getTicksUntilNextStage returns null for adult", () => {
-  const ticks = getTicksUntilNextStage("adult", 1_036_800);
+  const ticks = getTicksUntilNextStage(
+    "adult",
+    GROWTH_STAGE_DEFINITIONS.adult.minAgeTicks,
+  );
   expect(ticks).toBeNull();
 });
 
 // getTicksUntilNextSubstage tests
 test("getTicksUntilNextSubstage returns ticks for substage 1", () => {
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const expectedSubstageLength = Math.floor(
+    stageDuration / babyDef.substageCount,
+  );
   const ticks = getTicksUntilNextSubstage("baby", 1, 0);
-  // Baby has 3 substages over 172_800 ticks = 57_600 per substage
-  expect(ticks).toBe(57_600);
+  expect(ticks).toBe(expectedSubstageLength);
 });
 
 test("getTicksUntilNextSubstage returns null at max substage", () => {
-  const ticks = getTicksUntilNextSubstage("baby", 3, 172_000);
+  const ticks = getTicksUntilNextSubstage(
+    "baby",
+    3,
+    GROWTH_STAGE_DEFINITIONS.child.minAgeTicks - 800,
+  );
   expect(ticks).toBeNull();
 });
 
@@ -287,14 +382,25 @@ test("getStageProgressPercent returns 0 at stage start", () => {
 });
 
 test("getStageProgressPercent returns 50 halfway through stage", () => {
-  expect(getStageProgressPercent("baby", 86_400)).toBe(50);
+  const halfwayTicks = GROWTH_STAGE_DEFINITIONS.child.minAgeTicks / 2;
+  expect(getStageProgressPercent("baby", halfwayTicks)).toBe(50);
 });
 
 test("getStageProgressPercent returns 100 at stage end", () => {
-  expect(getStageProgressPercent("baby", 172_800)).toBe(100);
+  expect(
+    getStageProgressPercent("baby", GROWTH_STAGE_DEFINITIONS.child.minAgeTicks),
+  ).toBe(100);
 });
 
 // formatTicksDuration tests
+test("formatTicksDuration formats 0 ticks", () => {
+  expect(formatTicksDuration(0)).toBe("0m");
+});
+
+test("formatTicksDuration formats 1 tick (less than a minute)", () => {
+  expect(formatTicksDuration(1)).toBe("0m");
+});
+
 test("formatTicksDuration formats minutes", () => {
   expect(formatTicksDuration(2)).toBe("1m"); // 2 ticks = 60 seconds = 1 minute
 });

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -197,8 +197,13 @@ test("processGrowthTick transitions stage when reaching threshold", () => {
   expect(result.stageTransitioned).toBe(true);
   expect(result.growth.stage).toBe("child");
   expect(result.previousStage).toBe("baby");
-  // Should have gained stats (florabit has medium growth = +3)
+  // Should have gained stats (florabit has medium growth = +3 for all stats)
   expect(result.battleStats.strength).toBe(13);
+  expect(result.battleStats.endurance).toBe(13);
+  expect(result.battleStats.agility).toBe(13);
+  expect(result.battleStats.precision).toBe(13);
+  expect(result.battleStats.fortitude).toBe(13);
+  expect(result.battleStats.cunning).toBe(13);
 });
 
 // Parameterized tests for stage transitions

--- a/src/game/core/growth.ts
+++ b/src/game/core/growth.ts
@@ -9,6 +9,7 @@ import {
 } from "@/game/data/growthStages";
 import { getSpeciesById } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
+import { TICK_DURATION_MS, TICKS_PER_MONTH } from "@/game/types/common";
 import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
 import type { Pet, PetGrowth } from "@/game/types/pet";
 import type { StatGrowthRate } from "@/game/types/species";
@@ -16,9 +17,14 @@ import type { BattleStats } from "@/game/types/stats";
 
 /**
  * Duration in ticks for each adult substage (~1 month).
- * 1 tick = 30 seconds, so 86_400 ticks = 30 days.
+ * @deprecated Use TICKS_PER_MONTH from @/game/types/common instead.
  */
-export const ADULT_SUBSTAGE_TICKS = 86_400;
+export const ADULT_SUBSTAGE_TICKS = TICKS_PER_MONTH;
+
+/**
+ * Seconds per tick, derived from TICK_DURATION_MS.
+ */
+const SECONDS_PER_TICK = TICK_DURATION_MS / 1000;
 
 /**
  * Result of processing growth for a tick.
@@ -177,7 +183,7 @@ export function getTicksUntilNextSubstage(
   if (nextStageIndex >= GROWTH_STAGE_ORDER.length) {
     // Adult stage: fixed substage length
     const timeInStage = ageTicks - def.minAgeTicks;
-    const nextSubstageStartTick = substage * ADULT_SUBSTAGE_TICKS;
+    const nextSubstageStartTick = substage * TICKS_PER_MONTH;
     return Math.max(0, nextSubstageStartTick - timeInStage);
   }
 
@@ -220,7 +226,7 @@ export function getStageProgressPercent(
   if (!nextStage) {
     // Adult stage: calculate based on substages
     const timeInStage = ageTicks - def.minAgeTicks;
-    const totalDuration = def.substageCount * ADULT_SUBSTAGE_TICKS;
+    const totalDuration = def.substageCount * TICKS_PER_MONTH;
     return Math.min(100, Math.floor((timeInStage / totalDuration) * 100));
   }
 
@@ -235,7 +241,7 @@ export function getStageProgressPercent(
  * Format ticks as a human-readable duration.
  */
 export function formatTicksDuration(ticks: Tick): string {
-  const totalMinutes = Math.floor((ticks * 30) / 60); // 30 seconds per tick
+  const totalMinutes = Math.floor((ticks * SECONDS_PER_TICK) / 60);
   const totalHours = Math.floor(totalMinutes / 60);
   const totalDays = Math.floor(totalHours / 24);
 

--- a/src/game/core/growth.ts
+++ b/src/game/core/growth.ts
@@ -16,12 +16,6 @@ import type { StatGrowthRate } from "@/game/types/species";
 import type { BattleStats } from "@/game/types/stats";
 
 /**
- * Duration in ticks for each adult substage (~1 month).
- * @deprecated Use TICKS_PER_MONTH from @/game/types/common instead.
- */
-export const ADULT_SUBSTAGE_TICKS = TICKS_PER_MONTH;
-
-/**
  * Seconds per tick, derived from TICK_DURATION_MS.
  */
 const SECONDS_PER_TICK = TICK_DURATION_MS / 1000;

--- a/src/game/core/growth.ts
+++ b/src/game/core/growth.ts
@@ -1,0 +1,254 @@
+/**
+ * Growth logic for pet age accumulation, stage transitions, and stat updates.
+ */
+
+import {
+  GROWTH_STAGE_DEFINITIONS,
+  getStageFromAge,
+  getSubstage,
+} from "@/game/data/growthStages";
+import { getSpeciesById } from "@/game/data/species";
+import type { Tick } from "@/game/types/common";
+import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
+import type { Pet, PetGrowth } from "@/game/types/pet";
+import type { StatGrowthRate } from "@/game/types/species";
+import type { BattleStats } from "@/game/types/stats";
+
+/**
+ * Result of processing growth for a tick.
+ */
+export interface GrowthTickResult {
+  /** Updated growth state */
+  growth: PetGrowth;
+  /** Updated battle stats (if stage changed) */
+  battleStats: BattleStats;
+  /** Whether a main stage transition occurred */
+  stageTransitioned: boolean;
+  /** Whether a substage transition occurred (but not main stage) */
+  substageTransitioned: boolean;
+  /** Previous stage if transitioned */
+  previousStage: GrowthStage | null;
+  /** Previous substage if transitioned */
+  previousSubstage: number | null;
+}
+
+/**
+ * Stat gains per growth rate level per stage transition.
+ * Low: +1-2, Medium: +3-4, High: +5-6
+ */
+const GROWTH_RATE_GAINS: Record<StatGrowthRate, { min: number; max: number }> =
+  {
+    low: { min: 1, max: 2 },
+    medium: { min: 3, max: 4 },
+    high: { min: 5, max: 6 },
+  };
+
+/**
+ * Get stat gain for a given growth rate.
+ * Uses the midpoint (rounded down) for deterministic behavior.
+ */
+export function getStatGainForRate(rate: StatGrowthRate): number {
+  const gains = GROWTH_RATE_GAINS[rate];
+  // Use midpoint for deterministic behavior (can be randomized later if desired)
+  return Math.floor((gains.min + gains.max) / 2);
+}
+
+/**
+ * Calculate battle stat gains for a stage transition.
+ */
+export function calculateStageTransitionStatGains(
+  speciesId: string,
+): BattleStats | null {
+  const species = getSpeciesById(speciesId);
+  if (!species) return null;
+
+  const { statGrowth } = species;
+
+  return {
+    strength: getStatGainForRate(statGrowth.strength),
+    endurance: getStatGainForRate(statGrowth.endurance),
+    agility: getStatGainForRate(statGrowth.agility),
+    precision: getStatGainForRate(statGrowth.precision),
+    fortitude: getStatGainForRate(statGrowth.fortitude),
+    cunning: getStatGainForRate(statGrowth.cunning),
+  };
+}
+
+/**
+ * Apply stat gains to battle stats.
+ */
+export function applyStatGains(
+  currentStats: BattleStats,
+  gains: BattleStats,
+): BattleStats {
+  return {
+    strength: currentStats.strength + gains.strength,
+    endurance: currentStats.endurance + gains.endurance,
+    agility: currentStats.agility + gains.agility,
+    precision: currentStats.precision + gains.precision,
+    fortitude: currentStats.fortitude + gains.fortitude,
+    cunning: currentStats.cunning + gains.cunning,
+  };
+}
+
+/**
+ * Process growth for a single tick.
+ * Increments age and checks for stage/substage transitions.
+ */
+export function processGrowthTick(pet: Pet): GrowthTickResult {
+  const newAgeTicks = pet.growth.ageTicks + 1;
+
+  // Determine new stage and substage based on age
+  const newStage = getStageFromAge(newAgeTicks);
+  const newSubstage = getSubstage(newStage, newAgeTicks);
+
+  const stageTransitioned = newStage !== pet.growth.stage;
+  const substageTransitioned =
+    !stageTransitioned && newSubstage !== pet.growth.substage;
+
+  let newBattleStats = pet.battleStats;
+  let previousStage: GrowthStage | null = null;
+  let previousSubstage: number | null = null;
+
+  // Handle stage transition
+  if (stageTransitioned) {
+    previousStage = pet.growth.stage;
+    previousSubstage = pet.growth.substage;
+
+    // Apply stat gains for stage transition
+    const statGains = calculateStageTransitionStatGains(pet.identity.speciesId);
+    if (statGains) {
+      newBattleStats = applyStatGains(pet.battleStats, statGains);
+    }
+  } else if (substageTransitioned) {
+    previousSubstage = pet.growth.substage;
+  }
+
+  return {
+    growth: {
+      ...pet.growth,
+      ageTicks: newAgeTicks,
+      stage: newStage,
+      substage: newSubstage,
+    },
+    battleStats: newBattleStats,
+    stageTransitioned,
+    substageTransitioned,
+    previousStage,
+    previousSubstage,
+  };
+}
+
+/**
+ * Get the next growth stage (if any).
+ */
+export function getNextStage(stage: GrowthStage): GrowthStage | null {
+  const currentIndex = GROWTH_STAGE_ORDER.indexOf(stage);
+  if (currentIndex === -1 || currentIndex >= GROWTH_STAGE_ORDER.length - 1) {
+    return null;
+  }
+  return GROWTH_STAGE_ORDER[currentIndex + 1] ?? null;
+}
+
+/**
+ * Calculate ticks until next substage.
+ */
+export function getTicksUntilNextSubstage(
+  stage: GrowthStage,
+  substage: number,
+  ageTicks: Tick,
+): Tick | null {
+  const def = GROWTH_STAGE_DEFINITIONS[stage];
+  const stageIndex = GROWTH_STAGE_ORDER.indexOf(stage);
+  const nextStageIndex = stageIndex + 1;
+
+  // If at max substage, return null (need stage transition)
+  if (substage >= def.substageCount) {
+    return null;
+  }
+
+  // Calculate substage length
+  if (nextStageIndex >= GROWTH_STAGE_ORDER.length) {
+    // Adult stage: fixed substage length
+    const substageLength = 86_400; // ~1 month per substage
+    const timeInStage = ageTicks - def.minAgeTicks;
+    const currentSubstageEnd = substage * substageLength;
+    return Math.max(0, currentSubstageEnd - timeInStage);
+  }
+
+  const nextStage = GROWTH_STAGE_ORDER[nextStageIndex];
+  if (!nextStage) return null;
+
+  const nextStageDef = GROWTH_STAGE_DEFINITIONS[nextStage];
+  const stageDuration = nextStageDef.minAgeTicks - def.minAgeTicks;
+  const substageLength = stageDuration / def.substageCount;
+  const timeInStage = ageTicks - def.minAgeTicks;
+  const currentSubstageEnd = substage * substageLength;
+
+  return Math.max(0, Math.floor(currentSubstageEnd - timeInStage));
+}
+
+/**
+ * Calculate ticks until next main stage.
+ */
+export function getTicksUntilNextStage(
+  stage: GrowthStage,
+  ageTicks: Tick,
+): Tick | null {
+  const nextStage = getNextStage(stage);
+  if (!nextStage) return null;
+
+  const nextStageDef = GROWTH_STAGE_DEFINITIONS[nextStage];
+  return Math.max(0, nextStageDef.minAgeTicks - ageTicks);
+}
+
+/**
+ * Calculate progress percentage toward next stage (0-100).
+ */
+export function getStageProgressPercent(
+  stage: GrowthStage,
+  ageTicks: Tick,
+): number {
+  const def = GROWTH_STAGE_DEFINITIONS[stage];
+  const nextStage = getNextStage(stage);
+
+  if (!nextStage) {
+    // Adult stage: calculate based on substages
+    const timeInStage = ageTicks - def.minAgeTicks;
+    const totalDuration = def.substageCount * 86_400; // 3 months for adult
+    return Math.min(100, Math.floor((timeInStage / totalDuration) * 100));
+  }
+
+  const nextStageDef = GROWTH_STAGE_DEFINITIONS[nextStage];
+  const stageDuration = nextStageDef.minAgeTicks - def.minAgeTicks;
+  const timeInStage = ageTicks - def.minAgeTicks;
+
+  return Math.min(100, Math.floor((timeInStage / stageDuration) * 100));
+}
+
+/**
+ * Format ticks as a human-readable duration.
+ */
+export function formatTicksDuration(ticks: Tick): string {
+  const totalMinutes = Math.floor((ticks * 30) / 60); // 30 seconds per tick
+  const totalHours = Math.floor(totalMinutes / 60);
+  const totalDays = Math.floor(totalHours / 24);
+
+  if (totalDays > 0) {
+    const remainingHours = totalHours % 24;
+    if (remainingHours > 0) {
+      return `${totalDays}d ${remainingHours}h`;
+    }
+    return `${totalDays}d`;
+  }
+
+  if (totalHours > 0) {
+    const remainingMinutes = totalMinutes % 60;
+    if (remainingMinutes > 0) {
+      return `${totalHours}h ${remainingMinutes}m`;
+    }
+    return `${totalHours}h`;
+  }
+
+  return `${totalMinutes}m`;
+}

--- a/src/game/core/growth.ts
+++ b/src/game/core/growth.ts
@@ -15,6 +15,12 @@ import type { StatGrowthRate } from "@/game/types/species";
 import type { BattleStats } from "@/game/types/stats";
 
 /**
+ * Duration in ticks for each adult substage (~1 month).
+ * 1 tick = 30 seconds, so 86_400 ticks = 30 days.
+ */
+export const ADULT_SUBSTAGE_TICKS = 86_400;
+
+/**
  * Result of processing growth for a tick.
  */
 export interface GrowthTickResult {
@@ -170,10 +176,9 @@ export function getTicksUntilNextSubstage(
   // Calculate substage length
   if (nextStageIndex >= GROWTH_STAGE_ORDER.length) {
     // Adult stage: fixed substage length
-    const substageLength = 86_400; // ~1 month per substage
     const timeInStage = ageTicks - def.minAgeTicks;
-    const currentSubstageEnd = substage * substageLength;
-    return Math.max(0, currentSubstageEnd - timeInStage);
+    const nextSubstageStartTick = substage * ADULT_SUBSTAGE_TICKS;
+    return Math.max(0, nextSubstageStartTick - timeInStage);
   }
 
   const nextStage = GROWTH_STAGE_ORDER[nextStageIndex];
@@ -183,9 +188,9 @@ export function getTicksUntilNextSubstage(
   const stageDuration = nextStageDef.minAgeTicks - def.minAgeTicks;
   const substageLength = stageDuration / def.substageCount;
   const timeInStage = ageTicks - def.minAgeTicks;
-  const currentSubstageEnd = substage * substageLength;
+  const nextSubstageStartTick = substage * substageLength;
 
-  return Math.max(0, Math.floor(currentSubstageEnd - timeInStage));
+  return Math.max(0, Math.floor(nextSubstageStartTick - timeInStage));
 }
 
 /**
@@ -215,7 +220,7 @@ export function getStageProgressPercent(
   if (!nextStage) {
     // Adult stage: calculate based on substages
     const timeInStage = ageTicks - def.minAgeTicks;
-    const totalDuration = def.substageCount * 86_400; // 3 months for adult
+    const totalDuration = def.substageCount * ADULT_SUBSTAGE_TICKS;
     return Math.min(100, Math.floor((timeInStage / totalDuration) * 100));
   }
 

--- a/src/game/core/tick.ts
+++ b/src/game/core/tick.ts
@@ -6,6 +6,7 @@ import { applyCareLifeChange } from "@/game/core/care/careLife";
 import { applyCareDecay } from "@/game/core/care/careStats";
 import { processPoopTick } from "@/game/core/care/poop";
 import { applyEnergyRegen } from "@/game/core/energy";
+import { processGrowthTick } from "@/game/core/growth";
 import { calculatePetMaxStats } from "@/game/core/petStats";
 import { processSleepTick } from "@/game/core/sleep";
 import type { Pet } from "@/game/types/pet";
@@ -47,17 +48,15 @@ export function processPetTick(pet: Pet): Pet {
   // 5. Sleep timer progress
   const newSleep = processSleepTick(pet.sleep);
 
-  // 6. Growth stage time accumulation
-  const newAgeTicks = pet.growth.ageTicks + 1;
+  // 6. Growth stage time accumulation and stage transitions
+  const growthResult = processGrowthTick(pet);
 
   // 7. Activity timers (placeholder - will be implemented later)
 
   return {
     ...pet,
-    growth: {
-      ...pet.growth,
-      ageTicks: newAgeTicks,
-    },
+    growth: growthResult.growth,
+    battleStats: growthResult.battleStats,
     careStats: newCareStats,
     energyStats: {
       energy: newEnergy,

--- a/src/game/data/growthStages.ts
+++ b/src/game/data/growthStages.ts
@@ -3,6 +3,7 @@
  */
 
 import type { MicroValue, Tick } from "@/game/types/common";
+import { TICKS_PER_MONTH } from "@/game/types/common";
 import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
 
 /**
@@ -117,11 +118,9 @@ export function getSubstage(stage: GrowthStage, ageTicks: Tick): number {
   // If adult, calculate substage based on time in adult stage
   if (nextStageIndex >= GROWTH_STAGE_ORDER.length) {
     const timeInStage = ageTicks - def.minAgeTicks;
-    // Each substage is roughly equal portion of remaining progression
-    const substageLength = 86_400; // ~1 month per substage
     return Math.min(
       def.substageCount,
-      Math.floor(timeInStage / substageLength) + 1,
+      Math.floor(timeInStage / TICKS_PER_MONTH) + 1,
     );
   }
 

--- a/src/game/state/selectors.ts
+++ b/src/game/state/selectors.ts
@@ -271,13 +271,15 @@ export function selectGrowthProgress(
     substageCount: stageDef.substageCount,
     stageProgressPercent: getStageProgressPercent(stage, ageTicks),
     ticksUntilNextStage,
-    timeUntilNextStage: ticksUntilNextStage
-      ? formatTicksDuration(ticksUntilNextStage)
-      : null,
+    timeUntilNextStage:
+      ticksUntilNextStage !== null
+        ? formatTicksDuration(ticksUntilNextStage)
+        : null,
     ticksUntilNextSubstage,
-    timeUntilNextSubstage: ticksUntilNextSubstage
-      ? formatTicksDuration(ticksUntilNextSubstage)
-      : null,
+    timeUntilNextSubstage:
+      ticksUntilNextSubstage !== null
+        ? formatTicksDuration(ticksUntilNextSubstage)
+        : null,
     ageDays,
     ageTicks,
   };

--- a/src/game/types/common.ts
+++ b/src/game/types/common.ts
@@ -61,6 +61,12 @@ export const TICKS_PER_HOUR = 120;
 export const TICKS_PER_DAY = 2880;
 
 /**
+ * Ticks per month (86,400 = 30 days).
+ * Used for adult substage duration.
+ */
+export const TICKS_PER_MONTH = 86_400;
+
+/**
  * Convert milliseconds to ticks.
  */
 export function msToTicks(ms: number): Tick {


### PR DESCRIPTION
- Add growth.ts with age accumulation, stage/substage checks, and stat gains
- Update tickProcessor to use new growth processing logic
- Add battle stat gains on stage transitions based on species growth rates
- Update PetInfo.tsx to show substage progress (e.g., 'Baby 1/3')
- Create GrowthProgress.tsx component with progress bar to next stage
- Add selectGrowthProgress selector with time remaining calculations
- Add comprehensive tests for growth logic (30 new tests)
- Update TODO.md to mark completed tasks

Milestone 10.2 partial: Stage transition notification/animation not yet implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pet growth progress card added to Care view showing current/next stage, substage progress, percent to next stage, and estimated time until advancement.
  * Pet info updated to display stage with substage/count and pet age in days.

* **Tests**
  * Comprehensive growth logic tests added covering age progression, stage/substage transitions, stat changes, and formatting helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->