### PR TITLE
Remove unused get*ItemById functions

### DIFF
--- a/src/game/data/items/battle.ts
+++ b/src/game/data/items/battle.ts
@@ -99,10 +99,3 @@ export const BATTLE_ITEMS = {
 /** Array of all battle items for iteration. */
 export const BATTLE_ITEMS_LIST: readonly BattleItem[] =
   Object.values(BATTLE_ITEMS);
-
-/**
- * Get a battle item by ID.
- */
-export function getBattleItemById(id: string): BattleItem | undefined {
-  return BATTLE_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/cleaning.ts
+++ b/src/game/data/items/cleaning.ts
@@ -87,10 +87,3 @@ export const CLEANING_ITEMS = {
 /** Array of all cleaning items for iteration. */
 export const CLEANING_ITEMS_LIST: readonly CleaningItem[] =
   Object.values(CLEANING_ITEMS);
-
-/**
- * Get a cleaning item by ID.
- */
-export function getCleaningItemById(id: string): CleaningItem | undefined {
-  return CLEANING_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/drinks.ts
+++ b/src/game/data/items/drinks.ts
@@ -127,10 +127,3 @@ export const DRINK_ITEMS = {
 /** Array of all drink items for iteration. */
 export const DRINK_ITEMS_LIST: readonly DrinkItem[] =
   Object.values(DRINK_ITEMS);
-
-/**
- * Get a drink item by ID.
- */
-export function getDrinkItemById(id: string): DrinkItem | undefined {
-  return DRINK_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/equipment.ts
+++ b/src/game/data/items/equipment.ts
@@ -114,10 +114,3 @@ export const EQUIPMENT_ITEMS = {
 /** Array of all equipment items for iteration. */
 export const EQUIPMENT_ITEMS_LIST: readonly EquipmentItem[] =
   Object.values(EQUIPMENT_ITEMS);
-
-/**
- * Get an equipment item by ID.
- */
-export function getEquipmentItemById(id: string): EquipmentItem | undefined {
-  return EQUIPMENT_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/food.ts
+++ b/src/game/data/items/food.ts
@@ -150,10 +150,3 @@ export const FOOD_ITEMS = {
 
 /** Array of all food items for iteration. */
 export const FOOD_ITEMS_LIST: readonly FoodItem[] = Object.values(FOOD_ITEMS);
-
-/**
- * Get a food item by ID.
- */
-export function getFoodItemById(id: string): FoodItem | undefined {
-  return FOOD_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/index.ts
+++ b/src/game/data/items/index.ts
@@ -13,30 +13,14 @@ import type {
   MedicineItem,
   ToyItem,
 } from "@/game/types/item";
-import { BATTLE_ITEMS, BATTLE_ITEMS_LIST, getBattleItemById } from "./battle";
-import {
-  CLEANING_ITEMS,
-  CLEANING_ITEMS_LIST,
-  getCleaningItemById,
-} from "./cleaning";
-import { DRINK_ITEMS, DRINK_ITEMS_LIST, getDrinkItemById } from "./drinks";
-import {
-  EQUIPMENT_ITEMS,
-  EQUIPMENT_ITEMS_LIST,
-  getEquipmentItemById,
-} from "./equipment";
-import { FOOD_ITEMS, FOOD_ITEMS_LIST, getFoodItemById } from "./food";
-import {
-  getMaterialItemById,
-  MATERIAL_ITEMS,
-  MATERIAL_ITEMS_LIST,
-} from "./materials";
-import {
-  getMedicineItemById,
-  MEDICINE_ITEMS,
-  MEDICINE_ITEMS_LIST,
-} from "./medicine";
-import { getToyItemById, TOY_ITEMS, TOY_ITEMS_LIST } from "./toys";
+import { BATTLE_ITEMS, BATTLE_ITEMS_LIST } from "./battle";
+import { CLEANING_ITEMS, CLEANING_ITEMS_LIST } from "./cleaning";
+import { DRINK_ITEMS, DRINK_ITEMS_LIST } from "./drinks";
+import { EQUIPMENT_ITEMS, EQUIPMENT_ITEMS_LIST } from "./equipment";
+import { FOOD_ITEMS, FOOD_ITEMS_LIST } from "./food";
+import { MATERIAL_ITEMS, MATERIAL_ITEMS_LIST } from "./materials";
+import { MEDICINE_ITEMS, MEDICINE_ITEMS_LIST } from "./medicine";
+import { TOY_ITEMS, TOY_ITEMS_LIST } from "./toys";
 
 /**
  * All items in the game.
@@ -123,18 +107,6 @@ export function getAllEquipmentItems(): EquipmentItem[] {
 export function getAllMaterialItems(): MaterialItem[] {
   return [...MATERIAL_ITEMS_LIST];
 }
-
-// Re-export individual lookup functions
-export {
-  getBattleItemById,
-  getCleaningItemById,
-  getDrinkItemById,
-  getEquipmentItemById,
-  getFoodItemById,
-  getMaterialItemById,
-  getMedicineItemById,
-  getToyItemById,
-};
 
 // Re-export item objects (enum-like access via FOOD_ITEMS.KIBBLE.id)
 export {

--- a/src/game/data/items/materials.ts
+++ b/src/game/data/items/materials.ts
@@ -112,10 +112,3 @@ export const MATERIAL_ITEMS = {
 /** Array of all material items for iteration. */
 export const MATERIAL_ITEMS_LIST: readonly MaterialItem[] =
   Object.values(MATERIAL_ITEMS);
-
-/**
- * Get a material item by ID.
- */
-export function getMaterialItemById(id: string): MaterialItem | undefined {
-  return MATERIAL_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/medicine.ts
+++ b/src/game/data/items/medicine.ts
@@ -90,10 +90,3 @@ export const MEDICINE_ITEMS = {
 /** Array of all medicine items for iteration. */
 export const MEDICINE_ITEMS_LIST: readonly MedicineItem[] =
   Object.values(MEDICINE_ITEMS);
-
-/**
- * Get a medicine item by ID.
- */
-export function getMedicineItemById(id: string): MedicineItem | undefined {
-  return MEDICINE_ITEMS_LIST.find((item) => item.id === id);
-}

--- a/src/game/data/items/toys.ts
+++ b/src/game/data/items/toys.ts
@@ -133,10 +133,3 @@ export const TOY_ITEMS = {
 
 /** Array of all toy items for iteration. */
 export const TOY_ITEMS_LIST: readonly ToyItem[] = Object.values(TOY_ITEMS);
-
-/**
- * Get a toy item by ID.
- */
-export function getToyItemById(id: string): ToyItem | undefined {
-  return TOY_ITEMS_LIST.find((item) => item.id === id);
-}


### PR DESCRIPTION
Removed the following unused functions:
- getBattleItemById
- getCleaningItemById
- getDrinkItemById
- getEquipmentItemById
- getFoodItemById
- getMaterialItemById
- getMedicineItemById
- getToyItemById

These functions were only defined and re-exported but never actually used. The generic getItemById function in index.ts can be used instead if needed.