### PR TITLE
refactor: centralize max stats calculation to reduce code duplication

### DIFF
--- a/src/game/core/care/careStats.ts
+++ b/src/game/core/care/careStats.ts
@@ -2,8 +2,7 @@
  * Care stat decay logic per tick.
  */
 
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
-import { getSpeciesById } from "@/game/data/species";
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import type { MicroValue } from "@/game/types/common";
 import type { Pet } from "@/game/types/pet";
 
@@ -45,12 +44,9 @@ export function applyCareDecay(pet: Pet): Pet["careStats"] {
     : CARE_DECAY_AWAKE;
   const poopMultiplier = getPoopHappinessMultiplier(pet.poop.count);
 
-  const species = getSpeciesById(pet.identity.speciesId);
-  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
-
-  // Calculate actual max for clamping
-  const careCapMultiplier = species?.careCapMultiplier ?? 1.0;
-  const maxCareStat = Math.floor(stageDef.baseCareStatMax * careCapMultiplier);
+  // Use centralized max stat calculation
+  const maxStats = calculatePetMaxStats(pet);
+  const maxCareStat = maxStats?.careStatMax ?? 0;
 
   // Calculate new values with decay
   const newSatiety = Math.max(0, pet.careStats.satiety - decayRate);

--- a/src/game/core/exploration/encounter.ts
+++ b/src/game/core/exploration/encounter.ts
@@ -8,7 +8,7 @@ import {
   EncounterType,
   getEncounterTable,
 } from "@/game/data/tables/encounters";
-import type { GrowthStage } from "@/game/types/constants";
+import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
 import type { Pet } from "@/game/types/pet";
 import { type Combatant, createWildCombatant } from "../battle/battle";
 
@@ -86,9 +86,8 @@ function isEncounterAvailable(
     return true;
   }
 
-  const stageOrder = ["baby", "child", "teen", "youngAdult", "adult"];
-  const petStageIndex = stageOrder.indexOf(petStage);
-  const requiredIndex = stageOrder.indexOf(entry.minStage);
+  const petStageIndex = GROWTH_STAGE_ORDER.indexOf(petStage);
+  const requiredIndex = GROWTH_STAGE_ORDER.indexOf(entry.minStage);
 
   return petStageIndex >= requiredIndex;
 }

--- a/src/game/core/items.ts
+++ b/src/game/core/items.ts
@@ -4,9 +4,8 @@
 
 import { removePoop } from "@/game/core/care/poop";
 import { hasItem, removeItem } from "@/game/core/inventory";
-import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { getItemById } from "@/game/data/items";
-import { getSpeciesById } from "@/game/data/species";
 import type { GameState, InventoryItem } from "@/game/types/gameState";
 import {
   isCleaningItem,
@@ -29,12 +28,8 @@ export interface UseItemResult {
  */
 function getMaxCareStat(state: GameState): number {
   if (!state.pet) return 0;
-
-  const species = getSpeciesById(state.pet.identity.speciesId);
-  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
-  const careCapMultiplier = species?.careCapMultiplier ?? 1.0;
-
-  return Math.floor(stageDef.baseCareStatMax * careCapMultiplier);
+  const maxStats = calculatePetMaxStats(state.pet);
+  return maxStats?.careStatMax ?? 0;
 }
 
 /**
@@ -42,13 +37,8 @@ function getMaxCareStat(state: GameState): number {
  */
 function getMaxEnergy(state: GameState): number {
   if (!state.pet) return 0;
-
-  const species = getSpeciesById(state.pet.identity.speciesId);
-  const stageDef = GROWTH_STAGE_DEFINITIONS[state.pet.growth.stage];
-  // Use careCapMultiplier for energy as well (species don't have separate energyCapMultiplier)
-  const careCapMultiplier = species?.careCapMultiplier ?? 1.0;
-
-  return Math.floor(stageDef.baseEnergyMax * careCapMultiplier);
+  const maxStats = calculatePetMaxStats(state.pet);
+  return maxStats?.energyMax ?? 0;
 }
 
 /**

--- a/src/game/core/petStats.ts
+++ b/src/game/core/petStats.ts
@@ -5,6 +5,7 @@
 import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
 import { getSpeciesById } from "@/game/data/species";
 import type { MicroValue } from "@/game/types/common";
+import type { GrowthStage } from "@/game/types/constants";
 import type { Pet } from "@/game/types/pet";
 
 /**
@@ -18,14 +19,17 @@ export interface PetMaxStats {
 }
 
 /**
- * Calculate the maximum stats for a pet based on their growth stage and species.
- * Returns null if the pet's species or growth stage is invalid.
+ * Calculate the maximum stats for a given species and growth stage.
+ * Returns null if the species is invalid.
  */
-export function calculatePetMaxStats(pet: Pet): PetMaxStats | null {
-  const species = getSpeciesById(pet.identity.speciesId);
+export function calculateMaxStats(
+  speciesId: string,
+  stage: GrowthStage,
+): PetMaxStats | null {
+  const species = getSpeciesById(speciesId);
   if (!species) return null;
 
-  const stageDef = GROWTH_STAGE_DEFINITIONS[pet.growth.stage];
+  const stageDef = GROWTH_STAGE_DEFINITIONS[stage];
   if (!stageDef) return null;
 
   return {
@@ -34,4 +38,12 @@ export function calculatePetMaxStats(pet: Pet): PetMaxStats | null {
     ),
     energyMax: Math.floor(stageDef.baseEnergyMax * species.careCapMultiplier),
   };
+}
+
+/**
+ * Calculate the maximum stats for a pet based on their growth stage and species.
+ * Returns null if the pet's species or growth stage is invalid.
+ */
+export function calculatePetMaxStats(pet: Pet): PetMaxStats | null {
+  return calculateMaxStats(pet.identity.speciesId, pet.growth.stage);
 }

--- a/src/game/state/selectors.ts
+++ b/src/game/state/selectors.ts
@@ -9,6 +9,7 @@ import {
   getTicksUntilNextStage,
   getTicksUntilNextSubstage,
 } from "@/game/core/growth";
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import {
   GROWTH_STAGE_DEFINITIONS,
   type GrowthStageDefinition,
@@ -87,15 +88,14 @@ export function selectCareStats(state: GameState): CareStatDisplay | null {
   const ctx = getPetContext(state);
   if (!ctx) return null;
 
-  const { pet, species, stageDef } = ctx;
-  const careMax = Math.floor(
-    stageDef.baseCareStatMax * species.careCapMultiplier,
-  );
+  const { pet } = ctx;
+  const maxStats = calculatePetMaxStats(pet);
+  if (!maxStats) return null;
 
   const satiety = toDisplay(pet.careStats.satiety);
   const hydration = toDisplay(pet.careStats.hydration);
   const happiness = toDisplay(pet.careStats.happiness);
-  const max = toDisplay(careMax);
+  const max = toDisplay(maxStats.careStatMax);
 
   const satietyPercent = max > 0 ? Math.round((satiety / max) * 100) : 0;
   const hydrationPercent = max > 0 ? Math.round((hydration / max) * 100) : 0;
@@ -133,13 +133,12 @@ export function selectEnergy(state: GameState): EnergyDisplay | null {
   const ctx = getPetContext(state);
   if (!ctx) return null;
 
-  const { pet, species, stageDef } = ctx;
-  const energyMax = Math.floor(
-    stageDef.baseEnergyMax * species.careCapMultiplier,
-  );
+  const { pet } = ctx;
+  const maxStats = calculatePetMaxStats(pet);
+  if (!maxStats) return null;
 
   const energy = toDisplay(pet.energyStats.energy);
-  const max = toDisplay(energyMax);
+  const max = toDisplay(maxStats.energyMax);
 
   return {
     energy,


### PR DESCRIPTION
- Extract calculateMaxStats function in petStats.ts to accept speciesId and stage directly
- Update items.ts to use calculatePetMaxStats instead of duplicating the calculation
- Update careStats.ts to use calculatePetMaxStats instead of inline calculation
- Update selectors.ts to use calculatePetMaxStats instead of duplicating logic
- Update starting.ts to use calculateMaxStats and getInitialPoopTimer() instead of hardcoded values
- Update encounter.ts to use GROWTH_STAGE_ORDER constant instead of hardcoded array
- Add tests for the new calculateMaxStats function