### PR TITLE
fix: display forage duration in human-readable format

### DIFF
--- a/src/components/exploration/ActivitySelect.tsx
+++ b/src/components/exploration/ActivitySelect.tsx
@@ -5,6 +5,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ForageTable } from "@/game/data/tables/forage";
+import { formatTicksAsTime } from "@/game/types/common";
 
 interface ActivitySelectProps {
   forageInfo: ForageTable | undefined;
@@ -66,10 +67,7 @@ export function ActivitySelect({
 
         <div className="flex items-center justify-between text-sm">
           <span className="text-muted-foreground">Duration:</span>
-          <span>
-            {forageInfo.baseDurationTicks} tick
-            {forageInfo.baseDurationTicks !== 1 ? "s" : ""}
-          </span>
+          <span>{formatTicksAsTime(forageInfo.baseDurationTicks)}</span>
         </div>
 
         <Button


### PR DESCRIPTION
Use formatTicksAsTime() to convert ticks to a readable duration (e.g., '1m' instead of '2 ticks') in the Explore page's Forage activity.