### PR TITLE
fix: use ceiling rounding for care stats and fix item display

### DIFF
--- a/specs/care-system.md
+++ b/specs/care-system.md
@@ -32,10 +32,12 @@ To avoid floating point arithmetic, care stats use internal micro-units:
 
 **Display Value Calculation:**
 ```
-displayValue = floor(microValue / 1000)
+displayValue = ceil(microValue / 1000)
 ```
 
-A stat is considered 0 when its display value is 0, even if micro-value is greater than 0.
+This uses ceiling rounding, meaning any remaining micro-units round up to the next display value. For example, a microSatiety of 50,001 produces a display value of 51.
+
+A stat is considered 0 only when its micro-value is exactly 0.
 
 ### Stat Maximum by Growth Stage
 

--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { getItemById } from "@/game/data/items";
-import { toDisplay } from "@/game/types/common";
+import { toDisplay, toDisplayCare } from "@/game/types/common";
 import type {
   OfflineExplorationResult,
   OfflineReport as OfflineReportType,
@@ -52,21 +52,24 @@ function formatElapsedTime(ms: number): string {
 
 /**
  * Stat change indicator showing the difference between before and after values.
+ * Uses a configurable display function for rounding (defaults to floor for energy).
  */
 function StatChange({
   label,
   before,
   after,
   max,
+  displayFn = toDisplay,
 }: {
   label: string;
   before: number;
   after: number;
   max: number;
+  displayFn?: (value: number) => number;
 }) {
-  const beforeDisplay = toDisplay(before);
-  const afterDisplay = toDisplay(after);
-  const maxDisplay = toDisplay(max);
+  const beforeDisplay = displayFn(before);
+  const afterDisplay = displayFn(after);
+  const maxDisplay = displayFn(max);
   const change = afterDisplay - beforeDisplay;
 
   return (
@@ -251,18 +254,21 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
                     before={beforeStats.satiety}
                     after={afterStats.satiety}
                     max={maxCareStat}
+                    displayFn={toDisplayCare}
                   />
                   <StatChange
                     label="Hydration"
                     before={beforeStats.hydration}
                     after={afterStats.hydration}
                     max={maxCareStat}
+                    displayFn={toDisplayCare}
                   />
                   <StatChange
                     label="Happiness"
                     before={beforeStats.happiness}
                     after={afterStats.happiness}
                     max={maxCareStat}
+                    displayFn={toDisplayCare}
                   />
                   <StatChange
                     label="Energy"

--- a/src/components/inventory/ItemDetail.tsx
+++ b/src/components/inventory/ItemDetail.tsx
@@ -67,7 +67,7 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
     case "food":
       stats.push({
         label: "Satiety",
-        value: `+${toDisplay(itemDef.satietyRestore)}%`,
+        value: `+${toDisplay(itemDef.satietyRestore)}`,
       });
       if (itemDef.poopAcceleration) {
         stats.push({
@@ -79,7 +79,7 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
     case "drink":
       stats.push({
         label: "Hydration",
-        value: `+${toDisplay(itemDef.hydrationRestore)}%`,
+        value: `+${toDisplay(itemDef.hydrationRestore)}`,
       });
       if (itemDef.energyRestore) {
         stats.push({
@@ -91,7 +91,7 @@ function getItemStats(itemDef: Item): { label: string; value: string }[] {
     case "toy":
       stats.push({
         label: "Happiness",
-        value: `+${toDisplay(itemDef.happinessRestore)}%`,
+        value: `+${toDisplay(itemDef.happinessRestore)}`,
       });
       stats.push({
         label: "Durability",

--- a/src/game/core/care/careLife.ts
+++ b/src/game/core/care/careLife.ts
@@ -4,7 +4,7 @@
 
 import { GROWTH_STAGE_DEFINITIONS } from "@/game/data/growthStages";
 import type { MicroValue } from "@/game/types/common";
-import { toDisplay } from "@/game/types/common";
+import { toDisplayCare } from "@/game/types/common";
 import type { Pet } from "@/game/types/pet";
 import {
   CARE_LIFE_DRAIN_1_STAT,
@@ -39,9 +39,9 @@ export {
  */
 function countCriticalStats(pet: Pet): number {
   let count = 0;
-  if (toDisplay(pet.careStats.satiety) <= 0) count++;
-  if (toDisplay(pet.careStats.hydration) <= 0) count++;
-  if (toDisplay(pet.careStats.happiness) <= 0) count++;
+  if (toDisplayCare(pet.careStats.satiety) <= 0) count++;
+  if (toDisplayCare(pet.careStats.hydration) <= 0) count++;
+  if (toDisplayCare(pet.careStats.happiness) <= 0) count++;
   return count;
 }
 

--- a/src/game/core/integration.test.ts
+++ b/src/game/core/integration.test.ts
@@ -32,10 +32,11 @@ function createTestGameState(overrides: Partial<GameState> = {}): GameState {
 
 describe("Care system integration", () => {
   test("care stats and care life work together correctly", () => {
-    // Start with a pet that has low care stats
+    // Start with a pet that has exactly 0 satiety (critical)
+    // With ceiling rounding, a stat is only 0 when microValue is exactly 0
     const pet = createTestPet({
       careStats: {
-        satiety: 500, // Very low - below 1000 threshold for 0 display
+        satiety: 0, // Exactly 0 - critical stat
         hydration: 40_000,
         happiness: 40_000,
       },
@@ -44,7 +45,7 @@ describe("Care system integration", () => {
       },
     });
 
-    // Process care life - should drain since satiety is effectively 0
+    // Process care life - should drain since satiety is 0
     const maxStats = calculatePetMaxStats(pet);
     const updatedCareLife = applyCareLifeChange(
       pet,

--- a/src/game/state/selectors.ts
+++ b/src/game/state/selectors.ts
@@ -20,6 +20,7 @@ import {
   formatTicksAsTime,
   TICKS_PER_DAY,
   toDisplay,
+  toDisplayCare,
 } from "@/game/types/common";
 import {
   type CareThreshold,
@@ -95,10 +96,10 @@ export function selectCareStats(state: GameState): CareStatDisplay | null {
   const maxStats = calculatePetMaxStats(pet);
   if (!maxStats) return null;
 
-  const satiety = toDisplay(pet.careStats.satiety);
-  const hydration = toDisplay(pet.careStats.hydration);
-  const happiness = toDisplay(pet.careStats.happiness);
-  const max = toDisplay(maxStats.careStatMax);
+  const satiety = toDisplayCare(pet.careStats.satiety);
+  const hydration = toDisplayCare(pet.careStats.hydration);
+  const happiness = toDisplayCare(pet.careStats.happiness);
+  const max = toDisplayCare(maxStats.careStatMax);
 
   const satietyPercent = max > 0 ? Math.round((satiety / max) * 100) : 0;
   const hydrationPercent = max > 0 ? Math.round((hydration / max) * 100) : 0;

--- a/src/game/types/common.ts
+++ b/src/game/types/common.ts
@@ -5,7 +5,8 @@
 
 /**
  * Micro-unit values for precise integer arithmetic.
- * Display value = floor(microValue / 1000)
+ * Care stats display value = ceil(microValue / 1000)
+ * Energy display value = floor(microValue / 1000)
  *
  * Used for: Satiety, Hydration, Happiness, Energy, Care Life
  */
@@ -17,10 +18,22 @@ export type MicroValue = number;
 export const MICRO_RATIO = 1000;
 
 /**
- * Convert a micro-value to its display value.
+ * Convert a micro-value to its display value using floor.
+ * Use this for energy and other non-care stats.
  */
 export function toDisplay(microValue: MicroValue): number {
   return Math.floor(microValue / MICRO_RATIO);
+}
+
+/**
+ * Convert a care stat micro-value to its display value using ceil.
+ * Use this for satiety, hydration, and happiness.
+ *
+ * This ensures that any remaining micro-units round up to the next display value.
+ * For example, microSatiety of 50001 produces a display value of 51.
+ */
+export function toDisplayCare(microValue: MicroValue): number {
+  return Math.ceil(microValue / MICRO_RATIO);
 }
 
 /**


### PR DESCRIPTION
- Add toDisplayCare() function that uses Math.ceil for care stat micro-to-display conversion
- Update care stats (satiety, hydration, happiness) to use ceiling rounding
- Keep floor rounding for energy stats via existing toDisplay() function
- Fix item detail display: remove % symbol from care stat recovery (flat amounts, not percentages)
- Update care-system.md spec to document ceiling rounding behavior
- Update integration test to use exactly 0 for critical stat testing

This ensures that any remaining micro-units round up to the next display value. For example, microSatiety of 50001 produces a display value of 51/100 (51%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Care stat display values now use ceiling rounding; fractional amounts round up to the next whole number.

* **Bug Fixes**
  * Removed percentage symbols from care stat value displays in item details.

* **Documentation**
  * Updated care system documentation to clarify display value rounding behavior and zero-stat definition logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->