### PR TITLE
feat: show exploration results in offline report dialog

### DIFF
--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -213,13 +213,10 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
 
   // Determine button labels
   const isLastPage =
-    currentPage === "exploration" &&
-    explorationIndex === totalExplorationPages - 1;
-  const nextButtonLabel = isLastPage
-    ? "Continue"
-    : currentPage === "stats" && hasExplorationResults
-      ? "Next"
-      : "Continue";
+    (currentPage === "stats" && !hasExplorationResults) ||
+    (currentPage === "exploration" &&
+      explorationIndex === totalExplorationPages - 1);
+  const nextButtonLabel = isLastPage ? "Continue" : "Next";
 
   // Calculate page indicator
   const getCurrentPageNumber = () => {

--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -2,6 +2,7 @@
  * Offline report dialog showing what happened while the player was away.
  */
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,8 +11,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { getItemById } from "@/game/data/items";
 import { toDisplay } from "@/game/types/common";
-import type { OfflineReport as OfflineReportType } from "@/game/types/offline";
+import type {
+  OfflineExplorationResult,
+  OfflineReport as OfflineReportType,
+} from "@/game/types/offline";
 
 interface OfflineReportProps {
   report: OfflineReportType;
@@ -83,6 +88,69 @@ function StatChange({
 }
 
 /**
+ * Display a single exploration result.
+ */
+function ExplorationResultCard({
+  result,
+}: {
+  result: OfflineExplorationResult;
+}) {
+  const hasItems = result.itemsFound.length > 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">{hasItems ? "🌿" : "😔"}</span>
+        <div>
+          <p className="font-medium">Exploration Complete</p>
+          <p className="text-sm text-muted-foreground">{result.locationName}</p>
+        </div>
+      </div>
+
+      {hasItems ? (
+        <div className="bg-secondary/50 rounded-lg p-3">
+          <p className="text-xs font-medium text-muted-foreground mb-2">
+            Items Found
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {result.itemsFound.map((drop, index) => {
+              const item = getItemById(drop.itemId);
+              return (
+                <div
+                  key={`${drop.itemId}-${index}`}
+                  className="flex items-center gap-2 p-2 bg-background rounded-md"
+                >
+                  <span className="text-lg">{item?.icon ?? "❓"}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">
+                      {item?.name ?? drop.itemId}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      x{drop.quantity}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+        <div className="bg-secondary/50 rounded-lg p-3 text-center">
+          <p className="text-sm text-muted-foreground">
+            Didn't find anything this time.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Page types for the offline report.
+ */
+type OfflineReportPage = "stats" | "exploration";
+
+/**
  * Display the offline report as a dialog.
  */
 export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
@@ -95,13 +163,70 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
     maxStats,
     poopBefore,
     poopAfter,
+    explorationResults,
   } = report;
+
+  const hasExplorationResults = explorationResults.length > 0;
+
+  // Start on stats page, move to exploration if there are results
+  const [currentPage, setCurrentPage] = useState<OfflineReportPage>("stats");
+  const [explorationIndex, setExplorationIndex] = useState(0);
 
   const poopChange = poopAfter - poopBefore;
 
   // Use max values from report, with fallback for safety
   const maxCareStat = maxStats?.careStatMax ?? 200_000;
   const maxEnergy = maxStats?.energyMax ?? 200_000;
+
+  // Calculate total pages (1 for stats + number of exploration results)
+  const totalExplorationPages = explorationResults.length;
+  const hasPetInfo = petName && beforeStats && afterStats;
+
+  // Handle next button
+  const handleNext = () => {
+    if (currentPage === "stats") {
+      if (hasExplorationResults) {
+        setCurrentPage("exploration");
+        setExplorationIndex(0);
+      } else {
+        onDismiss();
+      }
+    } else {
+      if (explorationIndex < totalExplorationPages - 1) {
+        setExplorationIndex(explorationIndex + 1);
+      } else {
+        onDismiss();
+      }
+    }
+  };
+
+  // Handle back button
+  const handleBack = () => {
+    if (currentPage === "exploration") {
+      if (explorationIndex > 0) {
+        setExplorationIndex(explorationIndex - 1);
+      } else {
+        setCurrentPage("stats");
+      }
+    }
+  };
+
+  // Determine button labels
+  const isLastPage =
+    currentPage === "exploration" &&
+    explorationIndex === totalExplorationPages - 1;
+  const nextButtonLabel = isLastPage
+    ? "Continue"
+    : currentPage === "stats" && hasExplorationResults
+      ? "Next"
+      : "Continue";
+
+  // Calculate page indicator
+  const getCurrentPageNumber = () => {
+    if (currentPage === "stats") return 1;
+    return 2 + explorationIndex;
+  };
+  const getTotalPages = () => 1 + totalExplorationPages;
 
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
@@ -114,68 +239,96 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
           </DialogDescription>
         </DialogHeader>
 
-        {petName && beforeStats && afterStats && (
-          <div className="space-y-4">
-            <p className="text-sm">
-              While you were away, <strong>{petName}</strong> experienced the
-              following changes:
-            </p>
+        {currentPage === "stats" && (
+          <>
+            {hasPetInfo && (
+              <div className="space-y-4">
+                <p className="text-sm">
+                  While you were away, <strong>{petName}</strong> experienced
+                  the following changes:
+                </p>
 
-            <div className="space-y-1 text-sm">
-              <StatChange
-                label="Satiety"
-                before={beforeStats.satiety}
-                after={afterStats.satiety}
-                max={maxCareStat}
-              />
-              <StatChange
-                label="Hydration"
-                before={beforeStats.hydration}
-                after={afterStats.hydration}
-                max={maxCareStat}
-              />
-              <StatChange
-                label="Happiness"
-                before={beforeStats.happiness}
-                after={afterStats.happiness}
-                max={maxCareStat}
-              />
-              <StatChange
-                label="Energy"
-                before={beforeStats.energy}
-                after={afterStats.energy}
-                max={maxEnergy}
-              />
+                <div className="space-y-1 text-sm">
+                  <StatChange
+                    label="Satiety"
+                    before={beforeStats.satiety}
+                    after={afterStats.satiety}
+                    max={maxCareStat}
+                  />
+                  <StatChange
+                    label="Hydration"
+                    before={beforeStats.hydration}
+                    after={afterStats.hydration}
+                    max={maxCareStat}
+                  />
+                  <StatChange
+                    label="Happiness"
+                    before={beforeStats.happiness}
+                    after={afterStats.happiness}
+                    max={maxCareStat}
+                  />
+                  <StatChange
+                    label="Energy"
+                    before={beforeStats.energy}
+                    after={afterStats.energy}
+                    max={maxEnergy}
+                  />
 
-              {poopChange > 0 && (
-                <div className="flex justify-between items-center py-1">
-                  <span className="text-muted-foreground">Poop</span>
-                  <span className="text-amber-500">
-                    +{poopChange} poop{poopChange > 1 ? "s" : ""} accumulated
-                  </span>
+                  {poopChange > 0 && (
+                    <div className="flex justify-between items-center py-1">
+                      <span className="text-muted-foreground">Poop</span>
+                      <span className="text-amber-500">
+                        +{poopChange} poop{poopChange > 1 ? "s" : ""}{" "}
+                        accumulated
+                      </span>
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
 
-            {(afterStats.satiety === 0 ||
-              afterStats.hydration === 0 ||
-              afterStats.happiness === 0 ||
-              afterStats.energy === 0) && (
-              <p className="text-destructive text-sm">
-                ⚠️ Some needs are critical! Take care of your pet immediately.
+                {(afterStats.satiety === 0 ||
+                  afterStats.hydration === 0 ||
+                  afterStats.happiness === 0 ||
+                  afterStats.energy === 0) && (
+                  <p className="text-destructive text-sm">
+                    ⚠️ Some needs are critical! Take care of your pet
+                    immediately.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {!petName && (
+              <p className="text-sm text-muted-foreground">
+                Time has passed but you don&apos;t have a pet yet.
               </p>
             )}
+          </>
+        )}
+
+        {currentPage === "exploration" &&
+          explorationResults[explorationIndex] && (
+            <ExplorationResultCard
+              result={explorationResults[explorationIndex]}
+            />
+          )}
+
+        {/* Page indicator and navigation */}
+        <div className="flex items-center justify-between mt-4">
+          <div className="flex items-center gap-2">
+            {(hasExplorationResults || currentPage === "exploration") && (
+              <span className="text-xs text-muted-foreground">
+                Page {getCurrentPageNumber()} of {getTotalPages()}
+              </span>
+            )}
           </div>
-        )}
-
-        {!petName && (
-          <p className="text-sm text-muted-foreground">
-            Time has passed but you don&apos;t have a pet yet.
-          </p>
-        )}
-
-        <div className="flex justify-end mt-4">
-          <Button onClick={onDismiss}>Continue</Button>
+          <div className="flex gap-2">
+            {currentPage === "exploration" && (
+              <Button variant="outline" onClick={handleBack}>
+                Back
+              </Button>
+            )}
+            <Button onClick={handleNext}>{nextButtonLabel}</Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/game/core/tickProcessor.test.ts
+++ b/src/game/core/tickProcessor.test.ts
@@ -466,3 +466,85 @@ test("processGameTick updates quest progress when exploration completes", () => 
   // Quest progress should be updated for foraging
   expect(newState.quests[0]?.objectiveProgress.forage_once).toBe(1);
 });
+
+// Tests for exploration result collection in offline catchup
+
+test("processOfflineCatchup collects exploration result when exploration completes", () => {
+  const { ActivityState } = require("@/game/types/constants");
+
+  const pet = createTestPet({
+    activityState: ActivityState.Exploring,
+    activeExploration: {
+      locationId: "meadow",
+      activityType: "forage",
+      forageTableId: "meadow_forage",
+      ticksRemaining: 3, // Will complete on tick 3
+      durationTicks: 10,
+      startTick: 0,
+      energyCost: 0,
+    },
+  });
+
+  const state = createTestGameState({
+    pet,
+    player: {
+      ...createInitialGameState().player,
+      currentLocationId: "meadow",
+    },
+    totalTicks: 0,
+  });
+
+  const result = processOfflineCatchup(state, 10, 100);
+
+  // Should have collected at least one exploration result
+  expect(result.report.explorationResults.length).toBeGreaterThan(0);
+  // The result should have the correct location name
+  expect(result.report.explorationResults[0]?.locationName).toBe("Sunny Meadow");
+});
+
+test("processOfflineCatchup has empty explorationResults when no exploration completes", () => {
+  const pet = createTestPet({
+    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+  });
+  const state = createTestGameState({ pet, totalTicks: 0 });
+  const result = processOfflineCatchup(state, 10, 100);
+
+  // No exploration was active, so no results
+  expect(result.report.explorationResults).toEqual([]);
+});
+
+test("processOfflineCatchup collects exploration result for in-progress exploration", () => {
+  const { ActivityState } = require("@/game/types/constants");
+
+  // Exploration that was already in progress before going offline
+  // with only 2 ticks remaining
+  const pet = createTestPet({
+    activityState: ActivityState.Exploring,
+    activeExploration: {
+      locationId: "meadow",
+      activityType: "forage",
+      forageTableId: "meadow_forage",
+      ticksRemaining: 2,
+      durationTicks: 100, // Long duration, but only 2 ticks left
+      startTick: 0,
+      energyCost: 0,
+    },
+  });
+
+  const state = createTestGameState({
+    pet,
+    player: {
+      ...createInitialGameState().player,
+      currentLocationId: "meadow",
+    },
+    totalTicks: 0,
+  });
+
+  const result = processOfflineCatchup(state, 5, 100);
+
+  // Exploration should have completed and been collected
+  expect(result.report.explorationResults.length).toBe(1);
+  expect(result.report.explorationResults[0]?.locationName).toBe("Sunny Meadow");
+  // Pet should no longer be exploring
+  expect(result.state.pet?.activeExploration).toBeUndefined();
+});

--- a/src/game/core/tickProcessor.test.ts
+++ b/src/game/core/tickProcessor.test.ts
@@ -499,7 +499,9 @@ test("processOfflineCatchup collects exploration result when exploration complet
   // Should have collected at least one exploration result
   expect(result.report.explorationResults.length).toBeGreaterThan(0);
   // The result should have the correct location name
-  expect(result.report.explorationResults[0]?.locationName).toBe("Sunny Meadow");
+  expect(result.report.explorationResults[0]?.locationName).toBe(
+    "Sunny Meadow",
+  );
 });
 
 test("processOfflineCatchup has empty explorationResults when no exploration completes", () => {
@@ -544,7 +546,9 @@ test("processOfflineCatchup collects exploration result for in-progress explorat
 
   // Exploration should have completed and been collected
   expect(result.report.explorationResults.length).toBe(1);
-  expect(result.report.explorationResults[0]?.locationName).toBe("Sunny Meadow");
+  expect(result.report.explorationResults[0]?.locationName).toBe(
+    "Sunny Meadow",
+  );
   // Pet should no longer be exploring
   expect(result.state.pet?.activeExploration).toBeUndefined();
 });

--- a/src/game/types/offline.ts
+++ b/src/game/types/offline.ts
@@ -2,6 +2,7 @@
  * Types for offline progression reporting.
  */
 
+import type { ExplorationDrop } from "./activity";
 import type { MicroValue, Tick } from "./common";
 
 /**
@@ -12,6 +13,18 @@ export interface CareStatsSnapshot {
   hydration: MicroValue;
   happiness: MicroValue;
   energy: MicroValue;
+}
+
+/**
+ * Result of an exploration that completed during offline time.
+ */
+export interface OfflineExplorationResult {
+  /** Location name where exploration occurred */
+  locationName: string;
+  /** Items found during exploration */
+  itemsFound: ExplorationDrop[];
+  /** Message describing the result */
+  message: string;
 }
 
 /**
@@ -44,6 +57,8 @@ export interface OfflineReport {
   poopBefore: number;
   /** Poop count after offline processing */
   poopAfter: number;
+  /** Exploration results that completed during offline time */
+  explorationResults: OfflineExplorationResult[];
 }
 
 /**


### PR DESCRIPTION
- Add OfflineExplorationResult type to track exploration completions
- Extend OfflineReport to include an array of exploration results
- Modify processOfflineCatchup to collect exploration results during offline processing
- Update OfflineReport component with pagination to show stats page and exploration results
- Users can now navigate through multiple pages to see all offline activity outcomes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Offline play reports now display exploration results, including location names and items found.
  * Browse through exploration results with multi-page navigation and dynamic button controls.
  * Item icons and quantities are displayed for collected items during offline sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->