### PR TITLE
feat: refund energy when cancelling exploration or training

### DIFF
--- a/specs/exploration.md
+++ b/specs/exploration.md
@@ -96,6 +96,16 @@ Each location has encounter tables for events during exploration.
 | Scouting | Medium |
 | Deep Exploration | High |
 
+### Cancellation and Energy Refund
+
+Exploration sessions can be cancelled at any time before completion. When an exploration session is cancelled:
+
+- The pet returns to Idle state
+- **Energy is fully refunded** to the pet
+- No items are found
+- No skill XP is awarded
+- No cooldown is applied
+
 ### Wild Pet Level Calculation
 
 ```

--- a/specs/training.md
+++ b/specs/training.md
@@ -114,6 +114,15 @@ Training sessions have:
 
 Advanced training may have growth stage requirements.
 
+### Cancellation and Energy Refund
+
+Training sessions can be cancelled at any time before completion. When a training session is cancelled:
+
+- The pet returns to Idle state
+- **Energy is fully refunded** to the pet
+- No stat gains are awarded
+- No cooldown is applied
+
 ### Training Modifiers
 
 Training effectiveness may be modified by:

--- a/src/game/core/exploration/forage.test.ts
+++ b/src/game/core/exploration/forage.test.ts
@@ -158,6 +158,7 @@ test("processExplorationTick decrements ticksRemaining", () => {
     startTick: 0,
     durationTicks: 3,
     ticksRemaining: 3,
+    energyCost: 0,
   };
 
   const result = processExplorationTick(exploration);
@@ -173,6 +174,7 @@ test("processExplorationTick returns null when exploration completes", () => {
     startTick: 0,
     durationTicks: 3,
     ticksRemaining: 1,
+    energyCost: 0,
   };
 
   const result = processExplorationTick(exploration);
@@ -281,6 +283,7 @@ test("completeForaging returns success with active exploration", () => {
       startTick: 0,
       durationTicks: 2,
       ticksRemaining: 0,
+      energyCost: 0,
     },
   });
 
@@ -300,6 +303,7 @@ test("applyExplorationCompletion clears exploration state", () => {
       startTick: 0,
       durationTicks: 2,
       ticksRemaining: 0,
+      energyCost: 0,
     },
   });
 
@@ -310,7 +314,9 @@ test("applyExplorationCompletion clears exploration state", () => {
 });
 
 // cancelExploration tests
-test("cancelExploration clears exploration state", () => {
+test("cancelExploration clears exploration state and refunds energy", () => {
+  const initialEnergy = toMicro(50);
+  const energyCost = toMicro(10);
   const pet = createTestPet({
     activityState: ActivityState.Exploring,
     activeExploration: {
@@ -320,19 +326,24 @@ test("cancelExploration clears exploration state", () => {
       startTick: 0,
       durationTicks: 2,
       ticksRemaining: 1,
+      energyCost,
     },
+    energyStats: { energy: initialEnergy - energyCost },
   });
 
   const result = cancelExploration(pet);
   expect(result.success).toBe(true);
   expect(result.pet.activityState).toBe(ActivityState.Idle);
   expect(result.pet.activeExploration).toBeUndefined();
+  expect(result.energyRefunded).toBe(energyCost);
+  expect(result.pet.energyStats.energy).toBe(initialEnergy);
 });
 
 test("cancelExploration fails when no exploration active", () => {
   const pet = createTestPet();
   const result = cancelExploration(pet);
   expect(result.success).toBe(false);
+  expect(result.energyRefunded).toBe(0);
 });
 
 // getExplorationProgress tests
@@ -344,6 +355,7 @@ test("getExplorationProgress returns correct percentage", () => {
     startTick: 0,
     durationTicks: 10,
     ticksRemaining: 5,
+    energyCost: 0,
   };
 
   const progress = getExplorationProgress(exploration);
@@ -358,6 +370,7 @@ test("getExplorationProgress returns 0 at start", () => {
     startTick: 0,
     durationTicks: 10,
     ticksRemaining: 10,
+    energyCost: 0,
   };
 
   const progress = getExplorationProgress(exploration);
@@ -372,6 +385,7 @@ test("getExplorationProgress returns 100 at end", () => {
     startTick: 0,
     durationTicks: 10,
     ticksRemaining: 0,
+    energyCost: 0,
   };
 
   const progress = getExplorationProgress(exploration);
@@ -386,6 +400,7 @@ test("getExplorationProgress handles zero duration", () => {
     startTick: 0,
     durationTicks: 0,
     ticksRemaining: 0,
+    energyCost: 0,
   };
 
   const progress = getExplorationProgress(exploration);

--- a/src/game/core/exploration/forage.ts
+++ b/src/game/core/exploration/forage.ts
@@ -125,6 +125,7 @@ export function startForaging(
     startTick: currentTick,
     durationTicks: forageTable.baseDurationTicks,
     ticksRemaining: forageTable.baseDurationTicks,
+    energyCost: toMicro(forageTable.baseEnergyCost),
   };
 
   const newEnergy =
@@ -273,20 +274,24 @@ export function applyExplorationCompletion(
 
 /**
  * Cancel an active exploration session.
- * Energy is not refunded.
+ * Energy is refunded to the pet.
  */
 export function cancelExploration(pet: Pet): {
   success: boolean;
   pet: Pet;
   message: string;
+  energyRefunded: number;
 } {
   if (!pet.activeExploration) {
     return {
       success: false,
       pet,
       message: "No exploration session to cancel.",
+      energyRefunded: 0,
     };
   }
+
+  const energyRefunded = pet.activeExploration.energyCost;
 
   return {
     success: true,
@@ -294,8 +299,12 @@ export function cancelExploration(pet: Pet): {
       ...pet,
       activityState: ActivityState.Idle,
       activeExploration: undefined,
+      energyStats: {
+        energy: pet.energyStats.energy + energyRefunded,
+      },
     },
-    message: "Exploration cancelled. Energy spent is not refunded.",
+    message: "Exploration cancelled. Energy has been refunded.",
+    energyRefunded,
   };
 }
 

--- a/src/game/core/exploration/forage.ts
+++ b/src/game/core/exploration/forage.ts
@@ -2,6 +2,7 @@
  * Foraging exploration logic.
  */
 
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { getLocation } from "@/game/data/locations";
 import { type ForageTable, getForageTable } from "@/game/data/tables/forage";
 import type {
@@ -292,6 +293,8 @@ export function cancelExploration(pet: Pet): {
   }
 
   const energyRefunded = pet.activeExploration.energyCost;
+  const maxStats = calculatePetMaxStats(pet);
+  const maxEnergy = maxStats?.energyMax ?? 0;
 
   return {
     success: true,
@@ -300,7 +303,7 @@ export function cancelExploration(pet: Pet): {
       activityState: ActivityState.Idle,
       activeExploration: undefined,
       energyStats: {
-        energy: pet.energyStats.energy + energyRefunded,
+        energy: Math.min(pet.energyStats.energy + energyRefunded, maxEnergy),
       },
     },
     message: "Exploration cancelled. Energy has been refunded.",

--- a/src/game/core/tickProcessor.test.ts
+++ b/src/game/core/tickProcessor.test.ts
@@ -404,6 +404,7 @@ test("processGameTick updates quest progress when training completes", () => {
       ticksRemaining: 1, // Will complete on this tick
       durationTicks: 10,
       startTick: 0,
+      energyCost: 0,
     },
   });
 
@@ -439,6 +440,7 @@ test("processGameTick updates quest progress when exploration completes", () => 
       ticksRemaining: 1, // Will complete on this tick
       durationTicks: 10,
       startTick: 0,
+      energyCost: 0,
     },
   });
 

--- a/src/game/core/training.ts
+++ b/src/game/core/training.ts
@@ -110,6 +110,7 @@ export function startTraining(
     startTick: currentTick,
     durationTicks: session.durationTicks,
     ticksRemaining: session.durationTicks,
+    energyCost: toMicro(session.energyCost),
   };
 
   const newEnergy = pet.energyStats.energy - toMicro(session.energyCost);
@@ -219,20 +220,24 @@ export function applyTrainingCompletion(pet: Pet): Pet {
 
 /**
  * Cancel an active training session.
- * Energy is not refunded.
+ * Energy is refunded to the pet.
  */
 export function cancelTraining(pet: Pet): {
   success: boolean;
   pet: Pet;
   message: string;
+  energyRefunded: number;
 } {
   if (!pet.activeTraining) {
     return {
       success: false,
       pet,
       message: "No training session to cancel.",
+      energyRefunded: 0,
     };
   }
+
+  const energyRefunded = pet.activeTraining.energyCost;
 
   return {
     success: true,
@@ -240,8 +245,12 @@ export function cancelTraining(pet: Pet): {
       ...pet,
       activityState: ActivityState.Idle,
       activeTraining: undefined,
+      energyStats: {
+        energy: pet.energyStats.energy + energyRefunded,
+      },
     },
-    message: "Training cancelled. Energy spent is not refunded.",
+    message: "Training cancelled. Energy has been refunded.",
+    energyRefunded,
   };
 }
 

--- a/src/game/core/training.ts
+++ b/src/game/core/training.ts
@@ -2,6 +2,7 @@
  * Training system core logic.
  */
 
+import { calculatePetMaxStats } from "@/game/core/petStats";
 import { getFacility, getSession } from "@/game/data/facilities";
 import type {
   ActiveTraining,
@@ -238,6 +239,8 @@ export function cancelTraining(pet: Pet): {
   }
 
   const energyRefunded = pet.activeTraining.energyCost;
+  const maxStats = calculatePetMaxStats(pet);
+  const maxEnergy = maxStats?.energyMax ?? 0;
 
   return {
     success: true,
@@ -246,7 +249,7 @@ export function cancelTraining(pet: Pet): {
       activityState: ActivityState.Idle,
       activeTraining: undefined,
       energyStats: {
-        energy: pet.energyStats.energy + energyRefunded,
+        energy: Math.min(pet.energyStats.energy + energyRefunded, maxEnergy),
       },
     },
     message: "Training cancelled. Energy has been refunded.",

--- a/src/game/types/activity.ts
+++ b/src/game/types/activity.ts
@@ -96,6 +96,8 @@ export interface ActiveTraining {
   durationTicks: Tick;
   /** Ticks remaining */
   ticksRemaining: Tick;
+  /** Energy cost paid to start (in micro units, for refund on cancel) */
+  energyCost: number;
 }
 
 /**
@@ -146,6 +148,8 @@ export interface ActiveExploration {
   durationTicks: Tick;
   /** Ticks remaining */
   ticksRemaining: Tick;
+  /** Energy cost paid to start (in micro units, for refund on cancel) */
+  energyCost: number;
 }
 
 /**


### PR DESCRIPTION
- Add energyCost field to ActiveTraining and ActiveExploration interfaces
- Store energy cost (in micro units) when starting training/exploration
- Refund full energy when cancelling training or exploration sessions
- Update cancelTraining and cancelExploration to return energyRefunded
- Update spec documentation with new cancellation mechanics
- Update tests to verify energy refund behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Energy is now fully refunded when cancelling exploration or training sessions.
  * Cancelled sessions no longer apply cooldowns; pets return to Idle.
  * Cancelling yields no items, no skill/stat gains, and no rewards.

* **Documentation**
  * Updated cancellation policies for exploration and training sessions to reflect refund and reward behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->