### PR TITLE
feat: show training results in offline progress dialog

### DIFF
--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -16,7 +16,9 @@ import { toDisplay, toDisplayCare } from "@/game/types/common";
 import type {
   OfflineExplorationResult,
   OfflineReport as OfflineReportType,
+  OfflineTrainingResult,
 } from "@/game/types/offline";
+import type { BattleStats } from "@/game/types/stats";
 
 interface OfflineReportProps {
   report: OfflineReportType;
@@ -149,9 +151,82 @@ function ExplorationResultCard({
 }
 
 /**
+ * Stat display names for training.
+ */
+const STAT_DISPLAY_NAMES: Record<keyof BattleStats, string> = {
+  strength: "Strength",
+  endurance: "Endurance",
+  agility: "Agility",
+  precision: "Precision",
+  fortitude: "Fortitude",
+  cunning: "Cunning",
+};
+
+/**
+ * Stat icons for training.
+ */
+const STAT_ICONS: Record<keyof BattleStats, string> = {
+  strength: "💪",
+  endurance: "❤️",
+  agility: "⚡",
+  precision: "🎯",
+  fortitude: "🛡️",
+  cunning: "🧠",
+};
+
+/**
+ * Display a single training result.
+ */
+function TrainingResultCard({ result }: { result: OfflineTrainingResult }) {
+  const { facilityName, result: trainingResult } = result;
+  const statsGained = trainingResult.statsGained ?? {};
+
+  const gainedEntries = Object.entries(statsGained).filter(
+    ([_, value]) => value && value > 0,
+  ) as [keyof BattleStats, number][];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">🎉</span>
+        <div>
+          <p className="font-medium">Training Complete!</p>
+          <p className="text-sm text-muted-foreground">{facilityName}</p>
+        </div>
+      </div>
+
+      {gainedEntries.length > 0 ? (
+        <div className="bg-secondary/50 rounded-lg p-3">
+          <p className="text-xs font-medium text-muted-foreground mb-2">
+            Stats Gained
+          </p>
+          <div className="flex flex-col items-center gap-2">
+            {gainedEntries.map(([stat, value]) => (
+              <div key={stat} className="flex items-center gap-2">
+                <span>{STAT_ICONS[stat]}</span>
+                <span className="text-sm">{STAT_DISPLAY_NAMES[stat]}</span>
+                <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+                  +{value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="bg-secondary/50 rounded-lg p-3 text-center">
+          <p className="text-sm text-muted-foreground">
+            Training session completed.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
  * Page types for the offline report.
  */
-type OfflineReportPage = "stats" | "exploration";
+type OfflineReportPage = "stats" | "training" | "exploration";
 
 /**
  * Display the offline report as a dialog.
@@ -167,12 +242,15 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
     poopBefore,
     poopAfter,
     explorationResults,
+    trainingResults,
   } = report;
 
   const hasExplorationResults = explorationResults.length > 0;
+  const hasTrainingResults = trainingResults.length > 0;
 
-  // Start on stats page, move to exploration if there are results
+  // Start on stats page, move to training/exploration if there are results
   const [currentPage, setCurrentPage] = useState<OfflineReportPage>("stats");
+  const [trainingIndex, setTrainingIndex] = useState(0);
   const [explorationIndex, setExplorationIndex] = useState(0);
 
   const poopChange = poopAfter - poopBefore;
@@ -183,14 +261,28 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
   const maxHappiness = maxStats?.care?.happiness ?? 200_000;
   const maxEnergy = maxStats?.energy ?? 200_000;
 
-  // Calculate total pages (1 for stats + number of exploration results)
+  // Calculate total pages (1 for stats + training results + exploration results)
+  const totalTrainingPages = trainingResults.length;
   const totalExplorationPages = explorationResults.length;
   const hasPetInfo = petName && beforeStats && afterStats;
 
   // Handle next button
+  // Navigation order: stats -> training (if any) -> exploration (if any) -> dismiss
   const handleNext = () => {
     if (currentPage === "stats") {
-      if (hasExplorationResults) {
+      if (hasTrainingResults) {
+        setCurrentPage("training");
+        setTrainingIndex(0);
+      } else if (hasExplorationResults) {
+        setCurrentPage("exploration");
+        setExplorationIndex(0);
+      } else {
+        onDismiss();
+      }
+    } else if (currentPage === "training") {
+      if (trainingIndex < totalTrainingPages - 1) {
+        setTrainingIndex(trainingIndex + 1);
+      } else if (hasExplorationResults) {
         setCurrentPage("exploration");
         setExplorationIndex(0);
       } else {
@@ -207,9 +299,18 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
 
   // Handle back button
   const handleBack = () => {
-    if (currentPage === "exploration") {
+    if (currentPage === "training") {
+      if (trainingIndex > 0) {
+        setTrainingIndex(trainingIndex - 1);
+      } else {
+        setCurrentPage("stats");
+      }
+    } else if (currentPage === "exploration") {
       if (explorationIndex > 0) {
         setExplorationIndex(explorationIndex - 1);
+      } else if (hasTrainingResults) {
+        setCurrentPage("training");
+        setTrainingIndex(totalTrainingPages - 1);
       } else {
         setCurrentPage("stats");
       }
@@ -218,17 +319,24 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
 
   // Determine button labels
   const isLastPage =
-    (currentPage === "stats" && !hasExplorationResults) ||
+    (currentPage === "stats" &&
+      !hasTrainingResults &&
+      !hasExplorationResults) ||
+    (currentPage === "training" &&
+      trainingIndex === totalTrainingPages - 1 &&
+      !hasExplorationResults) ||
     (currentPage === "exploration" &&
       explorationIndex === totalExplorationPages - 1);
   const nextButtonLabel = isLastPage ? "Continue" : "Next";
 
   // Calculate page indicator
+  const hasMultiplePages = hasTrainingResults || hasExplorationResults;
   const getCurrentPageNumber = () => {
     if (currentPage === "stats") return 1;
-    return 2 + explorationIndex;
+    if (currentPage === "training") return 2 + trainingIndex;
+    return 2 + totalTrainingPages + explorationIndex;
   };
-  const getTotalPages = () => 1 + totalExplorationPages;
+  const getTotalPages = () => 1 + totalTrainingPages + totalExplorationPages;
 
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
@@ -310,6 +418,10 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
           </>
         )}
 
+        {currentPage === "training" && trainingResults[trainingIndex] && (
+          <TrainingResultCard result={trainingResults[trainingIndex]} />
+        )}
+
         {currentPage === "exploration" &&
           explorationResults[explorationIndex] && (
             <ExplorationResultCard
@@ -320,14 +432,14 @@ export function OfflineReport({ report, onDismiss }: OfflineReportProps) {
         {/* Page indicator and navigation */}
         <div className="flex items-center justify-between mt-4">
           <div className="flex items-center gap-2">
-            {(hasExplorationResults || currentPage === "exploration") && (
+            {hasMultiplePages && (
               <span className="text-xs text-muted-foreground">
                 Page {getCurrentPageNumber()} of {getTotalPages()}
               </span>
             )}
           </div>
           <div className="flex gap-2">
-            {currentPage === "exploration" && (
+            {(currentPage === "training" || currentPage === "exploration") && (
               <Button variant="outline" onClick={handleBack}>
                 Back
               </Button>

--- a/src/components/game/OfflineReport.tsx
+++ b/src/components/game/OfflineReport.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { StatsGainedDisplay } from "@/components/ui/StatsGainedDisplay";
 import { getItemById } from "@/game/data/items";
 import { toDisplay, toDisplayCare } from "@/game/types/common";
 import type {
@@ -18,7 +19,6 @@ import type {
   OfflineReport as OfflineReportType,
   OfflineTrainingResult,
 } from "@/game/types/offline";
-import type { BattleStats } from "@/game/types/stats";
 
 interface OfflineReportProps {
   report: OfflineReportType;
@@ -151,39 +151,10 @@ function ExplorationResultCard({
 }
 
 /**
- * Stat display names for training.
- */
-const STAT_DISPLAY_NAMES: Record<keyof BattleStats, string> = {
-  strength: "Strength",
-  endurance: "Endurance",
-  agility: "Agility",
-  precision: "Precision",
-  fortitude: "Fortitude",
-  cunning: "Cunning",
-};
-
-/**
- * Stat icons for training.
- */
-const STAT_ICONS: Record<keyof BattleStats, string> = {
-  strength: "💪",
-  endurance: "❤️",
-  agility: "⚡",
-  precision: "🎯",
-  fortitude: "🛡️",
-  cunning: "🧠",
-};
-
-/**
  * Display a single training result.
  */
 function TrainingResultCard({ result }: { result: OfflineTrainingResult }) {
   const { facilityName, result: trainingResult } = result;
-  const statsGained = trainingResult.statsGained ?? {};
-
-  const gainedEntries = Object.entries(statsGained).filter(
-    ([_, value]) => value && value > 0,
-  ) as [keyof BattleStats, number][];
 
   return (
     <div className="space-y-3">
@@ -195,23 +166,9 @@ function TrainingResultCard({ result }: { result: OfflineTrainingResult }) {
         </div>
       </div>
 
-      {gainedEntries.length > 0 ? (
-        <div className="bg-secondary/50 rounded-lg p-3">
-          <p className="text-xs font-medium text-muted-foreground mb-2">
-            Stats Gained
-          </p>
-          <div className="flex flex-col items-center gap-2">
-            {gainedEntries.map(([stat, value]) => (
-              <div key={stat} className="flex items-center gap-2">
-                <span>{STAT_ICONS[stat]}</span>
-                <span className="text-sm">{STAT_DISPLAY_NAMES[stat]}</span>
-                <span className="text-sm font-semibold text-green-600 dark:text-green-400">
-                  +{value}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
+      {trainingResult.statsGained &&
+      Object.values(trainingResult.statsGained).some((v) => v && v > 0) ? (
+        <StatsGainedDisplay statsGained={trainingResult.statsGained} />
       ) : (
         <div className="bg-secondary/50 rounded-lg p-3 text-center">
           <p className="text-sm text-muted-foreground">

--- a/src/components/game/TrainingCompleteNotification.tsx
+++ b/src/components/game/TrainingCompleteNotification.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { StatsGainedDisplay } from "@/components/ui/StatsGainedDisplay";
 import type { BattleStats } from "@/game/types/stats";
 import { cn } from "@/lib/utils";
 
@@ -20,30 +21,6 @@ interface TrainingCompleteNotificationProps {
   petName: string;
   onDismiss: () => void;
 }
-
-/**
- * Stat display names.
- */
-const STAT_DISPLAY_NAMES: Record<keyof BattleStats, string> = {
-  strength: "Strength",
-  endurance: "Endurance",
-  agility: "Agility",
-  precision: "Precision",
-  fortitude: "Fortitude",
-  cunning: "Cunning",
-};
-
-/**
- * Stat icons.
- */
-const STAT_ICONS: Record<keyof BattleStats, string> = {
-  strength: "💪",
-  endurance: "❤️",
-  agility: "⚡",
-  precision: "🎯",
-  fortitude: "🛡️",
-  cunning: "🧠",
-};
 
 /**
  * Display a notification when training completes.
@@ -61,10 +38,6 @@ export function TrainingCompleteNotification({
     const timer = setTimeout(() => setIsAnimating(false), 500);
     return () => clearTimeout(timer);
   }, []);
-
-  const gainedEntries = Object.entries(statsGained).filter(
-    ([_, value]) => value && value > 0,
-  ) as [keyof BattleStats, number][];
 
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
@@ -86,22 +59,7 @@ export function TrainingCompleteNotification({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="bg-secondary/50 rounded-lg p-4">
-            <h4 className="text-sm font-medium text-center mb-2">
-              Stats Gained
-            </h4>
-            <div className="flex flex-col items-center gap-2">
-              {gainedEntries.map(([stat, value]) => (
-                <div key={stat} className="flex items-center gap-2">
-                  <span>{STAT_ICONS[stat]}</span>
-                  <span className="text-sm">{STAT_DISPLAY_NAMES[stat]}</span>
-                  <span className="text-sm font-semibold text-green-600 dark:text-green-400">
-                    +{value}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
+          <StatsGainedDisplay statsGained={statsGained} />
           <Button onClick={onDismiss} className="w-full">
             Continue
           </Button>

--- a/src/components/ui/StatsGainedDisplay.tsx
+++ b/src/components/ui/StatsGainedDisplay.tsx
@@ -1,0 +1,51 @@
+/**
+ * Shared component for displaying gained battle stats.
+ */
+
+import {
+  extractStatGains,
+  STAT_DISPLAY_NAMES,
+  STAT_ICONS,
+} from "@/game/data/stats";
+import type { BattleStats } from "@/game/types/stats";
+
+interface StatsGainedDisplayProps {
+  /** Stats gained to display */
+  statsGained: Partial<BattleStats> | undefined;
+  /** Optional title to show above the stats */
+  title?: string;
+}
+
+/**
+ * Display a list of gained stats with icons and values.
+ * Used by training completion notifications and offline reports.
+ */
+export function StatsGainedDisplay({
+  statsGained,
+  title = "Stats Gained",
+}: StatsGainedDisplayProps) {
+  const gainedEntries = extractStatGains(statsGained);
+
+  if (gainedEntries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-secondary/50 rounded-lg p-3">
+      <p className="text-xs font-medium text-muted-foreground mb-2 text-center">
+        {title}
+      </p>
+      <div className="flex flex-col items-center gap-2">
+        {gainedEntries.map(([stat, value]) => (
+          <div key={stat} className="flex items-center gap-2">
+            <span>{STAT_ICONS[stat]}</span>
+            <span className="text-sm">{STAT_DISPLAY_NAMES[stat]}</span>
+            <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+              +{value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -11,6 +11,8 @@ import { updateQuestProgress } from "@/game/core/quests/quests";
 import { resetDailySleep } from "@/game/core/sleep";
 import { processPetTick } from "@/game/core/tick";
 import { getMidnightTimestamp, shouldDailyReset } from "@/game/core/time";
+import { completeTraining } from "@/game/core/training";
+import { getFacility } from "@/game/data/facilities";
 import { getLocation } from "@/game/data/locations";
 import { applyExplorationResults } from "@/game/state/actions/exploration";
 import type { Tick } from "@/game/types/common";
@@ -22,6 +24,7 @@ import type {
   MaxStatsSnapshot,
   OfflineExplorationResult,
   OfflineReport,
+  OfflineTrainingResult,
 } from "@/game/types/offline";
 import { ObjectiveType } from "@/game/types/quest";
 import { SkillType } from "@/game/types/skill";
@@ -77,6 +80,17 @@ export function processGameTick(
     workingState.pet.activityState === ActivityState.Training &&
     workingState.pet.activeTraining !== undefined;
 
+  // Capture training result BEFORE processing tick (since processPetTick clears the training state)
+  // Training completes when ticksRemaining === 1 (will be decremented to 0)
+  const trainingWillComplete =
+    wasTraining && workingState.pet.activeTraining?.ticksRemaining === 1;
+  const trainingResultBeforeCompletion = trainingWillComplete
+    ? completeTraining(workingState.pet)
+    : null;
+  const facilityId = trainingWillComplete
+    ? workingState.pet.activeTraining?.facilityId
+    : null;
+
   // Process pet tick (handles training, care, growth, etc.)
   const updatedPet = processPetTick(workingState.pet);
 
@@ -93,6 +107,8 @@ export function processGameTick(
     lastSaveTime: currentTime,
     // Clear any previous exploration result
     lastExplorationResult: undefined,
+    // Clear any previous training result
+    lastTrainingResult: undefined,
   };
 
   // Process exploration at game state level (needs access to inventory)
@@ -160,6 +176,15 @@ export function processGameTick(
       ObjectiveType.Train,
       "any",
     );
+
+    // Store the training result for UI notification
+    if (trainingResultBeforeCompletion && facilityId) {
+      const facility = getFacility(facilityId);
+      updatedState.lastTrainingResult = {
+        ...trainingResultBeforeCompletion,
+        facilityName: facility?.name ?? "Unknown Facility",
+      };
+    }
   }
 
   return updatedState;
@@ -245,7 +270,7 @@ function createMaxStatsSnapshot(state: GameState): MaxStatsSnapshot | null {
 
 /**
  * Process offline catch-up ticks.
- * Collects exploration results that complete during offline time.
+ * Collects exploration and training results that complete during offline time.
  */
 export function processOfflineCatchup(
   state: GameState,
@@ -264,8 +289,9 @@ export function processOfflineCatchup(
   const poopBefore = state.pet?.poop.count ?? 0;
   const petName = state.pet?.identity.name ?? null;
 
-  // Process ticks and collect exploration results using the shared tick processor
+  // Process ticks and collect exploration/training results using the shared tick processor
   const explorationResults: OfflineExplorationResult[] = [];
+  const trainingResults: OfflineTrainingResult[] = [];
   const currentState = processMultipleTicks(
     state,
     cappedTicks,
@@ -277,6 +303,17 @@ export function processOfflineCatchup(
           locationName: tickState.lastExplorationResult.locationName,
           itemsFound: tickState.lastExplorationResult.itemsFound,
           message: tickState.lastExplorationResult.message,
+        });
+      }
+      // Collect training result if one was generated this tick
+      if (tickState.lastTrainingResult) {
+        trainingResults.push({
+          facilityName: tickState.lastTrainingResult.facilityName,
+          result: {
+            success: tickState.lastTrainingResult.success,
+            message: tickState.lastTrainingResult.message,
+            statsGained: tickState.lastTrainingResult.statsGained,
+          },
         });
       }
     },
@@ -296,6 +333,7 @@ export function processOfflineCatchup(
     poopBefore,
     poopAfter,
     explorationResults,
+    trainingResults,
   };
 
   return {

--- a/src/game/data/stats.ts
+++ b/src/game/data/stats.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared constants and utilities for displaying battle stats.
+ */
+
+import type { BattleStats } from "@/game/types/stats";
+
+/**
+ * Display names for battle stats.
+ */
+export const STAT_DISPLAY_NAMES: Record<keyof BattleStats, string> = {
+  strength: "Strength",
+  endurance: "Endurance",
+  agility: "Agility",
+  precision: "Precision",
+  fortitude: "Fortitude",
+  cunning: "Cunning",
+};
+
+/**
+ * Emoji icons for battle stats.
+ */
+export const STAT_ICONS: Record<keyof BattleStats, string> = {
+  strength: "💪",
+  endurance: "❤️",
+  agility: "⚡",
+  precision: "🎯",
+  fortitude: "🛡️",
+  cunning: "🧠",
+};
+
+/**
+ * Type guard to check if a stat key is a valid BattleStats key.
+ */
+export function isBattleStat(key: string): key is keyof BattleStats {
+  return key in STAT_DISPLAY_NAMES;
+}
+
+/**
+ * Extract non-zero stat gains from a partial BattleStats object.
+ * Returns an array of [stat, value] tuples with proper typing.
+ */
+export function extractStatGains(
+  statsGained: Partial<BattleStats> | undefined,
+): Array<[keyof BattleStats, number]> {
+  if (!statsGained) return [];
+
+  return Object.entries(statsGained).filter(
+    (entry): entry is [keyof BattleStats, number] => {
+      const [key, value] = entry;
+      return isBattleStat(key) && typeof value === "number" && value > 0;
+    },
+  );
+}

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -2,7 +2,7 @@
  * Game state types for overall game and player state.
  */
 
-import type { ExplorationResult } from "./activity";
+import type { ExplorationResult, TrainingResult } from "./activity";
 import type { Tick, Timestamp } from "./common";
 import type { Pet } from "./pet";
 import type { QuestProgress } from "./quest";
@@ -82,6 +82,8 @@ export interface GameState {
   isInitialized: boolean;
   /** Last exploration result (for UI notification, cleared after display) */
   lastExplorationResult?: ExplorationResult & { locationName: string };
+  /** Last training result (for UI notification, cleared after display) */
+  lastTrainingResult?: TrainingResult & { facilityName: string };
   /**
    * Active battle (if in combat).
    * Reserved for future use: currently, battle state is managed locally in BattleScreen.

--- a/src/game/types/offline.ts
+++ b/src/game/types/offline.ts
@@ -2,7 +2,7 @@
  * Types for offline progression reporting.
  */
 
-import type { ExplorationDrop } from "./activity";
+import type { ExplorationDrop, TrainingResult } from "./activity";
 import type { MicroValue, Tick } from "./common";
 
 /**
@@ -25,6 +25,16 @@ export interface OfflineExplorationResult {
   itemsFound: ExplorationDrop[];
   /** Message describing the result */
   message: string;
+}
+
+/**
+ * Result of a training session that completed during offline time.
+ */
+export interface OfflineTrainingResult {
+  /** Facility name where training occurred */
+  facilityName: string;
+  /** Training result details */
+  result: TrainingResult;
 }
 
 /**
@@ -64,6 +74,8 @@ export interface OfflineReport {
   poopAfter: number;
   /** Exploration results that completed during offline time */
   explorationResults: OfflineExplorationResult[];
+  /** Training results that completed during offline time */
+  trainingResults: OfflineTrainingResult[];
 }
 
 /**


### PR DESCRIPTION
- Add OfflineTrainingResult type to offline.ts
- Add trainingResults array to OfflineReport type
- Add lastTrainingResult to GameState for capturing training completions
- Update processGameTick to store training result when training completes
- Update processOfflineCatchup to collect training results
- Add TrainingResultCard component to OfflineReport.tsx
- Update offline report navigation to include training pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training results now display in offline reports as a dedicated section
  * Updated report navigation to include training outcomes with facility details
  * Enhanced offline catch-up to capture and display training completion data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->