### PR TITLE
fix: correct item IDs in tutorial quest rewards

### DIFF
--- a/src/game/core/quests/quests.test.ts
+++ b/src/game/core/quests/quests.test.ts
@@ -159,6 +159,26 @@ test("completeQuest grants currency reward", () => {
   expect(result.state.player.currency.coins).toBe(initialCoins + 50);
 });
 
+test("completeQuest grants item reward", () => {
+  const progress: QuestProgress = {
+    questId: tutorialFirstSteps.id,
+    state: QuestState.Active,
+    objectiveProgress: {
+      feed_pet: 1,
+      give_water: 1,
+    },
+  };
+  const state = createTestState({}, [progress]);
+  const result = completeQuest(state, tutorialFirstSteps.id);
+  expect(result.success).toBe(true);
+  // Tutorial quest rewards 3 apples (food_apple)
+  const appleItem = result.state.player.inventory.items.find(
+    (item) => item.itemId === "food_apple",
+  );
+  expect(appleItem).toBeDefined();
+  expect(appleItem?.quantity).toBe(3);
+});
+
 test("updateQuestProgress advances matching objectives", () => {
   const progress: QuestProgress = {
     questId: tutorialFirstSteps.id,

--- a/src/game/data/quests/tutorial.ts
+++ b/src/game/data/quests/tutorial.ts
@@ -45,7 +45,7 @@ export const tutorialFirstSteps: Quest = {
     },
     {
       type: RewardType.Item,
-      target: "apple",
+      target: "food_apple",
       quantity: 3,
     },
   ],
@@ -88,7 +88,7 @@ export const tutorialExploration: Quest = {
     },
     {
       type: RewardType.Item,
-      target: "rubber_ball",
+      target: "toy_ball",
       quantity: 1,
     },
   ],


### PR DESCRIPTION
The tutorial quest rewards were using incorrect item IDs:
- 'apple' -> 'food_apple'
- 'rubber_ball' -> 'toy_ball'

This caused item rewards to not be added to inventory on quest completion because the addItem function silently returns the original inventory when the item ID doesn't exist.

Also added a test to verify item rewards are properly granted when completing quests.