### PR TITLE
feat: implement NPCs and dialogue system (Milestone 16)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -363,18 +363,18 @@ Non-battle skills for exploration.
 Interactable NPCs in towns.
 
 ### 16.1 Types & Data
-- [ ] Create `src/game/types/npc.ts` - NPC, Dialogue interfaces
-- [ ] Create `src/game/data/npcs.ts` - Initial NPCs
-- [ ] Create `src/game/data/dialogues.ts` - Dialogue trees
+- [x] Create `src/game/types/npc.ts` - NPC, Dialogue interfaces
+- [x] Create `src/game/data/npcs.ts` - Initial NPCs
+- [x] Create `src/game/data/dialogues.ts` - Dialogue trees
 
 ### 16.2 Dialogue Logic
-- [ ] Create `src/game/core/dialogue.ts` - Dialogue navigation
+- [x] Create `src/game/core/dialogue.ts` - Dialogue navigation
 
 ### 16.3 NPC UI
-- [ ] Create `src/components/npc/NPCDisplay.tsx` - NPC visual
-- [ ] Create `src/components/npc/DialogueBox.tsx` - Dialogue display
-- [ ] Create `src/components/npc/DialogueChoices.tsx` - Response options
-- [ ] Update LocationDetail - Show NPCs in location
+- [x] Create `src/components/npc/NPCDisplay.tsx` - NPC visual
+- [x] Create `src/components/npc/DialogueBox.tsx` - Dialogue display
+- [x] Create `src/components/npc/DialogueChoices.tsx` - Response options
+- [x] Update LocationDetail - Show NPCs in location
 
 **✓ Testable:** Visit town → Click NPC → Read dialogue → Make choices
 

--- a/src/components/map/LocationDetail.tsx
+++ b/src/components/map/LocationDetail.tsx
@@ -2,8 +2,10 @@
  * Location detail component showing information about a selected location.
  */
 
+import { NPCDisplay } from "@/components/npc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getNpcsAtLocation } from "@/game/data/npcs";
 import type { Location } from "@/game/types/location";
 import { FacilityType, LocationType } from "@/game/types/location";
 
@@ -14,6 +16,7 @@ interface LocationDetailProps {
   travelMessage?: string;
   energyCost?: number;
   onTravel: () => void;
+  onNpcClick?: (npcId: string) => void;
 }
 
 /**
@@ -95,8 +98,10 @@ export function LocationDetail({
   travelMessage,
   energyCost,
   onTravel,
+  onNpcClick,
 }: LocationDetailProps) {
   const typeDisplay = getLocationTypeDisplay(location.type);
+  const npcs = isCurrentLocation ? getNpcsAtLocation(location.id) : [];
 
   return (
     <Card>
@@ -144,6 +149,22 @@ export function LocationDetail({
                   </span>
                 );
               })}
+            </div>
+          </div>
+        )}
+
+        {/* NPCs (only shown for current location) */}
+        {isCurrentLocation && npcs.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium mb-2">People Here</h4>
+            <div className="flex flex-col gap-2">
+              {npcs.map((npc) => (
+                <NPCDisplay
+                  key={npc.id}
+                  npc={npc}
+                  onClick={() => onNpcClick?.(npc.id)}
+                />
+              ))}
             </div>
           </div>
         )}

--- a/src/components/npc/DialogueBox.tsx
+++ b/src/components/npc/DialogueBox.tsx
@@ -2,6 +2,7 @@
  * Dialogue box component for displaying NPC speech.
  */
 
+import type { KeyboardEvent } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import type { NPC } from "@/game/types/npc";
 
@@ -21,12 +22,25 @@ export function DialogueBox({
   onClick,
   showContinue = false,
 }: DialogueBoxProps) {
+  const handleKeyDown = onClick
+    ? (e: KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }
+    : undefined;
+
   return (
     <Card
       className={
         onClick ? "cursor-pointer hover:bg-accent/50 transition-colors" : ""
       }
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={handleKeyDown}
+      aria-label={onClick ? "Continue dialogue" : undefined}
     >
       <CardContent className="pt-4">
         <div className="flex gap-3">

--- a/src/components/npc/DialogueBox.tsx
+++ b/src/components/npc/DialogueBox.tsx
@@ -1,0 +1,49 @@
+/**
+ * Dialogue box component for displaying NPC speech.
+ */
+
+import { Card, CardContent } from "@/components/ui/card";
+import type { NPC } from "@/game/types/npc";
+
+interface DialogueBoxProps {
+  npc: NPC;
+  text: string;
+  onClick?: () => void;
+  showContinue?: boolean;
+}
+
+/**
+ * Displays NPC dialogue text in a styled box.
+ */
+export function DialogueBox({
+  npc,
+  text,
+  onClick,
+  showContinue = false,
+}: DialogueBoxProps) {
+  return (
+    <Card
+      className={
+        onClick ? "cursor-pointer hover:bg-accent/50 transition-colors" : ""
+      }
+      onClick={onClick}
+    >
+      <CardContent className="pt-4">
+        <div className="flex gap-3">
+          <span className="text-3xl shrink-0">{npc.emoji}</span>
+          <div className="flex-1">
+            <div className="font-medium text-sm mb-1">{npc.name}</div>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {text}
+            </p>
+            {showContinue && (
+              <p className="text-xs text-muted-foreground/60 mt-2 italic">
+                Click to continue...
+              </p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/npc/DialogueChoices.tsx
+++ b/src/components/npc/DialogueChoices.tsx
@@ -1,0 +1,32 @@
+/**
+ * Dialogue choices component for player response options.
+ */
+
+import { Button } from "@/components/ui/button";
+import type { DialogueChoice } from "@/game/types/npc";
+
+interface DialogueChoicesProps {
+  choices: DialogueChoice[];
+  onSelect: (index: number) => void;
+}
+
+/**
+ * Displays dialogue choice buttons for player selection.
+ */
+export function DialogueChoices({ choices, onSelect }: DialogueChoicesProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {choices.map((choice, index) => (
+        <Button
+          key={choice.nextNodeId}
+          variant="outline"
+          className="justify-start text-left h-auto py-3 px-4"
+          onClick={() => onSelect(index)}
+        >
+          <span className="text-muted-foreground mr-2">{index + 1}.</span>
+          {choice.text}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/npc/DialogueChoices.tsx
+++ b/src/components/npc/DialogueChoices.tsx
@@ -18,7 +18,7 @@ export function DialogueChoices({ choices, onSelect }: DialogueChoicesProps) {
     <div className="flex flex-col gap-2">
       {choices.map((choice, index) => (
         <Button
-          key={choice.nextNodeId}
+          key={`choice-${index}-${choice.nextNodeId}`}
           variant="outline"
           className="justify-start text-left h-auto py-3 px-4"
           onClick={() => onSelect(index)}

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -109,7 +109,12 @@ export function DialogueScreen({
               <span className="text-2xl">{npc.emoji}</span>
               <CardTitle className="text-lg">{npc.name}</CardTitle>
             </div>
-            <Button variant="ghost" size="sm" onClick={onClose}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              aria-label="Close dialogue"
+            >
               ✕
             </Button>
           </div>

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -1,0 +1,180 @@
+/**
+ * Dialogue screen component for NPC conversations.
+ */
+
+import { useCallback, useState } from "react";
+import { DialogueBox, DialogueChoices } from "@/components/npc";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  advanceDialogue,
+  selectChoice,
+  startDialogue,
+} from "@/game/core/dialogue";
+import { getNpc } from "@/game/data/npcs";
+import type { DialogueNode, DialogueState } from "@/game/types/npc";
+import { DialogueNodeType } from "@/game/types/npc";
+
+interface DialogueScreenProps {
+  npcId: string;
+  onClose: () => void;
+  onOpenShop?: (npcId: string) => void;
+}
+
+/**
+ * Full-screen dialogue interface for NPC conversations.
+ */
+export function DialogueScreen({
+  npcId,
+  onClose,
+  onOpenShop,
+}: DialogueScreenProps) {
+  const npc = getNpc(npcId);
+
+  // Initialize dialogue state
+  const [dialogueState, setDialogueState] = useState<DialogueState | null>(
+    () => {
+      const result = startDialogue(npcId);
+      return result.success && result.state ? result.state : null;
+    },
+  );
+  const [currentNode, setCurrentNode] = useState<DialogueNode | null>(() => {
+    const result = startDialogue(npcId);
+    return result.success && result.node ? result.node : null;
+  });
+
+  // Handle clicking to advance message nodes
+  const handleAdvance = useCallback(() => {
+    if (!dialogueState) return;
+
+    const result = advanceDialogue(dialogueState);
+    if (result.ended) {
+      onClose();
+    } else if (result.success && result.state && result.node) {
+      setDialogueState(result.state);
+      setCurrentNode(result.node);
+    }
+  }, [dialogueState, onClose]);
+
+  // Handle selecting a choice
+  const handleSelectChoice = useCallback(
+    (index: number) => {
+      if (!dialogueState) return;
+
+      const result = selectChoice(dialogueState, index);
+      if (result.success && result.state && result.node) {
+        // Check if this leads to a shop
+        if (result.node.type === DialogueNodeType.Shop) {
+          setDialogueState(result.state);
+          setCurrentNode(result.node);
+          return;
+        }
+
+        setDialogueState(result.state);
+        setCurrentNode(result.node);
+
+        if (result.ended) {
+          // Don't close immediately for end nodes - let user see final message
+        }
+      }
+    },
+    [dialogueState],
+  );
+
+  // Handle shop button
+  const handleOpenShop = useCallback(() => {
+    onOpenShop?.(npcId);
+    onClose();
+  }, [npcId, onOpenShop, onClose]);
+
+  if (!npc) {
+    return (
+      <Card>
+        <CardContent className="pt-4">
+          <p className="text-muted-foreground text-center">NPC not found.</p>
+          <Button className="w-full mt-4" onClick={onClose}>
+            Close
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!dialogueState || !currentNode) {
+    return (
+      <Card>
+        <CardContent className="pt-4">
+          <p className="text-muted-foreground text-center">
+            Could not start dialogue.
+          </p>
+          <Button className="w-full mt-4" onClick={onClose}>
+            Close
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-2xl">{npc.emoji}</span>
+              <CardTitle className="text-lg">{npc.name}</CardTitle>
+            </div>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              ✕
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Dialogue content */}
+      {currentNode.type === DialogueNodeType.Message && (
+        <DialogueBox
+          npc={npc}
+          text={currentNode.text}
+          onClick={handleAdvance}
+          showContinue={true}
+        />
+      )}
+
+      {currentNode.type === DialogueNodeType.Choice && (
+        <>
+          <DialogueBox npc={npc} text={currentNode.text} />
+          {currentNode.choices && (
+            <DialogueChoices
+              choices={currentNode.choices}
+              onSelect={handleSelectChoice}
+            />
+          )}
+        </>
+      )}
+
+      {currentNode.type === DialogueNodeType.End && (
+        <>
+          <DialogueBox npc={npc} text={currentNode.text} />
+          <Button className="w-full" onClick={onClose}>
+            Goodbye
+          </Button>
+        </>
+      )}
+
+      {currentNode.type === DialogueNodeType.Shop && (
+        <>
+          <DialogueBox npc={npc} text={currentNode.text} />
+          <div className="flex flex-col gap-2">
+            <Button className="w-full" onClick={handleOpenShop}>
+              Browse Shop
+            </Button>
+            <Button variant="outline" className="w-full" onClick={onClose}>
+              Maybe Later
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/npc/NPCDisplay.tsx
+++ b/src/components/npc/NPCDisplay.tsx
@@ -56,6 +56,7 @@ export function NPCDisplay({ npc, onClick }: NPCDisplayProps) {
       variant="outline"
       className="flex items-center gap-3 p-4 h-auto w-full justify-start"
       onClick={onClick}
+      aria-label={`Talk to ${npc.name}`}
     >
       <span className="text-3xl">{npc.emoji}</span>
       <div className="flex flex-col items-start">

--- a/src/components/npc/NPCDisplay.tsx
+++ b/src/components/npc/NPCDisplay.tsx
@@ -41,7 +41,7 @@ const ROLE_DISPLAY: Record<NpcRole, { name: string; color: string }> = {
  * Get display info for an NPC role.
  */
 function getRoleDisplay(role: NpcRole): { name: string; color: string } {
-  return ROLE_DISPLAY[role] ?? { name: role, color: "text-muted-foreground" };
+  return ROLE_DISPLAY[role];
 }
 
 /**

--- a/src/components/npc/NPCDisplay.tsx
+++ b/src/components/npc/NPCDisplay.tsx
@@ -1,0 +1,71 @@
+/**
+ * NPC display component showing the NPC avatar and info.
+ */
+
+import { Button } from "@/components/ui/button";
+import type { NPC } from "@/game/types/npc";
+import { NpcRole } from "@/game/types/npc";
+
+interface NPCDisplayProps {
+  npc: NPC;
+  onClick: () => void;
+}
+
+/**
+ * Display data for NPC roles.
+ */
+const ROLE_DISPLAY: Record<NpcRole, { name: string; color: string }> = {
+  [NpcRole.QuestGiver]: {
+    name: "Quest Giver",
+    color: "text-yellow-600 dark:text-yellow-400",
+  },
+  [NpcRole.Merchant]: {
+    name: "Merchant",
+    color: "text-green-600 dark:text-green-400",
+  },
+  [NpcRole.Trainer]: {
+    name: "Trainer",
+    color: "text-blue-600 dark:text-blue-400",
+  },
+  [NpcRole.Guide]: {
+    name: "Guide",
+    color: "text-purple-600 dark:text-purple-400",
+  },
+  [NpcRole.Lore]: {
+    name: "Lore",
+    color: "text-orange-600 dark:text-orange-400",
+  },
+};
+
+/**
+ * Get display info for an NPC role.
+ */
+function getRoleDisplay(role: NpcRole): { name: string; color: string } {
+  return ROLE_DISPLAY[role] ?? { name: role, color: "text-muted-foreground" };
+}
+
+/**
+ * Displays an NPC with their avatar and basic info.
+ */
+export function NPCDisplay({ npc, onClick }: NPCDisplayProps) {
+  const primaryRole = npc.roles[0];
+  const roleDisplay = primaryRole ? getRoleDisplay(primaryRole) : null;
+
+  return (
+    <Button
+      variant="outline"
+      className="flex items-center gap-3 p-4 h-auto w-full justify-start"
+      onClick={onClick}
+    >
+      <span className="text-3xl">{npc.emoji}</span>
+      <div className="flex flex-col items-start">
+        <span className="font-medium">{npc.name}</span>
+        {roleDisplay && (
+          <span className={`text-xs ${roleDisplay.color}`}>
+            {roleDisplay.name}
+          </span>
+        )}
+      </div>
+    </Button>
+  );
+}

--- a/src/components/npc/index.ts
+++ b/src/components/npc/index.ts
@@ -1,0 +1,8 @@
+/**
+ * NPC components barrel export.
+ */
+
+export { DialogueBox } from "./DialogueBox";
+export { DialogueChoices } from "./DialogueChoices";
+export { DialogueScreen } from "./DialogueScreen";
+export { NPCDisplay } from "./NPCDisplay";

--- a/src/components/screens/MapScreen.tsx
+++ b/src/components/screens/MapScreen.tsx
@@ -4,6 +4,7 @@
 
 import { useMemo, useState } from "react";
 import { LocationDetail, LocationNode } from "@/components/map";
+import { DialogueScreen } from "@/components/npc";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ErrorDialog } from "@/components/ui/error-dialog";
 import { getConnectedLocations, getLocation } from "@/game/data/locations";
@@ -20,6 +21,7 @@ export function MapScreen() {
     null,
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [talkingToNpcId, setTalkingToNpcId] = useState<string | null>(null);
 
   // Get current location
   const currentLocationId = state?.player.currentLocationId ?? "home";
@@ -69,6 +71,23 @@ export function MapScreen() {
     }
   };
 
+  // Handle NPC click
+  const handleNpcClick = (npcId: string) => {
+    setTalkingToNpcId(npcId);
+  };
+
+  // Handle dialogue close
+  const handleDialogueClose = () => {
+    setTalkingToNpcId(null);
+  };
+
+  // Handle shop open (placeholder for Milestone 17)
+  const handleOpenShop = (_npcId: string) => {
+    // Shop functionality will be implemented in Milestone 17
+    setErrorMessage("Shop is coming soon!");
+    setTalkingToNpcId(null);
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -82,6 +101,17 @@ export function MapScreen() {
       <div className="flex items-center justify-center h-64">
         <p className="text-muted-foreground">Error loading map data.</p>
       </div>
+    );
+  }
+
+  // If talking to an NPC, show dialogue screen
+  if (talkingToNpcId) {
+    return (
+      <DialogueScreen
+        npcId={talkingToNpcId}
+        onClose={handleDialogueClose}
+        onOpenShop={handleOpenShop}
+      />
     );
   }
 
@@ -152,6 +182,7 @@ export function MapScreen() {
             travelMessage={travelInfo[selectedLocation.id]?.message}
             energyCost={travelInfo[selectedLocation.id]?.energyCost}
             onTravel={() => handleTravel(selectedLocation.id)}
+            onNpcClick={handleNpcClick}
           />
         )}
 
@@ -162,6 +193,7 @@ export function MapScreen() {
             isCurrentLocation={true}
             canTravel={false}
             onTravel={() => {}}
+            onNpcClick={handleNpcClick}
           />
         )}
       </div>

--- a/src/game/core/dialogue.ts
+++ b/src/game/core/dialogue.ts
@@ -1,0 +1,251 @@
+/**
+ * Dialogue navigation logic.
+ */
+
+import { getDialogue } from "@/game/data/dialogues";
+import { getNpc } from "@/game/data/npcs";
+import {
+  type DialogueNode,
+  DialogueNodeType,
+  type DialogueState,
+} from "@/game/types/npc";
+
+/**
+ * Result of starting a dialogue.
+ */
+export interface StartDialogueResult {
+  success: boolean;
+  message: string;
+  state?: DialogueState;
+  node?: DialogueNode;
+}
+
+/**
+ * Result of advancing dialogue.
+ */
+export interface AdvanceDialogueResult {
+  success: boolean;
+  message: string;
+  state?: DialogueState;
+  node?: DialogueNode;
+  ended: boolean;
+}
+
+/**
+ * Start a dialogue with an NPC.
+ */
+export function startDialogue(npcId: string): StartDialogueResult {
+  const npc = getNpc(npcId);
+  if (!npc) {
+    return {
+      success: false,
+      message: "NPC not found.",
+    };
+  }
+
+  const dialogue = getDialogue(npc.dialogueId);
+  if (!dialogue) {
+    return {
+      success: false,
+      message: "Dialogue not found.",
+    };
+  }
+
+  const startNode = dialogue.nodes[dialogue.startNodeId];
+  if (!startNode) {
+    return {
+      success: false,
+      message: "Start node not found.",
+    };
+  }
+
+  const state: DialogueState = {
+    npcId,
+    dialogueId: dialogue.id,
+    currentNodeId: dialogue.startNodeId,
+  };
+
+  return {
+    success: true,
+    message: "Dialogue started.",
+    state,
+    node: startNode,
+  };
+}
+
+/**
+ * Get the current dialogue node.
+ */
+export function getCurrentNode(state: DialogueState): DialogueNode | undefined {
+  const dialogue = getDialogue(state.dialogueId);
+  if (!dialogue) return undefined;
+  return dialogue.nodes[state.currentNodeId];
+}
+
+/**
+ * Advance dialogue to the next node (for message nodes).
+ */
+export function advanceDialogue(state: DialogueState): AdvanceDialogueResult {
+  const currentNode = getCurrentNode(state);
+  if (!currentNode) {
+    return {
+      success: false,
+      message: "Current node not found.",
+      ended: true,
+    };
+  }
+
+  // Check if dialogue has ended
+  if (currentNode.type === DialogueNodeType.End) {
+    return {
+      success: true,
+      message: "Dialogue ended.",
+      ended: true,
+    };
+  }
+
+  // For shop nodes, dialogue ends (shop interface takes over)
+  if (currentNode.type === DialogueNodeType.Shop) {
+    return {
+      success: true,
+      message: "Opening shop.",
+      ended: true,
+    };
+  }
+
+  // For choice nodes, cannot advance without selecting
+  if (currentNode.type === DialogueNodeType.Choice) {
+    return {
+      success: false,
+      message: "Please select a choice.",
+      state,
+      node: currentNode,
+      ended: false,
+    };
+  }
+
+  // For message nodes, advance to next
+  if (currentNode.type === DialogueNodeType.Message) {
+    if (!currentNode.nextNodeId) {
+      return {
+        success: true,
+        message: "Dialogue ended.",
+        ended: true,
+      };
+    }
+
+    const dialogue = getDialogue(state.dialogueId);
+    const nextNode = dialogue?.nodes[currentNode.nextNodeId];
+    if (!nextNode) {
+      return {
+        success: false,
+        message: "Next node not found.",
+        ended: true,
+      };
+    }
+
+    const newState: DialogueState = {
+      ...state,
+      currentNodeId: currentNode.nextNodeId,
+    };
+
+    return {
+      success: true,
+      message: "Advanced to next node.",
+      state: newState,
+      node: nextNode,
+      ended: false,
+    };
+  }
+
+  return {
+    success: false,
+    message: "Unknown node type.",
+    ended: true,
+  };
+}
+
+/**
+ * Select a choice in a dialogue (for choice nodes).
+ */
+export function selectChoice(
+  state: DialogueState,
+  choiceIndex: number,
+): AdvanceDialogueResult {
+  const currentNode = getCurrentNode(state);
+  if (!currentNode) {
+    return {
+      success: false,
+      message: "Current node not found.",
+      ended: true,
+    };
+  }
+
+  if (currentNode.type !== DialogueNodeType.Choice) {
+    return {
+      success: false,
+      message: "Current node is not a choice node.",
+      state,
+      node: currentNode,
+      ended: false,
+    };
+  }
+
+  if (!currentNode.choices || choiceIndex >= currentNode.choices.length) {
+    return {
+      success: false,
+      message: "Invalid choice index.",
+      state,
+      node: currentNode,
+      ended: false,
+    };
+  }
+
+  const choice = currentNode.choices[choiceIndex];
+  if (!choice) {
+    return {
+      success: false,
+      message: "Choice not found.",
+      state,
+      node: currentNode,
+      ended: false,
+    };
+  }
+
+  const dialogue = getDialogue(state.dialogueId);
+  const nextNode = dialogue?.nodes[choice.nextNodeId];
+  if (!nextNode) {
+    return {
+      success: false,
+      message: "Next node not found.",
+      ended: true,
+    };
+  }
+
+  const newState: DialogueState = {
+    ...state,
+    currentNodeId: choice.nextNodeId,
+  };
+
+  // Check if the next node is an end or shop node
+  const ended =
+    nextNode.type === DialogueNodeType.End ||
+    nextNode.type === DialogueNodeType.Shop;
+
+  return {
+    success: true,
+    message: ended ? "Dialogue ended." : "Choice selected.",
+    state: newState,
+    node: nextNode,
+    ended,
+  };
+}
+
+/**
+ * Check if a node is a terminal node (end or shop).
+ */
+export function isTerminalNode(node: DialogueNode): boolean {
+  return (
+    node.type === DialogueNodeType.End || node.type === DialogueNodeType.Shop
+  );
+}

--- a/src/game/core/dialogue.ts
+++ b/src/game/core/dialogue.ts
@@ -191,7 +191,11 @@ export function selectChoice(
     };
   }
 
-  if (!currentNode.choices || choiceIndex >= currentNode.choices.length) {
+  if (
+    !currentNode.choices ||
+    choiceIndex < 0 ||
+    choiceIndex >= currentNode.choices.length
+  ) {
     return {
       success: false,
       message: "Invalid choice index.",
@@ -202,10 +206,11 @@ export function selectChoice(
   }
 
   const choice = currentNode.choices[choiceIndex];
+  // With noUncheckedIndexedAccess, TypeScript needs explicit check
   if (!choice) {
     return {
       success: false,
-      message: "Choice not found.",
+      message: "Invalid choice index.",
       state,
       node: currentNode,
       ended: false,

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -1,0 +1,180 @@
+/**
+ * Dialogue tree definitions for NPCs.
+ */
+
+import {
+  type DialogueNode,
+  DialogueNodeType,
+  type DialogueTree,
+} from "@/game/types/npc";
+
+/**
+ * Helper to create a message node.
+ */
+function messageNode(
+  id: string,
+  text: string,
+  nextNodeId?: string,
+): DialogueNode {
+  return {
+    id,
+    type: DialogueNodeType.Message,
+    text,
+    nextNodeId,
+  };
+}
+
+/**
+ * Helper to create a choice node.
+ */
+function choiceNode(
+  id: string,
+  text: string,
+  choices: { text: string; nextNodeId: string }[],
+): DialogueNode {
+  return {
+    id,
+    type: DialogueNodeType.Choice,
+    text,
+    choices,
+  };
+}
+
+/**
+ * Helper to create an end node.
+ */
+function endNode(id: string, text: string): DialogueNode {
+  return {
+    id,
+    type: DialogueNodeType.End,
+    text,
+  };
+}
+
+/**
+ * Helper to create a shop node.
+ */
+function shopNode(id: string, text: string): DialogueNode {
+  return {
+    id,
+    type: DialogueNodeType.Shop,
+    text,
+  };
+}
+
+/**
+ * Mira's dialogue tree.
+ */
+export const miraDialogue: DialogueTree = {
+  id: "mira_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "Welcome to my shop! I have all sorts of supplies for your pet. What can I help you with today?",
+      [
+        { text: "I'd like to browse your wares.", nextNodeId: "shop" },
+        { text: "Tell me about Willowbrook.", nextNodeId: "about_town" },
+        { text: "Just passing through. Goodbye!", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "Take your time and look around! Let me know if you need anything.",
+    ),
+    about_town: messageNode(
+      "about_town",
+      "Willowbrook has been a peaceful haven for pet owners for generations. The meadows to the east are great for foraging, and the Misty Woods beyond hold many mysteries.",
+      "about_town_2",
+    ),
+    about_town_2: choiceNode(
+      "about_town_2",
+      "Is there anything else you'd like to know?",
+      [
+        { text: "I'd like to see your shop.", nextNodeId: "shop" },
+        { text: "That's all, thank you!", nextNodeId: "farewell" },
+      ],
+    ),
+    farewell: endNode(
+      "farewell",
+      "Safe travels! Come back anytime you need supplies.",
+    ),
+  },
+};
+
+/**
+ * Oak's dialogue tree.
+ */
+export const oakDialogue: DialogueTree = {
+  id: "oak_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "Ah, a fellow pet trainer! I've dedicated my life to understanding these wonderful creatures. How can I assist you?",
+      [
+        { text: "Any tips for training?", nextNodeId: "training_tips" },
+        {
+          text: "What should new trainers know?",
+          nextNodeId: "beginner_advice",
+        },
+        { text: "I should get going.", nextNodeId: "farewell" },
+      ],
+    ),
+    training_tips: messageNode(
+      "training_tips",
+      "The key to effective training is consistency and patience. Make sure your pet is well-rested and well-fed before training sessions. A happy pet learns faster!",
+      "training_tips_2",
+    ),
+    training_tips_2: choiceNode(
+      "training_tips_2",
+      "Different training focuses develop different strengths. Would you like to know more?",
+      [
+        { text: "Tell me about battle stats.", nextNodeId: "battle_stats" },
+        { text: "I think I understand. Thanks!", nextNodeId: "farewell" },
+      ],
+    ),
+    battle_stats: messageNode(
+      "battle_stats",
+      "Every pet has six core attributes: Strength for power, Endurance for toughness, Agility for speed, Precision for accuracy, Fortitude for resilience, and Cunning for tactical advantage.",
+      "battle_stats_2",
+    ),
+    battle_stats_2: endNode(
+      "battle_stats_2",
+      "Master these, and your pet will become a formidable partner. Good luck with your training!",
+    ),
+    beginner_advice: messageNode(
+      "beginner_advice",
+      "New to pet raising? The most important thing is taking care of your pet's basic needs. Keep them fed, hydrated, and happy. A healthy pet is a strong pet!",
+      "beginner_advice_2",
+    ),
+    beginner_advice_2: messageNode(
+      "beginner_advice_2",
+      "Don't forget to let them rest when they're tired. And clean up after them - a messy environment isn't good for anyone!",
+      "beginner_advice_3",
+    ),
+    beginner_advice_3: endNode(
+      "beginner_advice_3",
+      "Once you've got the basics down, you can focus on training and exploration. You'll do great!",
+    ),
+    farewell: endNode(
+      "farewell",
+      "May your journey together be filled with adventure and growth. Until next time!",
+    ),
+  },
+};
+
+/**
+ * All dialogue trees indexed by ID.
+ */
+export const dialogues: Record<string, DialogueTree> = {
+  [miraDialogue.id]: miraDialogue,
+  [oakDialogue.id]: oakDialogue,
+};
+
+/**
+ * Get a dialogue tree by ID.
+ */
+export function getDialogue(dialogueId: string): DialogueTree | undefined {
+  return dialogues[dialogueId];
+}

--- a/src/game/data/npcs.ts
+++ b/src/game/data/npcs.ts
@@ -1,0 +1,58 @@
+/**
+ * NPC data definitions.
+ */
+
+import { type NPC, NpcRole } from "@/game/types/npc";
+
+/**
+ * Mira - the shopkeeper at Willowbrook.
+ * A friendly merchant who sells pet care supplies.
+ */
+export const shopkeeperMira: NPC = {
+  id: "shopkeeper_mira",
+  name: "Mira",
+  description:
+    "A cheerful shopkeeper with a warm smile. She runs the general store in Willowbrook.",
+  roles: [NpcRole.Merchant],
+  locationId: "willowbrook",
+  dialogueId: "mira_dialogue",
+  shopId: "willowbrook_shop",
+  emoji: "👩‍🌾",
+};
+
+/**
+ * Oak - the trainer at Willowbrook.
+ * An experienced trainer who helps pets grow stronger.
+ */
+export const trainerOak: NPC = {
+  id: "trainer_oak",
+  name: "Oak",
+  description:
+    "A seasoned trainer with years of experience. He can help your pet reach its full potential.",
+  roles: [NpcRole.Trainer, NpcRole.Guide],
+  locationId: "willowbrook",
+  dialogueId: "oak_dialogue",
+  emoji: "👴",
+};
+
+/**
+ * All NPCs indexed by ID.
+ */
+export const npcs: Record<string, NPC> = {
+  [shopkeeperMira.id]: shopkeeperMira,
+  [trainerOak.id]: trainerOak,
+};
+
+/**
+ * Get an NPC by ID.
+ */
+export function getNpc(npcId: string): NPC | undefined {
+  return npcs[npcId];
+}
+
+/**
+ * Get all NPCs at a specific location.
+ */
+export function getNpcsAtLocation(locationId: string): NPC[] {
+  return Object.values(npcs).filter((npc) => npc.locationId === locationId);
+}

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -10,6 +10,7 @@ export * from "./item";
 export * from "./location";
 export * from "./move";
 export * from "./notification";
+export * from "./npc";
 export * from "./offline";
 export * from "./pet";
 export * from "./skill";

--- a/src/game/types/npc.ts
+++ b/src/game/types/npc.ts
@@ -1,0 +1,107 @@
+/**
+ * NPC and Dialogue types for town interactions.
+ */
+
+/**
+ * NPC role types.
+ */
+export const NpcRole = {
+  QuestGiver: "questGiver",
+  Merchant: "merchant",
+  Trainer: "trainer",
+  Guide: "guide",
+  Lore: "lore",
+} as const;
+
+export type NpcRole = (typeof NpcRole)[keyof typeof NpcRole];
+
+/**
+ * Dialogue node types.
+ */
+export const DialogueNodeType = {
+  /** Simple text message */
+  Message: "message",
+  /** Multiple choice for player */
+  Choice: "choice",
+  /** Opens shop interface */
+  Shop: "shop",
+  /** Ends the dialogue */
+  End: "end",
+} as const;
+
+export type DialogueNodeType =
+  (typeof DialogueNodeType)[keyof typeof DialogueNodeType];
+
+/**
+ * A dialogue choice option.
+ */
+export interface DialogueChoice {
+  /** Text shown to the player */
+  text: string;
+  /** Node ID to navigate to when selected */
+  nextNodeId: string;
+}
+
+/**
+ * A single node in a dialogue tree.
+ */
+export interface DialogueNode {
+  /** Unique identifier within the dialogue tree */
+  id: string;
+  /** Node type */
+  type: DialogueNodeType;
+  /** NPC speaker text */
+  text: string;
+  /** Choices available (only for 'choice' type) */
+  choices?: DialogueChoice[];
+  /** Next node ID for automatic progression (only for 'message' type) */
+  nextNodeId?: string;
+}
+
+/**
+ * A complete dialogue tree.
+ */
+export interface DialogueTree {
+  /** Unique dialogue identifier */
+  id: string;
+  /** Starting node ID */
+  startNodeId: string;
+  /** All nodes in the tree */
+  nodes: Record<string, DialogueNode>;
+}
+
+/**
+ * NPC definition.
+ */
+export interface NPC {
+  /** Unique identifier */
+  id: string;
+  /** Display name */
+  name: string;
+  /** NPC description */
+  description: string;
+  /** Role(s) this NPC serves */
+  roles: NpcRole[];
+  /** Location ID where this NPC is found */
+  locationId: string;
+  /** Dialogue tree ID for conversations */
+  dialogueId: string;
+  /** Quest IDs this NPC offers (if quest giver) */
+  questIds?: string[];
+  /** Shop inventory ID (if merchant) */
+  shopId?: string;
+  /** Visual representation emoji */
+  emoji: string;
+}
+
+/**
+ * Current dialogue state for active conversation.
+ */
+export interface DialogueState {
+  /** NPC ID being spoken to */
+  npcId: string;
+  /** Current dialogue tree ID */
+  dialogueId: string;
+  /** Current node ID within the tree */
+  currentNodeId: string;
+}


### PR DESCRIPTION
- Add NPC and Dialogue types (npc.ts)
- Add initial NPCs: Mira (shopkeeper) and Oak (trainer) at Willowbrook
- Add dialogue trees with message, choice, shop, and end nodes
- Create dialogue navigation logic with start, advance, and choice selection
- Add NPC UI components: NPCDisplay, DialogueBox, DialogueChoices, DialogueScreen
- Update LocationDetail to show NPCs at current location
- Integrate dialogue system into MapScreen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NPCs now appear at locations with avatars, role labels and a "People Here" list.
  * Click or keyboard-activate NPCs to open a full‑screen dialogue experience with branching choices, continue/end flows, and optional shop actions.
  * New dialogue UI: message cards, selectable choice lists, and accessible interactive controls.
  * Map and location views integrate NPC interaction to start and close dialogues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->