### PR TITLE
refactor: DRY activity display names and add dialogue tests

### DIFF
--- a/src/game/core/dialogue.test.ts
+++ b/src/game/core/dialogue.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for dialogue navigation logic.
+ */
+
+import { expect, test } from "bun:test";
+import {
+  advanceDialogue,
+  getCurrentNode,
+  isTerminalNode,
+  selectChoice,
+  startDialogue,
+} from "@/game/core/dialogue";
+import type { DialogueState } from "@/game/types/npc";
+import { DialogueNodeType } from "@/game/types/npc";
+
+// startDialogue tests
+test("startDialogue succeeds with valid NPC", () => {
+  const result = startDialogue("shopkeeper_mira");
+  expect(result.success).toBe(true);
+  expect(result.state?.npcId).toBe("shopkeeper_mira");
+  expect(result.state?.dialogueId).toBe("mira_dialogue");
+  expect(result.node?.type).toBe(DialogueNodeType.Choice);
+});
+
+test("startDialogue fails with unknown NPC", () => {
+  const result = startDialogue("unknown_npc");
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("NPC not found.");
+});
+
+test("startDialogue returns correct starting node", () => {
+  const result = startDialogue("trainer_oak");
+  expect(result.success).toBe(true);
+  expect(result.node?.id).toBe("greeting");
+  expect(result.node?.text).toContain("fellow pet trainer");
+});
+
+// getCurrentNode tests
+test("getCurrentNode returns correct node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "greeting",
+  };
+  const node = getCurrentNode(state);
+  expect(node).toBeDefined();
+  expect(node?.id).toBe("greeting");
+});
+
+test("getCurrentNode returns undefined for invalid dialogue", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "invalid_dialogue",
+    currentNodeId: "greeting",
+  };
+  const node = getCurrentNode(state);
+  expect(node).toBeUndefined();
+});
+
+// advanceDialogue tests
+test("advanceDialogue advances message node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "about_town",
+  };
+  const result = advanceDialogue(state);
+  expect(result.success).toBe(true);
+  expect(result.ended).toBe(false);
+  expect(result.state?.currentNodeId).toBe("about_town_2");
+});
+
+test("advanceDialogue fails for choice node without selection", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "greeting",
+  };
+  const result = advanceDialogue(state);
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("Please select a choice.");
+  expect(result.ended).toBe(false);
+});
+
+test("advanceDialogue ends at end node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "farewell",
+  };
+  const result = advanceDialogue(state);
+  expect(result.success).toBe(true);
+  expect(result.ended).toBe(true);
+});
+
+test("advanceDialogue ends at shop node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "shop",
+  };
+  const result = advanceDialogue(state);
+  expect(result.success).toBe(true);
+  expect(result.ended).toBe(true);
+  expect(result.message).toBe("Opening shop.");
+});
+
+// selectChoice tests
+test("selectChoice advances to selected node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "greeting",
+  };
+  const result = selectChoice(state, 1); // "Tell me about Willowbrook"
+  expect(result.success).toBe(true);
+  expect(result.state?.currentNodeId).toBe("about_town");
+  expect(result.ended).toBe(false);
+});
+
+test("selectChoice fails with invalid index", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "greeting",
+  };
+  const result = selectChoice(state, 99);
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("Invalid choice index.");
+});
+
+test("selectChoice fails on non-choice node", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "about_town",
+  };
+  const result = selectChoice(state, 0);
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("Current node is not a choice node.");
+});
+
+test("selectChoice ends when selecting farewell", () => {
+  const state: DialogueState = {
+    npcId: "mira",
+    dialogueId: "mira_dialogue",
+    currentNodeId: "greeting",
+  };
+  const result = selectChoice(state, 2); // "Just passing through. Goodbye!"
+  expect(result.success).toBe(true);
+  expect(result.ended).toBe(true);
+});
+
+// isTerminalNode tests
+test("isTerminalNode returns true for end node", () => {
+  const node = {
+    id: "end",
+    type: DialogueNodeType.End,
+    text: "Goodbye!",
+  };
+  expect(isTerminalNode(node)).toBe(true);
+});
+
+test("isTerminalNode returns true for shop node", () => {
+  const node = {
+    id: "shop",
+    type: DialogueNodeType.Shop,
+    text: "Welcome to my shop!",
+  };
+  expect(isTerminalNode(node)).toBe(true);
+});
+
+test("isTerminalNode returns false for message node", () => {
+  const node = {
+    id: "msg",
+    type: DialogueNodeType.Message,
+    text: "Hello!",
+  };
+  expect(isTerminalNode(node)).toBe(false);
+});
+
+test("isTerminalNode returns false for choice node", () => {
+  const node = {
+    id: "choice",
+    type: DialogueNodeType.Choice,
+    text: "What would you like?",
+    choices: [],
+  };
+  expect(isTerminalNode(node)).toBe(false);
+});

--- a/src/game/core/dialogue.test.ts
+++ b/src/game/core/dialogue.test.ts
@@ -38,7 +38,7 @@ test("startDialogue returns correct starting node", () => {
 // getCurrentNode tests
 test("getCurrentNode returns correct node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "greeting",
   };
@@ -49,7 +49,7 @@ test("getCurrentNode returns correct node", () => {
 
 test("getCurrentNode returns undefined for invalid dialogue", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "invalid_dialogue",
     currentNodeId: "greeting",
   };
@@ -60,7 +60,7 @@ test("getCurrentNode returns undefined for invalid dialogue", () => {
 // advanceDialogue tests
 test("advanceDialogue advances message node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "about_town",
   };
@@ -72,7 +72,7 @@ test("advanceDialogue advances message node", () => {
 
 test("advanceDialogue fails for choice node without selection", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "greeting",
   };
@@ -84,7 +84,7 @@ test("advanceDialogue fails for choice node without selection", () => {
 
 test("advanceDialogue ends at end node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "farewell",
   };
@@ -95,7 +95,7 @@ test("advanceDialogue ends at end node", () => {
 
 test("advanceDialogue ends at shop node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "shop",
   };
@@ -108,7 +108,7 @@ test("advanceDialogue ends at shop node", () => {
 // selectChoice tests
 test("selectChoice advances to selected node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "greeting",
   };
@@ -120,7 +120,7 @@ test("selectChoice advances to selected node", () => {
 
 test("selectChoice fails with invalid index", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "greeting",
   };
@@ -131,7 +131,7 @@ test("selectChoice fails with invalid index", () => {
 
 test("selectChoice fails on non-choice node", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "about_town",
   };
@@ -142,7 +142,7 @@ test("selectChoice fails on non-choice node", () => {
 
 test("selectChoice ends when selecting farewell", () => {
   const state: DialogueState = {
-    npcId: "mira",
+    npcId: "shopkeeper_mira",
     dialogueId: "mira_dialogue",
     currentNodeId: "greeting",
   };

--- a/src/game/core/exploration/forage.test.ts
+++ b/src/game/core/exploration/forage.test.ts
@@ -78,7 +78,7 @@ test("canStartForaging fails when pet is already exploring", () => {
   });
   const result = canStartForaging(pet, "meadow");
   expect(result.canForage).toBe(false);
-  expect(result.message).toContain("already exploring");
+  expect(result.message).toContain("exploring");
 });
 
 test("canStartForaging fails when pet is training", () => {

--- a/src/game/core/exploration/forage.test.ts
+++ b/src/game/core/exploration/forage.test.ts
@@ -78,7 +78,7 @@ test("canStartForaging fails when pet is already exploring", () => {
   });
   const result = canStartForaging(pet, "meadow");
   expect(result.canForage).toBe(false);
-  expect(result.message).toContain("exploring");
+  expect(result.message).toBe("Your pet is already exploring.");
 });
 
 test("canStartForaging fails when pet is training", () => {

--- a/src/game/core/exploration/forage.ts
+++ b/src/game/core/exploration/forage.ts
@@ -11,7 +11,10 @@ import type {
 } from "@/game/types/activity";
 import { ExplorationActivityType } from "@/game/types/activity";
 import { type Tick, toDisplay, toMicro } from "@/game/types/common";
-import { ActivityState, getActivityDisplayName } from "@/game/types/constants";
+import {
+  ActivityState,
+  getActivityConflictMessage,
+} from "@/game/types/constants";
 import { FacilityType, LocationType } from "@/game/types/location";
 import type { Pet } from "@/game/types/pet";
 
@@ -29,10 +32,13 @@ export function canStartForaging(
 ): { canForage: boolean; message: string } {
   // Check if pet is already doing an activity
   if (pet.activityState !== ActivityState.Idle) {
-    const activityName = getActivityDisplayName(pet.activityState);
     return {
       canForage: false,
-      message: `Cannot forage while ${activityName}.`,
+      message: getActivityConflictMessage(
+        "forage",
+        pet.activityState,
+        ActivityState.Exploring,
+      ),
     };
   }
 

--- a/src/game/core/exploration/forage.ts
+++ b/src/game/core/exploration/forage.ts
@@ -11,7 +11,7 @@ import type {
 } from "@/game/types/activity";
 import { ExplorationActivityType } from "@/game/types/activity";
 import { type Tick, toDisplay, toMicro } from "@/game/types/common";
-import { ActivityState } from "@/game/types/constants";
+import { ActivityState, getActivityDisplayName } from "@/game/types/constants";
 import { FacilityType, LocationType } from "@/game/types/location";
 import type { Pet } from "@/game/types/pet";
 
@@ -29,14 +29,7 @@ export function canStartForaging(
 ): { canForage: boolean; message: string } {
   // Check if pet is already doing an activity
   if (pet.activityState !== ActivityState.Idle) {
-    const activityName =
-      pet.activityState === ActivityState.Sleeping
-        ? "sleeping"
-        : pet.activityState === ActivityState.Training
-          ? "training"
-          : pet.activityState === ActivityState.Exploring
-            ? "already exploring"
-            : pet.activityState;
+    const activityName = getActivityDisplayName(pet.activityState);
     return {
       canForage: false,
       message: `Cannot forage while ${activityName}.`,

--- a/src/game/core/training.test.ts
+++ b/src/game/core/training.test.ts
@@ -52,7 +52,7 @@ test("canStartTraining fails when pet is already training", () => {
     TrainingSessionType.Basic,
   );
   expect(result.canTrain).toBe(false);
-  expect(result.message).toContain("already training");
+  expect(result.message).toContain("training");
 });
 
 test("canStartTraining fails when not enough energy", () => {

--- a/src/game/core/training.test.ts
+++ b/src/game/core/training.test.ts
@@ -52,7 +52,7 @@ test("canStartTraining fails when pet is already training", () => {
     TrainingSessionType.Basic,
   );
   expect(result.canTrain).toBe(false);
-  expect(result.message).toContain("training");
+  expect(result.message).toBe("Your pet is already training.");
 });
 
 test("canStartTraining fails when not enough energy", () => {

--- a/src/game/core/training.ts
+++ b/src/game/core/training.ts
@@ -14,6 +14,7 @@ import {
   ActivityState,
   GROWTH_STAGE_ORDER,
   type GrowthStage,
+  getActivityDisplayName,
 } from "@/game/types/constants";
 import type { Pet } from "@/game/types/pet";
 import type { BattleStats } from "@/game/types/stats";
@@ -42,12 +43,7 @@ export function canStartTraining(
 ): { canTrain: boolean; message: string } {
   // Check if pet is already doing an activity
   if (pet.activityState !== ActivityState.Idle) {
-    const activityName =
-      pet.activityState === ActivityState.Sleeping
-        ? "sleeping"
-        : pet.activityState === ActivityState.Training
-          ? "already training"
-          : pet.activityState;
+    const activityName = getActivityDisplayName(pet.activityState);
     return {
       canTrain: false,
       message: `Cannot train while ${activityName}.`,

--- a/src/game/core/training.ts
+++ b/src/game/core/training.ts
@@ -14,7 +14,7 @@ import {
   ActivityState,
   GROWTH_STAGE_ORDER,
   type GrowthStage,
-  getActivityDisplayName,
+  getActivityConflictMessage,
 } from "@/game/types/constants";
 import type { Pet } from "@/game/types/pet";
 import type { BattleStats } from "@/game/types/stats";
@@ -43,10 +43,13 @@ export function canStartTraining(
 ): { canTrain: boolean; message: string } {
   // Check if pet is already doing an activity
   if (pet.activityState !== ActivityState.Idle) {
-    const activityName = getActivityDisplayName(pet.activityState);
     return {
       canTrain: false,
-      message: `Cannot train while ${activityName}.`,
+      message: getActivityConflictMessage(
+        "train",
+        pet.activityState,
+        ActivityState.Training,
+      ),
     };
   }
 

--- a/src/game/types/constants.ts
+++ b/src/game/types/constants.ts
@@ -110,6 +110,25 @@ export const ActivityState = {
 export type ActivityState = (typeof ActivityState)[keyof typeof ActivityState];
 
 /**
+ * Get a human-readable display name for an activity state.
+ * Used for error messages when an action cannot be performed.
+ */
+export function getActivityDisplayName(activity: ActivityState): string {
+  switch (activity) {
+    case ActivityState.Sleeping:
+      return "sleeping";
+    case ActivityState.Training:
+      return "training";
+    case ActivityState.Exploring:
+      return "exploring";
+    case ActivityState.Battling:
+      return "battling";
+    case ActivityState.Idle:
+      return "idle";
+  }
+}
+
+/**
  * Care stat thresholds for UI/feedback purposes.
  */
 export const CareThreshold = {

--- a/src/game/types/constants.ts
+++ b/src/game/types/constants.ts
@@ -129,6 +129,25 @@ export function getActivityDisplayName(activity: ActivityState): string {
 }
 
 /**
+ * Generate an error message for when an activity cannot start due to another activity.
+ * Provides clearer messaging when the pet is already doing the same activity.
+ *
+ * @param attemptedAction - The action being attempted (e.g., "train", "forage")
+ * @param currentActivity - The pet's current activity state
+ * @param sameActivityState - The activity state that matches the attempted action (optional)
+ */
+export function getActivityConflictMessage(
+  attemptedAction: string,
+  currentActivity: ActivityState,
+  sameActivityState?: ActivityState,
+): string {
+  if (sameActivityState && currentActivity === sameActivityState) {
+    return `Your pet is already ${getActivityDisplayName(currentActivity)}.`;
+  }
+  return `Cannot ${attemptedAction} while ${getActivityDisplayName(currentActivity)}.`;
+}
+
+/**
  * Care stat thresholds for UI/feedback purposes.
  */
 export const CareThreshold = {


### PR DESCRIPTION
- Add getActivityDisplayName helper function in constants.ts to centralize activity state name resolution for error messages
- Refactor training.ts and forage.ts to use the new helper function
- Update related tests to use simpler message assertions
- Add comprehensive test suite for dialogue.ts (17 new tests)

The getActivityDisplayName function provides consistent naming for activity states (sleeping, training, exploring, battling, idle) used in error messages when an action cannot be performed due to the pet being in a non-idle state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for dialogue navigation logic.

* **Refactor**
  * Consolidated activity conflict message generation into centralized utilities for consistency across game systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->