### PR TITLE
fix: prevent misleading training complete notification on cancel

### DIFF
--- a/src/game/context/GameContext.tsx
+++ b/src/game/context/GameContext.tsx
@@ -156,8 +156,14 @@ export function GameProvider({ children }: GameProviderProps) {
       return;
     }
 
-    // Training completed: was training before, not training now
-    if (previousTraining && !currentTraining) {
+    // Training completed: was training before, not training now, and was on last tick
+    // If ticksRemaining > 1, training was cancelled, not completed
+    const wasNaturalCompletion =
+      previousTraining &&
+      !currentTraining &&
+      previousTraining.ticksRemaining <= 1;
+
+    if (wasNaturalCompletion) {
       const facility = getFacility(previousTraining.facilityId);
       const session = getSession(
         previousTraining.facilityId,


### PR DESCRIPTION
When cancelling a training session, the 'Training Complete!' dialog was incorrectly shown even though no stats were awarded. This was because the notification logic only checked whether activeTraining transitioned from non-null to null, without distinguishing between natural completion and user cancellation.

The fix adds a check for ticksRemaining <= 1, which indicates that training completed naturally (the last tick). When training is cancelled, ticksRemaining is still > 1, so the notification is not shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed training completion notifications to only display when training naturally finishes, preventing notifications from appearing during cancellations or other scenarios.

* **Refactor**
  * Improved precision of training completion logic for more accurate state tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->