### PR TITLE
Fix mobile scroll on pet selection screen

### DIFF
--- a/src/components/screens/NewGameScreen.tsx
+++ b/src/components/screens/NewGameScreen.tsx
@@ -108,8 +108,8 @@ export function NewGameScreen({ onStartGame }: NewGameScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-background p-4">
-      <div className="mx-auto max-w-2xl space-y-8">
+    <div className="h-full overflow-y-auto bg-background p-4">
+      <div className="mx-auto max-w-2xl space-y-8 pb-8">
         <div className="text-center">
           <h1 className="text-4xl font-bold">🐾 Digital Pets</h1>
           <p className="text-muted-foreground mt-2">


### PR DESCRIPTION
Changed NewGameScreen container from min-h-screen with no overflow to h-full with overflow-y-auto. This allows the pet selection page to scroll on mobile devices where the content exceeds viewport height.

Also added pb-8 to the inner container to ensure the Start button has adequate spacing from the viewport edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the new game screen layout with improved spacing and scrolling behavior for better visibility of all content.
  * Enhanced welcome message text to guide players in selecting a companion and entering a name.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->