### PR TITLE
fix: Address PR review feedback for Milestone 10

### DIFF
--- a/src/components/screens/CareScreen.tsx
+++ b/src/components/screens/CareScreen.tsx
@@ -57,6 +57,7 @@ export function CareScreen() {
   const poop = selectPoop(state);
   const growthProgress = selectGrowthProgress(state);
 
+  // Check all required data is available
   if (
     !petInfo ||
     !careStats ||

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { expect, test } from "bun:test";
+import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
 import type { Pet } from "@/game/types/pet";
 import {
   applyStatGains,
@@ -164,13 +165,12 @@ test("processGrowthTick does not transition when within same stage", () => {
 });
 
 test("processGrowthTick transitions stage when reaching threshold", () => {
-  // Child stage starts at 172_800 ticks
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 3,
       birthTime: Date.now(),
-      ageTicks: 172_799,
+      ageTicks: GROWTH_STAGE_DEFINITIONS.child.minAgeTicks - 1,
     },
     battleStats: {
       strength: 10,
@@ -190,15 +190,93 @@ test("processGrowthTick transitions stage when reaching threshold", () => {
   expect(result.battleStats.strength).toBe(13);
 });
 
+test("processGrowthTick transitions child to teen", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "child",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.teen.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 13,
+      endurance: 13,
+      agility: 13,
+      precision: 13,
+      fortitude: 13,
+      cunning: 13,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("teen");
+  expect(result.previousStage).toBe("child");
+  expect(result.battleStats.strength).toBe(16);
+});
+
+test("processGrowthTick transitions teen to youngAdult", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "teen",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.youngAdult.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 16,
+      endurance: 16,
+      agility: 16,
+      precision: 16,
+      fortitude: 16,
+      cunning: 16,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("youngAdult");
+  expect(result.previousStage).toBe("teen");
+  expect(result.battleStats.strength).toBe(19);
+});
+
+test("processGrowthTick transitions youngAdult to adult", () => {
+  const pet = createTestPet({
+    growth: {
+      stage: "youngAdult",
+      substage: 3,
+      birthTime: Date.now(),
+      ageTicks: GROWTH_STAGE_DEFINITIONS.adult.minAgeTicks - 1,
+    },
+    battleStats: {
+      strength: 19,
+      endurance: 19,
+      agility: 19,
+      precision: 19,
+      fortitude: 19,
+      cunning: 19,
+    },
+  });
+  const result = processGrowthTick(pet);
+
+  expect(result.stageTransitioned).toBe(true);
+  expect(result.growth.stage).toBe("adult");
+  expect(result.previousStage).toBe("youngAdult");
+  expect(result.battleStats.strength).toBe(22);
+});
+
 test("processGrowthTick transitions substage within stage", () => {
-  // Baby has 3 substages over 172_800 ticks = ~57_600 ticks per substage
-  // Substage 2 starts at tick 57_600
+  // Baby has 3 substages, calculate tick for substage transition
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const substageLength = Math.floor(stageDuration / babyDef.substageCount);
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 1,
       birthTime: Date.now(),
-      ageTicks: 57_599,
+      ageTicks: substageLength - 1,
     },
   });
   const result = processGrowthTick(pet);
@@ -210,12 +288,16 @@ test("processGrowthTick transitions substage within stage", () => {
 });
 
 test("processGrowthTick does not modify battle stats on substage transition", () => {
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const substageLength = Math.floor(stageDuration / babyDef.substageCount);
   const pet = createTestPet({
     growth: {
       stage: "baby",
       substage: 1,
       birthTime: Date.now(),
-      ageTicks: 57_599,
+      ageTicks: substageLength - 1,
     },
     battleStats: {
       strength: 10,
@@ -256,28 +338,41 @@ test("getNextStage returns null for adult", () => {
 // getTicksUntilNextStage tests
 test("getTicksUntilNextStage returns correct ticks for baby at start", () => {
   const ticks = getTicksUntilNextStage("baby", 0);
-  expect(ticks).toBe(172_800); // Child stage starts at 172_800
+  expect(ticks).toBe(GROWTH_STAGE_DEFINITIONS.child.minAgeTicks);
 });
 
 test("getTicksUntilNextStage returns correct ticks for baby halfway", () => {
-  const ticks = getTicksUntilNextStage("baby", 86_400);
-  expect(ticks).toBe(86_400); // Half way to child
+  const halfwayTicks = GROWTH_STAGE_DEFINITIONS.child.minAgeTicks / 2;
+  const ticks = getTicksUntilNextStage("baby", halfwayTicks);
+  expect(ticks).toBe(halfwayTicks);
 });
 
 test("getTicksUntilNextStage returns null for adult", () => {
-  const ticks = getTicksUntilNextStage("adult", 1_036_800);
+  const ticks = getTicksUntilNextStage(
+    "adult",
+    GROWTH_STAGE_DEFINITIONS.adult.minAgeTicks,
+  );
   expect(ticks).toBeNull();
 });
 
 // getTicksUntilNextSubstage tests
 test("getTicksUntilNextSubstage returns ticks for substage 1", () => {
+  const babyDef = GROWTH_STAGE_DEFINITIONS.baby;
+  const childDef = GROWTH_STAGE_DEFINITIONS.child;
+  const stageDuration = childDef.minAgeTicks - babyDef.minAgeTicks;
+  const expectedSubstageLength = Math.floor(
+    stageDuration / babyDef.substageCount,
+  );
   const ticks = getTicksUntilNextSubstage("baby", 1, 0);
-  // Baby has 3 substages over 172_800 ticks = 57_600 per substage
-  expect(ticks).toBe(57_600);
+  expect(ticks).toBe(expectedSubstageLength);
 });
 
 test("getTicksUntilNextSubstage returns null at max substage", () => {
-  const ticks = getTicksUntilNextSubstage("baby", 3, 172_000);
+  const ticks = getTicksUntilNextSubstage(
+    "baby",
+    3,
+    GROWTH_STAGE_DEFINITIONS.child.minAgeTicks - 800,
+  );
   expect(ticks).toBeNull();
 });
 
@@ -287,14 +382,25 @@ test("getStageProgressPercent returns 0 at stage start", () => {
 });
 
 test("getStageProgressPercent returns 50 halfway through stage", () => {
-  expect(getStageProgressPercent("baby", 86_400)).toBe(50);
+  const halfwayTicks = GROWTH_STAGE_DEFINITIONS.child.minAgeTicks / 2;
+  expect(getStageProgressPercent("baby", halfwayTicks)).toBe(50);
 });
 
 test("getStageProgressPercent returns 100 at stage end", () => {
-  expect(getStageProgressPercent("baby", 172_800)).toBe(100);
+  expect(
+    getStageProgressPercent("baby", GROWTH_STAGE_DEFINITIONS.child.minAgeTicks),
+  ).toBe(100);
 });
 
 // formatTicksDuration tests
+test("formatTicksDuration formats 0 ticks", () => {
+  expect(formatTicksDuration(0)).toBe("0m");
+});
+
+test("formatTicksDuration formats 1 tick (less than a minute)", () => {
+  expect(formatTicksDuration(1)).toBe("0m");
+});
+
 test("formatTicksDuration formats minutes", () => {
   expect(formatTicksDuration(2)).toBe("1m"); // 2 ticks = 60 seconds = 1 minute
 });

--- a/src/game/core/growth.ts
+++ b/src/game/core/growth.ts
@@ -15,6 +15,12 @@ import type { StatGrowthRate } from "@/game/types/species";
 import type { BattleStats } from "@/game/types/stats";
 
 /**
+ * Duration in ticks for each adult substage (~1 month).
+ * 1 tick = 30 seconds, so 86_400 ticks = 30 days.
+ */
+export const ADULT_SUBSTAGE_TICKS = 86_400;
+
+/**
  * Result of processing growth for a tick.
  */
 export interface GrowthTickResult {
@@ -170,10 +176,9 @@ export function getTicksUntilNextSubstage(
   // Calculate substage length
   if (nextStageIndex >= GROWTH_STAGE_ORDER.length) {
     // Adult stage: fixed substage length
-    const substageLength = 86_400; // ~1 month per substage
     const timeInStage = ageTicks - def.minAgeTicks;
-    const currentSubstageEnd = substage * substageLength;
-    return Math.max(0, currentSubstageEnd - timeInStage);
+    const nextSubstageStartTick = substage * ADULT_SUBSTAGE_TICKS;
+    return Math.max(0, nextSubstageStartTick - timeInStage);
   }
 
   const nextStage = GROWTH_STAGE_ORDER[nextStageIndex];
@@ -183,9 +188,9 @@ export function getTicksUntilNextSubstage(
   const stageDuration = nextStageDef.minAgeTicks - def.minAgeTicks;
   const substageLength = stageDuration / def.substageCount;
   const timeInStage = ageTicks - def.minAgeTicks;
-  const currentSubstageEnd = substage * substageLength;
+  const nextSubstageStartTick = substage * substageLength;
 
-  return Math.max(0, Math.floor(currentSubstageEnd - timeInStage));
+  return Math.max(0, Math.floor(nextSubstageStartTick - timeInStage));
 }
 
 /**
@@ -215,7 +220,7 @@ export function getStageProgressPercent(
   if (!nextStage) {
     // Adult stage: calculate based on substages
     const timeInStage = ageTicks - def.minAgeTicks;
-    const totalDuration = def.substageCount * 86_400; // 3 months for adult
+    const totalDuration = def.substageCount * ADULT_SUBSTAGE_TICKS;
     return Math.min(100, Math.floor((timeInStage / totalDuration) * 100));
   }
 


### PR DESCRIPTION
- Extract magic number 86_400 as ADULT_SUBSTAGE_TICKS constant
- Rename currentSubstageEnd to nextSubstageStartTick for clarity
- Use GROWTH_STAGE_DEFINITIONS constants instead of hardcoded tick values in tests
- Add tests for all stage transitions (child→teen, teen→youngAdult, youngAdult→adult)
- Add edge case tests for formatTicksDuration (0 and 1 tick)
- Add clarifying comment for required data check in CareScreen

Note: The array.some() suggestion for CareScreen was not applied as it breaks TypeScript type narrowing - the explicit checks are necessary.