### PR TITLE
fix: block care actions, sleep, and travel during training/exploring

### DIFF
--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -467,3 +467,82 @@ test("useFoodItem fails when pet is exploring", () => {
   expect(result.success).toBe(false);
   expect(result.message).toContain("exploring");
 });
+
+test("useFoodItem fails when pet is battling", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Battling;
+  }
+
+  const result = useFoodItem(state, FOOD_ITEMS.KIBBLE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});
+
+test("useDrinkItem fails when pet is exploring", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Exploring;
+  }
+
+  const result = useDrinkItem(state, DRINK_ITEMS.WATER.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
+});
+
+test("useDrinkItem fails when pet is battling", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Battling;
+  }
+
+  const result = useDrinkItem(state, DRINK_ITEMS.WATER.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});
+
+test("useCleaningItem fails when pet is exploring", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Exploring;
+    state.pet.poop.count = 3;
+  }
+
+  const result = useCleaningItem(state, CLEANING_ITEMS.TISSUE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
+});
+
+test("useCleaningItem fails when pet is battling", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Battling;
+    state.pet.poop.count = 3;
+  }
+
+  const result = useCleaningItem(state, CLEANING_ITEMS.TISSUE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});
+
+test("useToyItem fails when pet is exploring", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Exploring;
+  }
+
+  const result = useToyItem(state, TOY_ITEMS.BALL.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
+});
+
+test("useToyItem fails when pet is battling", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Battling;
+  }
+
+  const result = useToyItem(state, TOY_ITEMS.BALL.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -12,6 +12,7 @@ import {
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
+import { ActivityState } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import { createInitialSkills } from "@/game/types/skill";
 import {
@@ -99,6 +100,7 @@ test("useFoodItem fails when pet is sleeping", () => {
   const state = createTestState();
   if (state.pet) {
     state.pet.sleep.isSleeping = true;
+    state.pet.activityState = ActivityState.Sleeping;
   }
 
   const result = useFoodItem(state, FOOD_ITEMS.KIBBLE.id);
@@ -153,6 +155,7 @@ test("useDrinkItem fails when pet is sleeping", () => {
   const state = createTestState();
   if (state.pet) {
     state.pet.sleep.isSleeping = true;
+    state.pet.activityState = ActivityState.Sleeping;
   }
 
   const result = useDrinkItem(state, DRINK_ITEMS.WATER.id);
@@ -363,6 +366,7 @@ test("useToyItem fails when pet is sleeping", () => {
   const state = createTestState();
   if (state.pet) {
     state.pet.sleep.isSleeping = true;
+    state.pet.activityState = ActivityState.Sleeping;
   }
 
   const result = useToyItem(state, TOY_ITEMS.BALL.id);
@@ -406,4 +410,62 @@ test("useToyItem clamps happiness to max", () => {
   expect(result.success).toBe(true);
   // Baby stage max with florabit multiplier is 50_000
   expect(result.state.pet?.careStats.happiness).toBe(50_000);
+});
+
+// Tests for blocking care actions during training
+
+test("useFoodItem fails when pet is training", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Training;
+  }
+
+  const result = useFoodItem(state, FOOD_ITEMS.KIBBLE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("useDrinkItem fails when pet is training", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Training;
+  }
+
+  const result = useDrinkItem(state, DRINK_ITEMS.WATER.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("useCleaningItem fails when pet is training", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Training;
+    state.pet.poop.count = 3;
+  }
+
+  const result = useCleaningItem(state, CLEANING_ITEMS.TISSUE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("useToyItem fails when pet is training", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Training;
+  }
+
+  const result = useToyItem(state, TOY_ITEMS.BALL.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("useFoodItem fails when pet is exploring", () => {
+  const state = createTestState();
+  if (state.pet) {
+    state.pet.activityState = ActivityState.Exploring;
+  }
+
+  const result = useFoodItem(state, FOOD_ITEMS.KIBBLE.id);
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
 });

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/game/data/items";
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
+import { createSleepingTestPet } from "@/game/testing/createTestPet";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
 import { ActivityState } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
@@ -98,10 +99,9 @@ test("useFoodItem consumes item from inventory", () => {
 
 test("useFoodItem fails when pet is sleeping", () => {
   const state = createTestState();
-  if (state.pet) {
-    state.pet.sleep.isSleeping = true;
-    state.pet.activityState = ActivityState.Sleeping;
-  }
+  state.pet = createSleepingTestPet({
+    careStats: { satiety: 10_000, hydration: 10_000, happiness: 10_000 },
+  });
 
   const result = useFoodItem(state, FOOD_ITEMS.KIBBLE.id);
   expect(result.success).toBe(false);
@@ -153,10 +153,9 @@ test("useDrinkItem with energy drink also restores energy", () => {
 
 test("useDrinkItem fails when pet is sleeping", () => {
   const state = createTestState();
-  if (state.pet) {
-    state.pet.sleep.isSleeping = true;
-    state.pet.activityState = ActivityState.Sleeping;
-  }
+  state.pet = createSleepingTestPet({
+    careStats: { satiety: 10_000, hydration: 10_000, happiness: 10_000 },
+  });
 
   const result = useDrinkItem(state, DRINK_ITEMS.WATER.id);
   expect(result.success).toBe(false);
@@ -364,10 +363,9 @@ test("useToyItem destroys toy when durability reaches 0", () => {
 
 test("useToyItem fails when pet is sleeping", () => {
   const state = createTestState();
-  if (state.pet) {
-    state.pet.sleep.isSleeping = true;
-    state.pet.activityState = ActivityState.Sleeping;
-  }
+  state.pet = createSleepingTestPet({
+    careStats: { satiety: 10_000, hydration: 10_000, happiness: 10_000 },
+  });
 
   const result = useToyItem(state, TOY_ITEMS.BALL.id);
   expect(result.success).toBe(false);

--- a/src/game/core/items.ts
+++ b/src/game/core/items.ts
@@ -6,6 +6,10 @@ import { removePoop } from "@/game/core/care/poop";
 import { hasItem, removeItem } from "@/game/core/inventory";
 import { calculatePetMaxStats } from "@/game/core/petStats";
 import { getItemById } from "@/game/data/items";
+import {
+  ActivityState,
+  getActivityConflictMessage,
+} from "@/game/types/constants";
 import type { GameState, InventoryItem } from "@/game/types/gameState";
 import {
   isCleaningItem,
@@ -54,9 +58,13 @@ export function useFoodItem(state: GameState, itemId: string): UseItemResult {
     return { success: false, state, message: "No pet to feed!" };
   }
 
-  // Check if pet is sleeping
-  if (state.pet.sleep.isSleeping) {
-    return { success: false, state, message: "Can't feed a sleeping pet!" };
+  // Check if pet is idle (not sleeping, training, exploring, or battling)
+  if (state.pet.activityState !== ActivityState.Idle) {
+    return {
+      success: false,
+      state,
+      message: getActivityConflictMessage("feed", state.pet.activityState),
+    };
   }
 
   // Check if item exists and is food
@@ -128,12 +136,15 @@ export function useDrinkItem(state: GameState, itemId: string): UseItemResult {
     return { success: false, state, message: "No pet to give water!" };
   }
 
-  // Check if pet is sleeping
-  if (state.pet.sleep.isSleeping) {
+  // Check if pet is idle (not sleeping, training, exploring, or battling)
+  if (state.pet.activityState !== ActivityState.Idle) {
     return {
       success: false,
       state,
-      message: "Can't give water to a sleeping pet!",
+      message: getActivityConflictMessage(
+        "give water",
+        state.pet.activityState,
+      ),
     };
   }
 
@@ -205,6 +216,15 @@ export function useCleaningItem(
   // Check if pet exists
   if (!state.pet) {
     return { success: false, state, message: "No pet to clean!" };
+  }
+
+  // Check if pet is idle (not sleeping, training, exploring, or battling)
+  if (state.pet.activityState !== ActivityState.Idle) {
+    return {
+      success: false,
+      state,
+      message: getActivityConflictMessage("clean", state.pet.activityState),
+    };
   }
 
   // Check if item exists and is cleaning
@@ -285,12 +305,12 @@ export function useToyItem(state: GameState, itemId: string): UseItemResult {
     return { success: false, state, message: "No pet to play with!" };
   }
 
-  // Check if pet is sleeping
-  if (state.pet.sleep.isSleeping) {
+  // Check if pet is idle (not sleeping, training, exploring, or battling)
+  if (state.pet.activityState !== ActivityState.Idle) {
     return {
       success: false,
       state,
-      message: "Can't play with a sleeping pet!",
+      message: getActivityConflictMessage("play", state.pet.activityState),
     };
   }
 

--- a/src/game/core/sleep.test.ts
+++ b/src/game/core/sleep.test.ts
@@ -7,6 +7,7 @@ import {
   createSleepingTestPet,
   createTestPet,
 } from "@/game/testing/createTestPet";
+import { ActivityState } from "@/game/types/constants";
 import {
   canPerformCareActions,
   getRemainingMinSleep,
@@ -33,6 +34,22 @@ test("putToSleep fails when pet is already sleeping", () => {
 
   expect(result.success).toBe(false);
   expect(result.message).toBe("Pet is already sleeping.");
+});
+
+test("putToSleep fails when pet is training", () => {
+  const pet = createTestPet({ activityState: ActivityState.Training });
+  const result = putToSleep(pet);
+
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("putToSleep fails when pet is exploring", () => {
+  const pet = createTestPet({ activityState: ActivityState.Exploring });
+  const result = putToSleep(pet);
+
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
 });
 
 test("wakeUp succeeds when pet is sleeping", () => {

--- a/src/game/core/sleep.test.ts
+++ b/src/game/core/sleep.test.ts
@@ -52,6 +52,14 @@ test("putToSleep fails when pet is exploring", () => {
   expect(result.message).toContain("exploring");
 });
 
+test("putToSleep fails when pet is battling", () => {
+  const pet = createTestPet({ activityState: ActivityState.Battling });
+  const result = putToSleep(pet);
+
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});
+
 test("wakeUp succeeds when pet is sleeping", () => {
   const pet = createSleepingTestPet();
   const result = wakeUp(pet);

--- a/src/game/core/sleep.ts
+++ b/src/game/core/sleep.ts
@@ -5,7 +5,11 @@
 import { getSpeciesGrowthStage } from "@/game/data/species";
 import type { Tick } from "@/game/types/common";
 import { now } from "@/game/types/common";
-import type { GrowthStage } from "@/game/types/constants";
+import {
+  ActivityState,
+  type GrowthStage,
+  getActivityConflictMessage,
+} from "@/game/types/constants";
 import type { Pet, PetSleep } from "@/game/types/pet";
 
 /**
@@ -68,6 +72,18 @@ export function hasMetSleepRequirement(pet: Pet): boolean {
  * Put the pet to sleep.
  */
 export function putToSleep(pet: Pet): SleepTransitionResult {
+  // Check if pet is busy with another activity (training, exploring, battling)
+  if (
+    pet.activityState !== ActivityState.Idle &&
+    pet.activityState !== ActivityState.Sleeping
+  ) {
+    return {
+      success: false,
+      sleep: pet.sleep,
+      message: getActivityConflictMessage("put to sleep", pet.activityState),
+    };
+  }
+
   if (pet.sleep.isSleeping) {
     return {
       success: false,

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -160,6 +160,15 @@ test("canTravel fails when pet is exploring", () => {
   expect(result.message).toContain("exploring");
 });
 
+test("canTravel fails when pet is battling", () => {
+  const state = createTestState({
+    pet: createTestPet({ activityState: ActivityState.Battling }),
+  });
+  const result = canTravel(state, "meadow");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("battling");
+});
+
 test("canTravel fails for unknown destination", () => {
   const state = createTestState({});
   const result = canTravel(state, "unknown-location");

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -8,7 +8,7 @@ import {
   createTestPet,
 } from "@/game/testing/createTestPet";
 import { toMicro } from "@/game/types/common";
-import { GrowthStage } from "@/game/types/constants";
+import { ActivityState, GrowthStage } from "@/game/types/constants";
 import { createInitialGameState, type GameState } from "@/game/types/gameState";
 import type { Pet } from "@/game/types/pet";
 import {
@@ -140,6 +140,24 @@ test("canTravel fails when pet is sleeping", () => {
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
   expect(result.message).toContain("sleeping");
+});
+
+test("canTravel fails when pet is training", () => {
+  const state = createTestState({
+    pet: createTestPet({ activityState: ActivityState.Training }),
+  });
+  const result = canTravel(state, "meadow");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("training");
+});
+
+test("canTravel fails when pet is exploring", () => {
+  const state = createTestState({
+    pet: createTestPet({ activityState: ActivityState.Exploring }),
+  });
+  const result = canTravel(state, "meadow");
+  expect(result.success).toBe(false);
+  expect(result.message).toContain("exploring");
 });
 
 test("canTravel fails for unknown destination", () => {

--- a/src/game/core/travel.ts
+++ b/src/game/core/travel.ts
@@ -5,7 +5,12 @@
 import { updateQuestProgress } from "@/game/core/quests/quests";
 import { areLocationsConnected, getLocation } from "@/game/data/locations";
 import { toDisplay, toMicro } from "@/game/types/common";
-import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
+import {
+  ActivityState,
+  GROWTH_STAGE_ORDER,
+  type GrowthStage,
+  getActivityConflictMessage,
+} from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import type { LocationRequirement, TravelResult } from "@/game/types/location";
 import { ObjectiveType } from "@/game/types/quest";
@@ -104,11 +109,11 @@ export function canTravel(
     return { success: false, message: "You need a pet to travel." };
   }
 
-  // Cannot travel while sleeping
-  if (state.pet.sleep.isSleeping) {
+  // Cannot travel while doing another activity
+  if (state.pet.activityState !== ActivityState.Idle) {
     return {
       success: false,
-      message: "Your pet is sleeping. Wake them up first.",
+      message: getActivityConflictMessage("travel", state.pet.activityState),
     };
   }
 

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -13,8 +13,8 @@ import { dailyCareRoutine } from "@/game/data/quests/daily";
 import { tutorialFirstSteps } from "@/game/data/quests/tutorial";
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
+import { createSleepingTestPet } from "@/game/testing/createTestPet";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
-import { ActivityState } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import type { QuestProgress } from "@/game/types/quest";
 import { QuestState } from "@/game/types/quest";
@@ -150,10 +150,9 @@ test("care actions do not update quest progress when action fails", () => {
   };
   const state = createTestState([progress]);
   // Make pet sleep so feeding fails
-  if (state.pet) {
-    state.pet.sleep.isSleeping = true;
-    state.pet.activityState = ActivityState.Sleeping;
-  }
+  state.pet = createSleepingTestPet({
+    careStats: { satiety: 10_000, hydration: 10_000, happiness: 10_000 },
+  });
 
   const result = feedPet(state, FOOD_ITEMS.KIBBLE.id);
 

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -14,6 +14,7 @@ import { tutorialFirstSteps } from "@/game/data/quests/tutorial";
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
+import { ActivityState } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import type { QuestProgress } from "@/game/types/quest";
 import { QuestState } from "@/game/types/quest";
@@ -151,6 +152,7 @@ test("care actions do not update quest progress when action fails", () => {
   // Make pet sleep so feeding fails
   if (state.pet) {
     state.pet.sleep.isSleeping = true;
+    state.pet.activityState = ActivityState.Sleeping;
   }
 
   const result = feedPet(state, FOOD_ITEMS.KIBBLE.id);


### PR DESCRIPTION
- Add activity state checks to useFoodItem, useDrinkItem, useToyItem, useCleaningItem
- Add activity state check to putToSleep to prevent sleeping while training/exploring
- Add activity state check to canTravel to prevent travel while training/exploring
- Update existing tests and add new tests for training/exploring blocking scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Care actions (feed, drink, clean, play), travel, and sleep now block when the pet is engaged in another activity (Training, Exploring, Battling) and show standardized conflict messages including the activity name.

* **Tests**
  * Expanded tests to cover blocking behavior and messages for Training, Exploring, and Battling; updated care tests to use dedicated sleeping test pets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->