### PR TITLE
feat: expand game world with new areas, NPCs, and quests

### DIFF
--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -62,6 +62,10 @@ function shopNode(id: string, text: string): DialogueNode {
   };
 }
 
+// ========================================
+// WILLOWBROOK DIALOGUES
+// ========================================
+
 /**
  * Mira's dialogue tree.
  */
@@ -164,12 +168,602 @@ export const oakDialogue: DialogueTree = {
   },
 };
 
+// ========================================
+// IRONHAVEN DIALOGUES
+// ========================================
+
+/**
+ * Grom's dialogue tree.
+ */
+export const gromDialogue: DialogueTree = {
+  id: "grom_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*The forge crackles behind him* Ah, a traveler! Name's Grom. I forge the finest equipment in these mountains. What brings you to my smithy?",
+      [
+        { text: "I'd like to see your wares.", nextNodeId: "shop" },
+        { text: "Tell me about Ironhaven.", nextNodeId: "about_town" },
+        { text: "I need ore for crafting.", nextNodeId: "about_ore" },
+        { text: "Just looking around.", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "Take a look at what I've got. Everything's made right here in my forge!",
+    ),
+    about_town: messageNode(
+      "about_town",
+      "Ironhaven was built by miners centuries ago. The mountains are rich with ore and crystals, but they're also dangerous. Many tunnels lead deep underground...",
+      "about_town_2",
+    ),
+    about_town_2: messageNode(
+      "about_town_2",
+      "The Crystal Caves to the south are popular with adventurers, and beyond the peaks lies the Frozen Wastes. Not many return from there.",
+      "greeting",
+    ),
+    about_ore: messageNode(
+      "about_ore",
+      "Iron ore can be found in the highlands and caves. If you're looking for rarer materials, you'll need to venture deeper. The Shadow Depths hold the most precious finds.",
+      "about_ore_2",
+    ),
+    about_ore_2: endNode(
+      "about_ore_2",
+      "Bring me quality ore, and I'll pay a fair price. Or we can work together to forge something special.",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*returns to hammering* Safe travels, and watch out for cave-ins!",
+    ),
+  },
+};
+
+/**
+ * Delva's dialogue tree.
+ */
+export const delvaDialogue: DialogueTree = {
+  id: "delva_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*adjusts her mining helmet* Well met, adventurer! I've been mining these tunnels for thirty years. Looking for some guidance underground?",
+      [
+        { text: "Tell me about mining.", nextNodeId: "mining_tips" },
+        { text: "What dangers should I watch for?", nextNodeId: "dangers" },
+        { text: "I'm looking for rare crystals.", nextNodeId: "crystals" },
+        { text: "I should keep moving.", nextNodeId: "farewell" },
+      ],
+    ),
+    mining_tips: messageNode(
+      "mining_tips",
+      "Mining's not just about swinging a pickaxe. You need to read the rock - look for color variations, listen for hollow sounds, and always check your surroundings.",
+      "mining_tips_2",
+    ),
+    mining_tips_2: endNode(
+      "mining_tips_2",
+      "The deeper you go, the better the ore, but also the more dangerous. Start with the Highlands, then work your way to the caves.",
+    ),
+    dangers: messageNode(
+      "dangers",
+      "Underground, you'll face cave-ins, toxic fumes, and creatures that live in the dark. Some say there are things in the Shadow Depths that haven't seen light in centuries.",
+      "dangers_2",
+    ),
+    dangers_2: endNode(
+      "dangers_2",
+      "Keep your pet close and your energy high. Many have entered those depths unprepared and never returned.",
+    ),
+    crystals: messageNode(
+      "crystals",
+      "Crystals, eh? The purest ones form deep in the caves where pressure is highest. I've seen some that glow with their own inner light!",
+      "crystals_2",
+    ),
+    crystals_2: endNode(
+      "crystals_2",
+      "Check the Crystal Caves first. If you need truly rare specimens, you'll have to brave the Shadow Depths. Good luck!",
+    ),
+    farewell: endNode(
+      "farewell",
+      "May your pickaxe stay sharp and your lantern stay lit!",
+    ),
+  },
+};
+
+// ========================================
+// TIDECREST DIALOGUES
+// ========================================
+
+/**
+ * Marina's dialogue tree.
+ */
+export const marinaDialogue: DialogueTree = {
+  id: "marina_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*mending a fishing net* Ahoy there! Welcome to Tidecrest. I'm Marina - been fishing these waters since before I could walk. What can I do for you?",
+      [
+        { text: "Show me your fishing supplies.", nextNodeId: "shop" },
+        { text: "Any fishing tips?", nextNodeId: "fishing_tips" },
+        { text: "Tell me about the local waters.", nextNodeId: "about_waters" },
+        { text: "See you around.", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "Got everything you need for a good day's fishing. Fresh bait too!",
+    ),
+    fishing_tips: messageNode(
+      "fishing_tips",
+      "Fishing is all about patience and knowing your quarry. Different fish prefer different depths and times of day. The rare ones... they need special lures.",
+      "fishing_tips_2",
+    ),
+    fishing_tips_2: endNode(
+      "fishing_tips_2",
+      "Start at the coast, then try the reef. If you're feeling brave, the waters around the Sunken Temple hold legendary catches!",
+    ),
+    about_waters: messageNode(
+      "about_waters",
+      "The Whispering Coast is calm and good for beginners. Beyond it lies the Coral Reef - beautiful but with stronger currents and fiercer fish.",
+      "about_waters_2",
+    ),
+    about_waters_2: messageNode(
+      "about_waters_2",
+      "And then there's the Sunken Temple... ancient ruins beneath the waves. Captain Torrent knows more about that place than anyone.",
+      "greeting",
+    ),
+    farewell: endNode(
+      "farewell",
+      "May the tides be in your favor! Come back if you catch anything interesting.",
+    ),
+  },
+};
+
+/**
+ * Captain Torrent's dialogue tree.
+ */
+export const torrentDialogue: DialogueTree = {
+  id: "torrent_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*takes a long puff from his pipe* Another curious soul, eh? I'm Captain Torrent. I've sailed every sea and seen things that would make your hair stand on end.",
+      [
+        { text: "Tell me about your adventures.", nextNodeId: "adventures" },
+        { text: "What's the Sunken Temple?", nextNodeId: "temple" },
+        {
+          text: "Any treasures waiting to be found?",
+          nextNodeId: "treasures",
+        },
+        { text: "I should go.", nextNodeId: "farewell" },
+      ],
+    ),
+    adventures: messageNode(
+      "adventures",
+      "Ha! Where to begin? I've weathered hurricanes, outrun pirates, and once... once I saw something rise from the deep that shouldn't exist.",
+      "adventures_2",
+    ),
+    adventures_2: messageNode(
+      "adventures_2",
+      "*his eyes grow distant* That was near the Sunken Temple. The creature that guards that place... it's older than the sea itself.",
+      "greeting",
+    ),
+    temple: messageNode(
+      "temple",
+      "The Sunken Temple was once above the waves, belonging to an ancient civilization. When their city fell, the temple sank with it. Strange glyphs still glow on its walls.",
+      "temple_2",
+    ),
+    temple_2: messageNode(
+      "temple_2",
+      "Some say it holds artifacts of incredible power. Others say it's cursed. *leans in* I say both are true.",
+      "greeting",
+    ),
+    treasures: messageNode(
+      "treasures",
+      "*chuckles* Aye, there's treasure aplenty beneath the waves. Pearls, ancient coins, and things more valuable than gold.",
+      "treasures_2",
+    ),
+    treasures_2: endNode(
+      "treasures_2",
+      "But treasure is guarded, always. The Coral Reef has minor baubles. The real prizes? They're in the Temple. If you're brave enough.",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*waves his pipe* Fair winds to you, adventurer. And remember - the sea takes what it wants, but rewards those who respect it.",
+    ),
+  },
+};
+
+// ========================================
+// STARFALL SANCTUARY DIALOGUES
+// ========================================
+
+/**
+ * Sage Lumina's dialogue tree.
+ */
+export const luminaDialogue: DialogueTree = {
+  id: "lumina_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*her form shimmers with starlight* Welcome, traveler. I am Lumina. You have journeyed far to reach this place. What wisdom do you seek?",
+      [
+        {
+          text: "Tell me about this sanctuary.",
+          nextNodeId: "about_sanctuary",
+        },
+        { text: "What can I learn here?", nextNodeId: "training" },
+        { text: "What lies in the Celestial Spire?", nextNodeId: "spire" },
+        { text: "I'm not ready. I should go.", nextNodeId: "farewell" },
+      ],
+    ),
+    about_sanctuary: messageNode(
+      "about_sanctuary",
+      "Starfall Sanctuary has existed since the first stars fell to earth. It is a place of learning, of understanding the bond between pet and trainer.",
+      "about_sanctuary_2",
+    ),
+    about_sanctuary_2: messageNode(
+      "about_sanctuary_2",
+      "Only those who have proven themselves worthy may enter. You have survived the Shadow Depths and earned your place here.",
+      "greeting",
+    ),
+    training: messageNode(
+      "training",
+      "Here, we teach the deepest secrets of pet evolution and the cosmic energies that flow through all living things.",
+      "training_2",
+    ),
+    training_2: endNode(
+      "training_2",
+      "Master these teachings, and your pet will transcend ordinary limits. But the path is long and demanding.",
+    ),
+    spire: messageNode(
+      "spire",
+      "The Celestial Spire is the ultimate test. A tower that reaches into the realm of stars, where only the most powerful may climb.",
+      "spire_2",
+    ),
+    spire_2: messageNode(
+      "spire_2",
+      "At its peak awaits... something. An entity of pure cosmic energy. Few have reached it. Fewer still have returned.",
+      "greeting",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*bows gracefully* The stars will guide your path. Return when you are ready to learn.",
+    ),
+  },
+};
+
+/**
+ * Archivist Echo's dialogue tree.
+ */
+export const echoDialogue: DialogueTree = {
+  id: "echo_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*a whispered voice from the shadows* Knowledge has weight. Truth has cost. What do you seek in these archives, traveler?",
+      [
+        { text: "I want to see your collection.", nextNodeId: "shop" },
+        { text: "What knowledge do you keep?", nextNodeId: "knowledge" },
+        { text: "Tell me about ancient pets.", nextNodeId: "ancient_pets" },
+        { text: "I'll come back another time.", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "Browse carefully. Some of these texts are... temperamental. They choose their readers.",
+    ),
+    knowledge: messageNode(
+      "knowledge",
+      "Everything ever known about pets rests in these halls. Their origins, their potential, their connection to the stars themselves.",
+      "knowledge_2",
+    ),
+    knowledge_2: endNode(
+      "knowledge_2",
+      "I preserve what others would forget. The dangerous knowledge. The forbidden techniques. All of it waits here for those worthy enough to learn.",
+    ),
+    ancient_pets: messageNode(
+      "ancient_pets",
+      "In ages past, pets were different. More powerful. More... aware. The ones we know today are but echoes of what once existed.",
+      "ancient_pets_2",
+    ),
+    ancient_pets_2: messageNode(
+      "ancient_pets_2",
+      "Some believe the original species still exist, hidden in places where time has no meaning. The Celestial Spire, perhaps, or beyond...",
+      "greeting",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*fades slightly into shadow* Knowledge waits patiently. Return when curiosity drives you back.",
+    ),
+  },
+};
+
+// ========================================
+// WANDERING NPC DIALOGUES
+// ========================================
+
+/**
+ * Fern's dialogue tree.
+ */
+export const fernDialogue: DialogueTree = {
+  id: "fern_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*gently places herbs in a basket* Oh! A fellow traveler in the grove. I'm Fern. I gather medicinal plants to help injured pets. Can I help you?",
+      [
+        { text: "Show me your remedies.", nextNodeId: "shop" },
+        { text: "Tell me about healing herbs.", nextNodeId: "herbs" },
+        { text: "What grows in this grove?", nextNodeId: "grove" },
+        { text: "I'll let you work. Goodbye.", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "I've prepared some remedies from my recent foraging. Take what you need!",
+    ),
+    herbs: messageNode(
+      "herbs",
+      "Every plant has healing properties if you know how to use them. Moonpetal soothes burns, Starbloom restores energy, and Shadowroot... well, that's for special cases.",
+      "herbs_2",
+    ),
+    herbs_2: endNode(
+      "herbs_2",
+      "The rarest herbs grow in the strangest places. The Mushroom Hollow has some unique specimens you won't find anywhere else!",
+    ),
+    grove: messageNode(
+      "grove",
+      "The Ancient Grove is sacred. The trees here are older than any record. They've seen civilizations rise and fall.",
+      "grove_2",
+    ),
+    grove_2: endNode(
+      "grove_2",
+      "Forage gently and take only what you need. The grove provides for those who respect it.",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*returns to gathering* May nature's blessing follow you on your journey!",
+    ),
+  },
+};
+
+/**
+ * Blaze's dialogue tree.
+ */
+export const blazeDialogue: DialogueTree = {
+  id: "blaze_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*wipes sweat from brow* Welcome to the highlands, trainer! I'm Blaze. I train pets to withstand extreme heat. Think your pet can handle it?",
+      [
+        { text: "Tell me about heat training.", nextNodeId: "training" },
+        { text: "What lives in the volcano?", nextNodeId: "volcano" },
+        { text: "Is the caldera safe to explore?", nextNodeId: "caldera" },
+        { text: "Not today. See you.", nextNodeId: "farewell" },
+      ],
+    ),
+    training: messageNode(
+      "training",
+      "Heat training builds thermal resistance and raw power. Start slow - even the strongest pet can be overwhelmed by volcanic temperatures.",
+      "training_2",
+    ),
+    training_2: endNode(
+      "training_2",
+      "Master fire, and few enemies will stand against you. But respect it - fire is both a tool and a danger.",
+    ),
+    volcano: messageNode(
+      "volcano",
+      "Emberfox are the most common. Fierce, fast, and hot to the touch. But deeper in, there are things that have never known cold...",
+      "volcano_2",
+    ),
+    volcano_2: endNode(
+      "volcano_2",
+      "The Volcanic Caldera is their domain. Only enter if you're truly prepared.",
+    ),
+    caldera: messageNode(
+      "caldera",
+      "*laughs* Safe? Nothing about the caldera is safe. The ground shifts, lava pools appear without warning, and the creatures there are brutal.",
+      "caldera_2",
+    ),
+    caldera_2: endNode(
+      "caldera_2",
+      "But if you want the rarest volcanic materials and the strongest fire training, it's the only place. Risk and reward, my friend.",
+    ),
+    farewell: endNode(
+      "farewell",
+      "Stay cool out there... or don't! Ha! *returns to training*",
+    ),
+  },
+};
+
+/**
+ * Dr. Frost's dialogue tree.
+ */
+export const frostDialogue: DialogueTree = {
+  id: "frost_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*adjusts thick goggles* Fascinating! Another specimen- I mean, visitor! I'm Dr. Frost. I study cold adaptation in creatures. What brings you to the peaks?",
+      [
+        { text: "What are you researching?", nextNodeId: "research" },
+        { text: "How do creatures survive here?", nextNodeId: "survival" },
+        {
+          text: "What's in the Glacial Cavern?",
+          nextNodeId: "cavern",
+        },
+        { text: "I need to warm up. Goodbye.", nextNodeId: "farewell" },
+      ],
+    ),
+    research: messageNode(
+      "research",
+      "I'm documenting how creatures develop cold resistance! Some produce antifreeze compounds, others generate internal heat, and a few simply... embrace the cold entirely.",
+      "research_2",
+    ),
+    research_2: endNode(
+      "research_2",
+      "My research could help trainers prepare their pets for any environment. If you find any unusual ice samples, please bring them to me!",
+    ),
+    survival: messageNode(
+      "survival",
+      "The creatures here have adapted over millennia. Their fur is denser, their metabolisms slower, and they've developed unique hunting strategies.",
+      "survival_2",
+    ),
+    survival_2: endNode(
+      "survival_2",
+      "Your pet will need protection from the cold. Energy drains faster here, and some attacks can freeze a pet solid if they're not resistant!",
+    ),
+    cavern: messageNode(
+      "cavern",
+      "The Glacial Cavern is a natural wonder - ice formations older than recorded history! But it's also home to creatures that have evolved in total isolation.",
+      "cavern_2",
+    ),
+    cavern_2: endNode(
+      "cavern_2",
+      "They're unlike anything you've encountered. Be prepared for surprises, and bring plenty of warming supplies!",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*scribbles in notebook* Yes, yes, stay warm! Science waits for no one - including me!",
+    ),
+  },
+};
+
+/**
+ * Coral's dialogue tree.
+ */
+export const coralDialogue: DialogueTree = {
+  id: "coral_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*adjusts diving mask* Oh, surface-dweller! I'm Coral. I've mapped every inch of this reef. Planning to explore the depths?",
+      [
+        { text: "Tell me about the reef.", nextNodeId: "reef" },
+        { text: "What should I know about diving?", nextNodeId: "diving" },
+        { text: "Have you been to the Sunken Temple?", nextNodeId: "temple" },
+        { text: "Maybe later. See you.", nextNodeId: "farewell" },
+      ],
+    ),
+    reef: messageNode(
+      "reef",
+      "The Coral Reef is alive with color and danger! Beautiful fish, precious materials, and creatures that protect their territory fiercely.",
+      "reef_2",
+    ),
+    reef_2: endNode(
+      "reef_2",
+      "The currents can be tricky, and some of the larger predators are no joke. But for the prepared explorer, it's a treasure trove!",
+    ),
+    diving: messageNode(
+      "diving",
+      "Underwater exploration requires endurance. Your pet needs to handle the pressure and the cold. Energy depletes faster, and there's no quick escape.",
+      "diving_2",
+    ),
+    diving_2: endNode(
+      "diving_2",
+      "Start shallow, practice your navigation, and always know your way back. The depths can be disorienting.",
+    ),
+    temple: messageNode(
+      "temple",
+      "*her eyes light up* The Sunken Temple! I've been to the outer chambers. Ancient architecture, glowing symbols, guardian creatures...",
+      "temple_2",
+    ),
+    temple_2: messageNode(
+      "temple_2",
+      "But the inner sanctum remains unexplored. Something prevents entry - a puzzle, a guardian, or perhaps something worse.",
+      "greeting",
+    ),
+    farewell: endNode(
+      "farewell",
+      "Happy exploring! The reef has many secrets - come find me if you uncover something interesting!",
+    ),
+  },
+};
+
+/**
+ * Gloom's dialogue tree.
+ */
+export const gloomDialogue: DialogueTree = {
+  id: "gloom_dialogue",
+  startNodeId: "greeting",
+  nodes: {
+    greeting: choiceNode(
+      "greeting",
+      "*materializes from shadows* You... have ventured deep. I am Gloom. I have answers you seek... for a price.",
+      [
+        { text: "What do you sell?", nextNodeId: "shop" },
+        { text: "What are you?", nextNodeId: "identity" },
+        { text: "What secrets lie deeper?", nextNodeId: "secrets" },
+        { text: "I'll stay in the light.", nextNodeId: "farewell" },
+      ],
+    ),
+    shop: shopNode(
+      "shop",
+      "Items that cannot be found in sunlight. Essences, shadow materials, and... other things. Browse carefully.",
+    ),
+    identity: messageNode(
+      "identity",
+      "*shifts and flickers* I was like you once. A trainer who ventured too deep. The shadows embraced me, and I embraced them back.",
+      "identity_2",
+    ),
+    identity_2: endNode(
+      "identity_2",
+      "Do not pity me. In darkness, I have found power. And knowledge that the light-dwellers fear to understand.",
+    ),
+    secrets: messageNode(
+      "secrets",
+      "Beyond these depths... there are places where reality bends. Where creatures exist that predate the world itself.",
+      "secrets_2",
+    ),
+    secrets_2: messageNode(
+      "secrets_2",
+      "The Celestial Spire above and the endless depths below are mirrors of each other. Light and dark, creation and void.",
+      "secrets_3",
+    ),
+    secrets_3: endNode(
+      "secrets_3",
+      "Master both, and you might understand what pets truly are. But that knowledge comes at a cost few are willing to pay.",
+    ),
+    farewell: endNode(
+      "farewell",
+      "*fades back into darkness* The shadows will wait. They always do. Return when you are ready to see.",
+    ),
+  },
+};
+
 /**
  * All dialogue trees indexed by ID.
  */
 export const dialogues: Record<string, DialogueTree> = {
+  // Willowbrook
   [miraDialogue.id]: miraDialogue,
   [oakDialogue.id]: oakDialogue,
+  // Ironhaven
+  [gromDialogue.id]: gromDialogue,
+  [delvaDialogue.id]: delvaDialogue,
+  // Tidecrest
+  [marinaDialogue.id]: marinaDialogue,
+  [torrentDialogue.id]: torrentDialogue,
+  // Starfall Sanctuary
+  [luminaDialogue.id]: luminaDialogue,
+  [echoDialogue.id]: echoDialogue,
+  // Wandering NPCs
+  [fernDialogue.id]: fernDialogue,
+  [blazeDialogue.id]: blazeDialogue,
+  [frostDialogue.id]: frostDialogue,
+  [coralDialogue.id]: coralDialogue,
+  [gloomDialogue.id]: gloomDialogue,
 };
 
 /**

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -200,7 +200,7 @@ export const gromDialogue: DialogueTree = {
     ),
     about_town_2: messageNode(
       "about_town_2",
-      "The Crystal Caves to the south are popular with adventurers, and beyond the peaks lies the Frozen Peaks. Not many return from there.",
+      "The Crystal Caves to the south are popular with adventurers, and to the north lie the Frozen Peaks. Not many return from there.",
       "greeting",
     ),
     about_ore: messageNode(

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -200,7 +200,7 @@ export const gromDialogue: DialogueTree = {
     ),
     about_town_2: messageNode(
       "about_town_2",
-      "The Crystal Caves to the south are popular with adventurers, and beyond the peaks lies the Frozen Wastes. Not many return from there.",
+      "The Crystal Caves to the south are popular with adventurers, and beyond the peaks lies the Frozen Peaks. Not many return from there.",
       "greeting",
     ),
     about_ore: messageNode(

--- a/src/game/data/locations/towns.ts
+++ b/src/game/data/locations/towns.ts
@@ -2,6 +2,7 @@
  * Town location data.
  */
 
+import { GrowthStage } from "@/game/types/constants";
 import {
   FacilityType,
   type Location,
@@ -22,6 +23,7 @@ export const willowbrookTown: Location = {
     { targetId: "home", energyCost: 10 },
     { targetId: "meadow", energyCost: 5 },
     { targetId: "misty_woods", energyCost: 15 },
+    { targetId: "whispering_coast", energyCost: 12 },
   ],
   facilities: [
     FacilityType.Shop,
@@ -34,6 +36,92 @@ export const willowbrookTown: Location = {
 };
 
 /**
+ * Ironhaven - a mining town near the mountains.
+ * Specializes in mining equipment and ore trading.
+ */
+export const ironhavenTown: Location = {
+  id: "ironhaven",
+  name: "Ironhaven",
+  description:
+    "A rugged mining town built into the mountainside. The sound of pickaxes echoes through the streets, and the smell of forge fires fills the air.",
+  type: LocationType.Town,
+  connections: [
+    { targetId: "scorched_highlands", energyCost: 15, terrainModifier: 1.2 },
+    { targetId: "crystal_caves", energyCost: 12 },
+    { targetId: "frozen_peaks", energyCost: 20, terrainModifier: 1.4 },
+  ],
+  requirements: {
+    stage: GrowthStage.Child,
+  },
+  facilities: [
+    FacilityType.Shop,
+    FacilityType.Trainer,
+    FacilityType.Inn,
+    FacilityType.QuestBoard,
+  ],
+  npcIds: ["blacksmith_grom", "miner_delva"],
+  emoji: "⚒️",
+};
+
+/**
+ * Tidecrest - a coastal fishing village.
+ * Known for seafood and aquatic supplies.
+ */
+export const tidecrestTown: Location = {
+  id: "tidecrest",
+  name: "Tidecrest",
+  description:
+    "A quaint fishing village perched on the cliffs overlooking the sea. Fresh catch is sold daily at the harbor market.",
+  type: LocationType.Town,
+  connections: [
+    { targetId: "whispering_coast", energyCost: 8 },
+    { targetId: "coral_reef", energyCost: 15, terrainModifier: 1.3 },
+    { targetId: "sunken_temple", energyCost: 25, terrainModifier: 1.5 },
+  ],
+  facilities: [
+    FacilityType.Shop,
+    FacilityType.Trainer,
+    FacilityType.Inn,
+    FacilityType.QuestBoard,
+  ],
+  npcIds: ["fisher_marina", "captain_torrent"],
+  emoji: "⚓",
+};
+
+/**
+ * Starfall Sanctuary - a mystical enclave.
+ * End-game town with rare goods and advanced training.
+ */
+export const starfallSanctuary: Location = {
+  id: "starfall_sanctuary",
+  name: "Starfall Sanctuary",
+  description:
+    "An ancient sanctuary hidden among the stars. Only the most accomplished pet trainers find their way here, drawn by whispers of forgotten knowledge.",
+  type: LocationType.Town,
+  connections: [
+    { targetId: "shadow_depths", energyCost: 25, terrainModifier: 1.5 },
+    { targetId: "frozen_peaks", energyCost: 30, terrainModifier: 1.6 },
+    { targetId: "celestial_spire", energyCost: 35, terrainModifier: 1.8 },
+  ],
+  requirements: {
+    stage: GrowthStage.YoungAdult,
+  },
+  facilities: [
+    FacilityType.Shop,
+    FacilityType.Trainer,
+    FacilityType.Inn,
+    FacilityType.QuestBoard,
+  ],
+  npcIds: ["sage_lumina", "archivist_echo"],
+  emoji: "✨",
+};
+
+/**
  * All town locations.
  */
-export const townLocations: Location[] = [willowbrookTown];
+export const townLocations: Location[] = [
+  willowbrookTown,
+  ironhavenTown,
+  tidecrestTown,
+  starfallSanctuary,
+];

--- a/src/game/data/locations/wild.ts
+++ b/src/game/data/locations/wild.ts
@@ -24,6 +24,7 @@ export const sunnyMeadow: Location = {
     { targetId: "willowbrook", energyCost: 5 },
     { targetId: "misty_woods", energyCost: 10, terrainModifier: 1.2 },
     { targetId: "whispering_coast", energyCost: 15, terrainModifier: 1.3 },
+    { targetId: "ancient_grove", energyCost: 12, terrainModifier: 1.1 },
   ],
   levelMin: 1,
   levelMax: 5,
@@ -52,6 +53,8 @@ export const mistyWoods: Location = {
     { targetId: "willowbrook", energyCost: 15 },
     { targetId: "crystal_caves", energyCost: 20, terrainModifier: 1.5 },
     { targetId: "scorched_highlands", energyCost: 25, terrainModifier: 1.4 },
+    { targetId: "ancient_grove", energyCost: 15, terrainModifier: 1.2 },
+    { targetId: "mushroom_hollow", energyCost: 12, terrainModifier: 1.1 },
   ],
   levelMin: 5,
   levelMax: 15,
@@ -81,6 +84,8 @@ export const whisperingCoast: Location = {
   connections: [
     { targetId: "willowbrook", energyCost: 12 },
     { targetId: "meadow", energyCost: 15, terrainModifier: 1.3 },
+    { targetId: "tidecrest", energyCost: 8 },
+    { targetId: "coral_reef", energyCost: 18, terrainModifier: 1.4 },
   ],
   levelMin: 3,
   levelMax: 10,
@@ -107,6 +112,8 @@ export const scorchedHighlands: Location = {
   connections: [
     { targetId: "misty_woods", energyCost: 25, terrainModifier: 1.4 },
     { targetId: "crystal_caves", energyCost: 20, terrainModifier: 1.3 },
+    { targetId: "ironhaven", energyCost: 15, terrainModifier: 1.2 },
+    { targetId: "volcanic_caldera", energyCost: 25, terrainModifier: 1.5 },
   ],
   levelMin: 15,
   levelMax: 25,
@@ -137,6 +144,7 @@ export const crystalCaves: Location = {
     { targetId: "misty_woods", energyCost: 20, terrainModifier: 1.5 },
     { targetId: "scorched_highlands", energyCost: 20, terrainModifier: 1.3 },
     { targetId: "shadow_depths", energyCost: 30, terrainModifier: 1.8 },
+    { targetId: "ironhaven", energyCost: 12 },
   ],
   levelMin: 10,
   levelMax: 20,
@@ -165,6 +173,7 @@ export const shadowDepths: Location = {
   type: LocationType.Dungeon,
   connections: [
     { targetId: "crystal_caves", energyCost: 30, terrainModifier: 1.8 },
+    { targetId: "starfall_sanctuary", energyCost: 25, terrainModifier: 1.5 },
   ],
   levelMin: 20,
   levelMax: 30,
@@ -178,6 +187,226 @@ export const shadowDepths: Location = {
 };
 
 /**
+ * Ancient Grove - a mystical forest area.
+ * Features unique flora and peaceful exploration.
+ */
+export const ancientGrove: Location = {
+  id: "ancient_grove",
+  name: "Ancient Grove",
+  description:
+    "A sacred forest where ancient trees tower to the sky. The air hums with natural energy, and rare herbs grow in abundance.",
+  type: LocationType.Wild,
+  connections: [
+    { targetId: "meadow", energyCost: 12, terrainModifier: 1.1 },
+    { targetId: "misty_woods", energyCost: 15, terrainModifier: 1.2 },
+    { targetId: "mushroom_hollow", energyCost: 10 },
+  ],
+  levelMin: 4,
+  levelMax: 12,
+  facilities: [
+    FacilityType.RestPoint,
+    FacilityType.ForageZone,
+    FacilityType.BattleArea,
+  ],
+  forageTableId: "grove_forage",
+  encounterTableId: "grove_encounters",
+  emoji: "🌳",
+};
+
+/**
+ * Mushroom Hollow - underground fungal caves.
+ * A bioluminescent wonderland with unique resources.
+ */
+export const mushroomHollow: Location = {
+  id: "mushroom_hollow",
+  name: "Mushroom Hollow",
+  description:
+    "An underground cavern lit by glowing mushrooms of every color. Strange spores float through the air, and peculiar creatures call this place home.",
+  type: LocationType.Wild,
+  connections: [
+    { targetId: "misty_woods", energyCost: 12, terrainModifier: 1.1 },
+    { targetId: "ancient_grove", energyCost: 10 },
+    { targetId: "crystal_caves", energyCost: 18, terrainModifier: 1.3 },
+  ],
+  levelMin: 8,
+  levelMax: 16,
+  requirements: {
+    stage: GrowthStage.Child,
+  },
+  facilities: [
+    FacilityType.RestPoint,
+    FacilityType.ForageZone,
+    FacilityType.BattleArea,
+  ],
+  forageTableId: "hollow_forage",
+  encounterTableId: "hollow_encounters",
+  emoji: "🍄",
+};
+
+/**
+ * Coral Reef - underwater exploration zone.
+ * Rich in aquatic resources and sea creatures.
+ */
+export const coralReef: Location = {
+  id: "coral_reef",
+  name: "Coral Reef",
+  description:
+    "A vibrant underwater paradise teeming with colorful fish and coral formations. The water is crystal clear and warm.",
+  type: LocationType.Wild,
+  connections: [
+    { targetId: "whispering_coast", energyCost: 18, terrainModifier: 1.4 },
+    { targetId: "tidecrest", energyCost: 15, terrainModifier: 1.3 },
+    { targetId: "sunken_temple", energyCost: 22, terrainModifier: 1.5 },
+  ],
+  levelMin: 10,
+  levelMax: 18,
+  requirements: {
+    stage: GrowthStage.Child,
+  },
+  facilities: [
+    FacilityType.RestPoint,
+    FacilityType.ForageZone,
+    FacilityType.BattleArea,
+  ],
+  forageTableId: "reef_forage",
+  encounterTableId: "reef_encounters",
+  emoji: "🪸",
+};
+
+/**
+ * Frozen Peaks - icy mountain region.
+ * Harsh conditions but valuable ice crystals and rare creatures.
+ */
+export const frozenPeaks: Location = {
+  id: "frozen_peaks",
+  name: "Frozen Peaks",
+  description:
+    "Snow-capped mountains where blizzards rage and ice covers everything. Only the hardiest pets can withstand the freezing temperatures.",
+  type: LocationType.Wild,
+  connections: [
+    { targetId: "ironhaven", energyCost: 20, terrainModifier: 1.4 },
+    { targetId: "starfall_sanctuary", energyCost: 30, terrainModifier: 1.6 },
+    { targetId: "glacial_cavern", energyCost: 25, terrainModifier: 1.5 },
+  ],
+  levelMin: 18,
+  levelMax: 28,
+  requirements: {
+    stage: GrowthStage.Teen,
+  },
+  facilities: [
+    FacilityType.RestPoint,
+    FacilityType.ForageZone,
+    FacilityType.BattleArea,
+  ],
+  forageTableId: "peaks_forage",
+  encounterTableId: "peaks_encounters",
+  emoji: "🏔️",
+};
+
+/**
+ * Volcanic Caldera - the heart of the volcano.
+ * End-game fire area with rare magma materials.
+ */
+export const volcanicCaldera: Location = {
+  id: "volcanic_caldera",
+  name: "Volcanic Caldera",
+  description:
+    "The blazing heart of an active volcano. Lava flows freely and the heat is almost unbearable, but legendary treasures await within.",
+  type: LocationType.Dungeon,
+  connections: [
+    { targetId: "scorched_highlands", energyCost: 25, terrainModifier: 1.5 },
+  ],
+  levelMin: 22,
+  levelMax: 32,
+  requirements: {
+    stage: GrowthStage.YoungAdult,
+  },
+  facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
+  forageTableId: "caldera_forage",
+  encounterTableId: "caldera_encounters",
+  emoji: "🔥",
+};
+
+/**
+ * Sunken Temple - ancient underwater ruins.
+ * A mysterious dungeon with aquatic challenges.
+ */
+export const sunkenTemple: Location = {
+  id: "sunken_temple",
+  name: "Sunken Temple",
+  description:
+    "The ruins of an ancient civilization now lie beneath the waves. Strange glyphs glow on the walls, and guardian creatures protect its secrets.",
+  type: LocationType.Dungeon,
+  connections: [
+    { targetId: "coral_reef", energyCost: 22, terrainModifier: 1.5 },
+    { targetId: "tidecrest", energyCost: 25, terrainModifier: 1.5 },
+  ],
+  levelMin: 18,
+  levelMax: 26,
+  requirements: {
+    stage: GrowthStage.Teen,
+  },
+  facilities: [
+    FacilityType.RestPoint,
+    FacilityType.ForageZone,
+    FacilityType.BattleArea,
+  ],
+  forageTableId: "temple_forage",
+  encounterTableId: "temple_encounters",
+  emoji: "🏛️",
+};
+
+/**
+ * Glacial Cavern - ice dungeon in the mountains.
+ * Features frozen creatures and ice materials.
+ */
+export const glacialCavern: Location = {
+  id: "glacial_cavern",
+  name: "Glacial Cavern",
+  description:
+    "A vast ice cave where stalactites of pure crystal hang from the ceiling. The cold preserves ancient mysteries within its frozen walls.",
+  type: LocationType.Dungeon,
+  connections: [
+    { targetId: "frozen_peaks", energyCost: 25, terrainModifier: 1.5 },
+    { targetId: "celestial_spire", energyCost: 35, terrainModifier: 1.7 },
+  ],
+  levelMin: 24,
+  levelMax: 34,
+  requirements: {
+    stage: GrowthStage.YoungAdult,
+  },
+  facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
+  forageTableId: "glacial_forage",
+  encounterTableId: "glacial_encounters",
+  emoji: "🧊",
+};
+
+/**
+ * Celestial Spire - the ultimate end-game zone.
+ * The highest challenge with the rarest rewards.
+ */
+export const celestialSpire: Location = {
+  id: "celestial_spire",
+  name: "Celestial Spire",
+  description:
+    "A tower that reaches beyond the clouds into the realm of stars. Only pets who have mastered all challenges may enter this sacred place.",
+  type: LocationType.Dungeon,
+  connections: [
+    { targetId: "glacial_cavern", energyCost: 35, terrainModifier: 1.7 },
+    { targetId: "starfall_sanctuary", energyCost: 35, terrainModifier: 1.8 },
+  ],
+  levelMin: 28,
+  levelMax: 40,
+  requirements: {
+    stage: GrowthStage.Adult,
+  },
+  facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
+  forageTableId: "spire_forage",
+  encounterTableId: "spire_encounters",
+  emoji: "🌟",
+};
+
+/**
  * All explorable locations (wild areas and dungeons).
  */
 export const explorableLocations: Location[] = [
@@ -187,4 +416,12 @@ export const explorableLocations: Location[] = [
   scorchedHighlands,
   crystalCaves,
   shadowDepths,
+  ancientGrove,
+  mushroomHollow,
+  coralReef,
+  frozenPeaks,
+  volcanicCaldera,
+  sunkenTemple,
+  glacialCavern,
+  celestialSpire,
 ];

--- a/src/game/data/locations/wild.ts
+++ b/src/game/data/locations/wild.ts
@@ -145,6 +145,7 @@ export const crystalCaves: Location = {
     { targetId: "scorched_highlands", energyCost: 20, terrainModifier: 1.3 },
     { targetId: "shadow_depths", energyCost: 30, terrainModifier: 1.8 },
     { targetId: "ironhaven", energyCost: 12 },
+    { targetId: "mushroom_hollow", energyCost: 18 },
   ],
   levelMin: 10,
   levelMax: 20,

--- a/src/game/data/npcs.ts
+++ b/src/game/data/npcs.ts
@@ -142,7 +142,11 @@ export const sageLumina: NPC = {
   roles: [NpcRole.Trainer, NpcRole.Lore, NpcRole.QuestGiver],
   locationId: "starfall_sanctuary",
   dialogueId: "lumina_dialogue",
-  questIds: ["main_celestial_trial", "side_starlight_gathering"],
+  questIds: [
+    "main_celestial_trial",
+    "main_frozen_ascent",
+    "side_starlight_gathering",
+  ],
   emoji: "🧙‍♀️",
 };
 
@@ -204,8 +208,8 @@ export const trainerBlaze: NPC = {
  * Frost - an ice-specialized researcher.
  * Studies creatures adapted to extreme cold.
  */
-export const researcherFrost: NPC = {
-  id: "researcher_frost",
+export const drFrost: NPC = {
+  id: "dr_frost",
   name: "Dr. Frost",
   description:
     "A dedicated researcher bundled in heavy furs, studying how creatures survive in the frozen peaks. Their research could revolutionize pet training.",
@@ -268,7 +272,7 @@ export const npcs: Record<string, NPC> = {
   // Wandering/Location-based
   [herbalistFern.id]: herbalistFern,
   [trainerBlaze.id]: trainerBlaze,
-  [researcherFrost.id]: researcherFrost,
+  [drFrost.id]: drFrost,
   [explorerCoral.id]: explorerCoral,
   [shadowGloom.id]: shadowGloom,
 };

--- a/src/game/data/npcs.ts
+++ b/src/game/data/npcs.ts
@@ -4,6 +4,10 @@
 
 import { type NPC, NpcRole } from "@/game/types/npc";
 
+// ========================================
+// WILLOWBROOK NPCs
+// ========================================
+
 /**
  * Mira - the shopkeeper at Willowbrook.
  * A friendly merchant who sells pet care supplies.
@@ -13,10 +17,15 @@ export const shopkeeperMira: NPC = {
   name: "Mira",
   description:
     "A cheerful shopkeeper with a warm smile. She runs the general store in Willowbrook.",
-  roles: [NpcRole.Merchant],
+  roles: [NpcRole.Merchant, NpcRole.QuestGiver],
   locationId: "willowbrook",
   dialogueId: "mira_dialogue",
   shopId: "willowbrook_shop",
+  questIds: [
+    "side_coastal_explorer",
+    "side_gourmet_chef",
+    "side_rare_collector",
+  ],
   emoji: "👩‍🌾",
 };
 
@@ -29,18 +38,239 @@ export const trainerOak: NPC = {
   name: "Oak",
   description:
     "A seasoned trainer with years of experience. He can help your pet reach its full potential.",
-  roles: [NpcRole.Trainer, NpcRole.Guide],
+  roles: [NpcRole.Trainer, NpcRole.Guide, NpcRole.QuestGiver],
   locationId: "willowbrook",
   dialogueId: "oak_dialogue",
+  questIds: [
+    "main_new_journey",
+    "main_crystal_discovery",
+    "main_rising_flames",
+    "main_shadow_depths",
+    "side_material_gatherer",
+    "side_monster_hunter",
+  ],
   emoji: "👴",
+};
+
+// ========================================
+// IRONHAVEN NPCs
+// ========================================
+
+/**
+ * Grom - the blacksmith at Ironhaven.
+ * A master craftsman who forges equipment and trades ore.
+ */
+export const blacksmithGrom: NPC = {
+  id: "blacksmith_grom",
+  name: "Grom",
+  description:
+    "A burly blacksmith with arms like tree trunks. His forge produces the finest equipment in the region, and he pays well for quality ore.",
+  roles: [NpcRole.Merchant, NpcRole.QuestGiver],
+  locationId: "ironhaven",
+  dialogueId: "grom_dialogue",
+  shopId: "ironhaven_shop",
+  questIds: ["side_ore_collector", "side_forge_master"],
+  emoji: "🧔",
+};
+
+/**
+ * Delva - the mining expert at Ironhaven.
+ * A veteran miner who knows every tunnel in the mountains.
+ */
+export const minerDelva: NPC = {
+  id: "miner_delva",
+  name: "Delva",
+  description:
+    "A weathered miner with a pickaxe always at her side. She has explored every cave and tunnel in the mountain range.",
+  roles: [NpcRole.Trainer, NpcRole.QuestGiver, NpcRole.Lore],
+  locationId: "ironhaven",
+  dialogueId: "delva_dialogue",
+  questIds: ["side_deep_mining", "side_crystal_hunter"],
+  emoji: "👷‍♀️",
+};
+
+// ========================================
+// TIDECREST NPCs
+// ========================================
+
+/**
+ * Marina - the fisher at Tidecrest.
+ * A skilled angler who knows the secrets of the sea.
+ */
+export const fisherMarina: NPC = {
+  id: "fisher_marina",
+  name: "Marina",
+  description:
+    "A sun-weathered fisher with an encyclopedic knowledge of the sea. She can identify any fish by its silhouette and knows the best fishing spots.",
+  roles: [NpcRole.Trainer, NpcRole.QuestGiver, NpcRole.Merchant],
+  locationId: "tidecrest",
+  dialogueId: "marina_dialogue",
+  shopId: "tidecrest_shop",
+  questIds: ["side_big_catch", "side_pearl_diving"],
+  emoji: "🧜‍♀️",
+};
+
+/**
+ * Captain Torrent - a retired sea captain at Tidecrest.
+ * A legendary sailor with tales of ancient underwater ruins.
+ */
+export const captainTorrent: NPC = {
+  id: "captain_torrent",
+  name: "Captain Torrent",
+  description:
+    "A grizzled sea captain with a peg leg and endless stories. He speaks of sunken temples and treasures lost to the deep.",
+  roles: [NpcRole.Lore, NpcRole.QuestGiver],
+  locationId: "tidecrest",
+  dialogueId: "torrent_dialogue",
+  questIds: ["side_treasure_hunt", "main_sunken_secrets"],
+  emoji: "🧑‍✈️",
+};
+
+// ========================================
+// STARFALL SANCTUARY NPCs
+// ========================================
+
+/**
+ * Sage Lumina - the mystical sage at Starfall Sanctuary.
+ * A wise elder who guards ancient knowledge.
+ */
+export const sageLumina: NPC = {
+  id: "sage_lumina",
+  name: "Sage Lumina",
+  description:
+    "An ethereal sage who seems to shimmer with starlight. She has devoted her life to studying the mysteries of pet evolution and cosmic energy.",
+  roles: [NpcRole.Trainer, NpcRole.Lore, NpcRole.QuestGiver],
+  locationId: "starfall_sanctuary",
+  dialogueId: "lumina_dialogue",
+  questIds: ["main_celestial_trial", "side_starlight_gathering"],
+  emoji: "🧙‍♀️",
+};
+
+/**
+ * Archivist Echo - the keeper of records at Starfall Sanctuary.
+ * Preserves all knowledge about pets and the world.
+ */
+export const archivistEcho: NPC = {
+  id: "archivist_echo",
+  name: "Archivist Echo",
+  description:
+    "A mysterious figure whose face is always hidden in shadow. They maintain the vast library of pet knowledge accumulated over millennia.",
+  roles: [NpcRole.Lore, NpcRole.QuestGiver, NpcRole.Merchant],
+  locationId: "starfall_sanctuary",
+  dialogueId: "echo_dialogue",
+  shopId: "sanctuary_shop",
+  questIds: ["side_lost_knowledge", "side_ancient_texts"],
+  emoji: "📚",
+};
+
+// ========================================
+// WANDERING NPCs (found during exploration)
+// ========================================
+
+/**
+ * Fern - a traveling herbalist.
+ * Appears in wild areas and offers healing items.
+ */
+export const herbalistFern: NPC = {
+  id: "herbalist_fern",
+  name: "Fern",
+  description:
+    "A gentle herbalist who wanders the wilds gathering medicinal plants. She's always happy to share her remedies with fellow travelers.",
+  roles: [NpcRole.Merchant, NpcRole.QuestGiver],
+  locationId: "ancient_grove",
+  dialogueId: "fern_dialogue",
+  shopId: "fern_traveling_shop",
+  questIds: ["side_rare_herbs", "side_mushroom_mystery"],
+  emoji: "🌿",
+};
+
+/**
+ * Blaze - a fire-focused trainer.
+ * Found in volcanic areas, specializes in thermal training.
+ */
+export const trainerBlaze: NPC = {
+  id: "trainer_blaze",
+  name: "Blaze",
+  description:
+    "An intense trainer who has dedicated their life to understanding thermal resistance. They train exclusively in the volcanic regions.",
+  roles: [NpcRole.Trainer, NpcRole.QuestGiver],
+  locationId: "scorched_highlands",
+  dialogueId: "blaze_dialogue",
+  questIds: ["side_trial_by_fire", "side_volcanic_champion"],
+  emoji: "🔥",
+};
+
+/**
+ * Frost - an ice-specialized researcher.
+ * Studies creatures adapted to extreme cold.
+ */
+export const researcherFrost: NPC = {
+  id: "researcher_frost",
+  name: "Dr. Frost",
+  description:
+    "A dedicated researcher bundled in heavy furs, studying how creatures survive in the frozen peaks. Their research could revolutionize pet training.",
+  roles: [NpcRole.Lore, NpcRole.QuestGiver],
+  locationId: "frozen_peaks",
+  dialogueId: "frost_dialogue",
+  questIds: ["side_cold_adaptation", "side_ice_sample_collection"],
+  emoji: "🥶",
+};
+
+/**
+ * Coral - an underwater explorer.
+ * Knows the secrets of the reef and temple.
+ */
+export const explorerCoral: NPC = {
+  id: "explorer_coral",
+  name: "Coral",
+  description:
+    "An intrepid underwater explorer who has mapped every corner of the reef. She seeks to uncover the mysteries of the Sunken Temple.",
+  roles: [NpcRole.Guide, NpcRole.QuestGiver],
+  locationId: "coral_reef",
+  dialogueId: "coral_dialogue",
+  questIds: ["side_reef_survey", "side_temple_expedition"],
+  emoji: "🤿",
+};
+
+/**
+ * Gloom - a mysterious shadow dweller.
+ * Offers rare knowledge about the depths.
+ */
+export const shadowGloom: NPC = {
+  id: "shadow_gloom",
+  name: "Gloom",
+  description:
+    "A shadowy figure who has spent so long in the darkness that they seem to merge with it. They know secrets that should remain forgotten.",
+  roles: [NpcRole.Lore, NpcRole.QuestGiver, NpcRole.Merchant],
+  locationId: "shadow_depths",
+  dialogueId: "gloom_dialogue",
+  shopId: "shadow_shop",
+  questIds: ["side_embrace_darkness", "side_shadow_essence"],
+  emoji: "👤",
 };
 
 /**
  * All NPCs indexed by ID.
  */
 export const npcs: Record<string, NPC> = {
+  // Willowbrook
   [shopkeeperMira.id]: shopkeeperMira,
   [trainerOak.id]: trainerOak,
+  // Ironhaven
+  [blacksmithGrom.id]: blacksmithGrom,
+  [minerDelva.id]: minerDelva,
+  // Tidecrest
+  [fisherMarina.id]: fisherMarina,
+  [captainTorrent.id]: captainTorrent,
+  // Starfall Sanctuary
+  [sageLumina.id]: sageLumina,
+  [archivistEcho.id]: archivistEcho,
+  // Wandering/Location-based
+  [herbalistFern.id]: herbalistFern,
+  [trainerBlaze.id]: trainerBlaze,
+  [researcherFrost.id]: researcherFrost,
+  [explorerCoral.id]: explorerCoral,
+  [shadowGloom.id]: shadowGloom,
 };
 
 /**

--- a/src/game/data/quests/main.ts
+++ b/src/game/data/quests/main.ts
@@ -185,7 +185,7 @@ export const mainRisingFlames: Quest = {
 
 /**
  * Main Quest 4: Into the Shadow Depths
- * The final main story quest.
+ * Exploring the deepest caves.
  */
 export const mainShadowDepths: Quest = {
   id: "main_shadow_depths",
@@ -245,6 +245,196 @@ export const mainShadowDepths: Quest = {
     },
   ],
   chainPrevious: "main_rising_flames",
+  chainNext: "main_sunken_secrets",
+};
+
+/**
+ * Main Quest 5: Sunken Secrets
+ * Discovering the underwater temple.
+ */
+export const mainSunkenSecrets: Quest = {
+  id: "main_sunken_secrets",
+  name: "Sunken Secrets",
+  description:
+    "Captain Torrent speaks of an ancient temple beneath the waves. Its mysteries call to those brave enough to dive deep.",
+  type: QuestType.Main,
+  giverId: "captain_torrent",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "main_shadow_depths",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_reef",
+      type: ObjectiveType.Visit,
+      description: "Explore the Coral Reef",
+      target: "coral_reef",
+      quantity: 1,
+    },
+    {
+      id: "visit_temple",
+      type: ObjectiveType.Visit,
+      description: "Enter the Sunken Temple",
+      target: "sunken_temple",
+      quantity: 1,
+    },
+    {
+      id: "defeat_guardians",
+      type: ObjectiveType.Defeat,
+      description: "Defeat temple guardians",
+      target: "any",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 1200,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_guardians_pendant",
+      quantity: 1,
+    },
+    {
+      type: RewardType.Unlock,
+      target: SPECIES.CORALITE.id,
+      quantity: 1,
+    },
+  ],
+  chainPrevious: "main_shadow_depths",
+  chainNext: "main_frozen_ascent",
+};
+
+/**
+ * Main Quest 6: Frozen Ascent
+ * Climbing the frozen peaks.
+ */
+export const mainFrozenAscent: Quest = {
+  id: "main_frozen_ascent",
+  name: "Frozen Ascent",
+  description:
+    "The path to the Starfall Sanctuary passes through the Frozen Peaks. Brave the cold and climb to new heights.",
+  type: QuestType.Main,
+  giverId: "sage_lumina",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "main_sunken_secrets",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_peaks",
+      type: ObjectiveType.Visit,
+      description: "Reach the Frozen Peaks",
+      target: "frozen_peaks",
+      quantity: 1,
+    },
+    {
+      id: "visit_cavern",
+      type: ObjectiveType.Visit,
+      description: "Enter the Glacial Cavern",
+      target: "glacial_cavern",
+      quantity: 1,
+    },
+    {
+      id: "defeat_ice",
+      type: ObjectiveType.Defeat,
+      description: "Defeat ice creatures",
+      target: "any",
+      quantity: 12,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 1500,
+    },
+    {
+      type: RewardType.Item,
+      target: "medicine_super_potion",
+      quantity: 5,
+    },
+  ],
+  chainPrevious: "main_sunken_secrets",
+  chainNext: "main_celestial_trial",
+};
+
+/**
+ * Main Quest 7: Celestial Trial
+ * The ultimate challenge.
+ */
+export const mainCelestialTrial: Quest = {
+  id: "main_celestial_trial",
+  name: "Celestial Trial",
+  description:
+    "The Celestial Spire awaits. At its peak lies the ultimate test - prove that your bond with your pet transcends all limits.",
+  type: QuestType.Main,
+  giverId: "sage_lumina",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "main_frozen_ascent",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Adult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_spire",
+      type: ObjectiveType.Visit,
+      description: "Enter the Celestial Spire",
+      target: "celestial_spire",
+      quantity: 1,
+    },
+    {
+      id: "defeat_celestial",
+      type: ObjectiveType.Defeat,
+      description: "Overcome celestial guardians",
+      target: "any",
+      quantity: 25,
+    },
+    {
+      id: "explore_spire",
+      type: ObjectiveType.Explore,
+      description: "Reach the spire's peak",
+      target: "celestial_spire",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 5000,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_hunters_eye",
+      quantity: 1,
+    },
+    {
+      type: RewardType.Item,
+      target: "food_feast",
+      quantity: 10,
+    },
+  ],
+  chainPrevious: "main_frozen_ascent",
 };
 
 /**
@@ -255,4 +445,7 @@ export const mainQuests: Record<string, Quest> = {
   [mainCrystalDiscovery.id]: mainCrystalDiscovery,
   [mainRisingFlames.id]: mainRisingFlames,
   [mainShadowDepths.id]: mainShadowDepths,
+  [mainSunkenSecrets.id]: mainSunkenSecrets,
+  [mainFrozenAscent.id]: mainFrozenAscent,
+  [mainCelestialTrial.id]: mainCelestialTrial,
 };

--- a/src/game/data/quests/side.ts
+++ b/src/game/data/quests/side.ts
@@ -11,6 +11,10 @@ import {
   RewardType,
 } from "@/game/types/quest";
 
+// ========================================
+// WILLOWBROOK SIDE QUESTS
+// ========================================
+
 /**
  * Side Quest: Coastal Explorer
  * Encourages visiting the Whispering Coast.
@@ -268,13 +272,1157 @@ export const sideGourmetChef: Quest = {
   ],
 };
 
+// ========================================
+// IRONHAVEN SIDE QUESTS
+// ========================================
+
+/**
+ * Side Quest: Ore Collector
+ * Gathering ores for the blacksmith.
+ */
+export const sideOreCollector: Quest = {
+  id: "side_ore_collector",
+  name: "Ore Collector",
+  description:
+    "Grom needs iron ore to keep his forge running. He'll pay well for quality materials.",
+  type: QuestType.Side,
+  giverId: "blacksmith_grom",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Child,
+    },
+  ],
+  objectives: [
+    {
+      id: "collect_iron",
+      type: ObjectiveType.Collect,
+      description: "Collect Iron Ore",
+      target: "material_iron_ore",
+      quantity: 15,
+    },
+    {
+      id: "collect_stone",
+      type: ObjectiveType.Collect,
+      description: "Collect Stone",
+      target: "material_stone",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 250,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_iron_bangle",
+      quantity: 1,
+    },
+    {
+      type: RewardType.XP,
+      target: "mining",
+      quantity: 75,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Forge Master
+ * Crafting a special item with Grom.
+ */
+export const sideForgeMaster: Quest = {
+  id: "side_forge_master",
+  name: "Forge Master",
+  description:
+    "Grom has a special project in mind. Bring him rare materials and he'll craft something unique.",
+  type: QuestType.Side,
+  giverId: "blacksmith_grom",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_ore_collector",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Teen,
+    },
+  ],
+  objectives: [
+    {
+      id: "collect_crystals",
+      type: ObjectiveType.Collect,
+      description: "Collect Crystal Shards",
+      target: "material_crystal",
+      quantity: 5,
+    },
+    {
+      id: "collect_iron",
+      type: ObjectiveType.Collect,
+      description: "Collect Iron Ore",
+      target: "material_iron_ore",
+      quantity: 10,
+    },
+    {
+      id: "collect_fangs",
+      type: ObjectiveType.Collect,
+      description: "Collect Monster Fangs",
+      target: "material_monster_fang",
+      quantity: 8,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 400,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_guardians_pendant",
+      quantity: 1,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Deep Mining
+ * Exploring the deeper caves.
+ */
+export const sideDeepMining: Quest = {
+  id: "side_deep_mining",
+  name: "Deep Mining",
+  description:
+    "Delva has heard of a rich ore vein in the Crystal Caves. Explore and bring back samples.",
+  type: QuestType.Side,
+  giverId: "miner_delva",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Child,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_caves",
+      type: ObjectiveType.Visit,
+      description: "Enter the Crystal Caves",
+      target: "crystal_caves",
+      quantity: 1,
+    },
+    {
+      id: "collect_crystals",
+      type: ObjectiveType.Collect,
+      description: "Collect Crystal Shards",
+      target: "material_crystal",
+      quantity: 8,
+    },
+    {
+      id: "defeat_creatures",
+      type: ObjectiveType.Defeat,
+      description: "Defeat cave dwellers",
+      target: "any",
+      quantity: 5,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 300,
+    },
+    {
+      type: RewardType.XP,
+      target: "mining",
+      quantity: 100,
+    },
+    {
+      type: RewardType.Item,
+      target: "medicine_super_potion",
+      quantity: 2,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Crystal Hunter
+ * Finding the rarest crystals.
+ */
+export const sideCrystalHunter: Quest = {
+  id: "side_crystal_hunter",
+  name: "Crystal Hunter",
+  description:
+    "Delva wants to study the purest crystals. Find them in the deepest caves.",
+  type: QuestType.Side,
+  giverId: "miner_delva",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_deep_mining",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_depths",
+      type: ObjectiveType.Visit,
+      description: "Enter the Shadow Depths",
+      target: "shadow_depths",
+      quantity: 1,
+    },
+    {
+      id: "collect_essence",
+      type: ObjectiveType.Collect,
+      description: "Collect Essence Drops",
+      target: "material_essence",
+      quantity: 5,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 800,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_hunters_eye",
+      quantity: 1,
+    },
+    {
+      type: RewardType.XP,
+      target: "mining",
+      quantity: 200,
+    },
+  ],
+};
+
+// ========================================
+// TIDECREST SIDE QUESTS
+// ========================================
+
+/**
+ * Side Quest: Big Catch
+ * Catching impressive fish.
+ */
+export const sideBigCatch: Quest = {
+  id: "side_big_catch",
+  name: "The Big Catch",
+  description:
+    "Marina wants to see your fishing skills. Catch some impressive fish from different waters!",
+  type: QuestType.Side,
+  giverId: "fisher_marina",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_coastal_explorer",
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_reef",
+      type: ObjectiveType.Visit,
+      description: "Visit the Coral Reef",
+      target: "coral_reef",
+      quantity: 1,
+    },
+    {
+      id: "collect_fish",
+      type: ObjectiveType.Collect,
+      description: "Collect Grilled Fish",
+      target: "food_fish",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 200,
+    },
+    {
+      type: RewardType.XP,
+      target: "fishing",
+      quantity: 100,
+    },
+    {
+      type: RewardType.Item,
+      target: "drink_coconut",
+      quantity: 5,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Pearl Diving
+ * Finding valuable pearls underwater.
+ */
+export const sidePearlDiving: Quest = {
+  id: "side_pearl_diving",
+  name: "Pearl Diving",
+  description:
+    "The reef holds beautiful pearls. Marina knows the best spots - help her gather some!",
+  type: QuestType.Side,
+  giverId: "fisher_marina",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_big_catch",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Teen,
+    },
+  ],
+  objectives: [
+    {
+      id: "explore_reef",
+      type: ObjectiveType.Explore,
+      description: "Forage in the Coral Reef",
+      target: "coral_reef",
+      quantity: 5,
+    },
+    {
+      id: "collect_materials",
+      type: ObjectiveType.Collect,
+      description: "Collect Coral Fragments",
+      target: "material_coral",
+      quantity: 8,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 400,
+    },
+    {
+      type: RewardType.XP,
+      target: "fishing",
+      quantity: 150,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_lucky_charm",
+      quantity: 1,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Treasure Hunt
+ * Captain Torrent's treasure map.
+ */
+export const sideTreasureHunt: Quest = {
+  id: "side_treasure_hunt",
+  name: "Treasure Hunt",
+  description:
+    "Captain Torrent has an old treasure map. Help him find the chest he buried years ago!",
+  type: QuestType.Side,
+  giverId: "captain_torrent",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Child,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_coast",
+      type: ObjectiveType.Visit,
+      description: "Search the Whispering Coast",
+      target: "whispering_coast",
+      quantity: 1,
+    },
+    {
+      id: "visit_reef",
+      type: ObjectiveType.Visit,
+      description: "Search the Coral Reef",
+      target: "coral_reef",
+      quantity: 1,
+    },
+    {
+      id: "forage_reef",
+      type: ObjectiveType.Explore,
+      description: "Deep exploration of the reef",
+      target: "coral_reef",
+      quantity: 3,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 500,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_lucky_charm",
+      quantity: 1,
+    },
+    {
+      type: RewardType.Item,
+      target: "food_feast",
+      quantity: 2,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Temple Expedition
+ * Exploring the outer temple.
+ */
+export const sideTempleExpedition: Quest = {
+  id: "side_temple_expedition",
+  name: "Temple Expedition",
+  description:
+    "Coral wants to explore the Sunken Temple's outer chambers. Join her expedition!",
+  type: QuestType.Side,
+  giverId: "explorer_coral",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Teen,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_temple",
+      type: ObjectiveType.Visit,
+      description: "Enter the Sunken Temple",
+      target: "sunken_temple",
+      quantity: 1,
+    },
+    {
+      id: "defeat_guardians",
+      type: ObjectiveType.Defeat,
+      description: "Defeat temple guardians",
+      target: "any",
+      quantity: 8,
+    },
+    {
+      id: "explore_temple",
+      type: ObjectiveType.Explore,
+      description: "Explore the temple chambers",
+      target: "sunken_temple",
+      quantity: 3,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 600,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_guardians_pendant",
+      quantity: 1,
+    },
+    {
+      type: RewardType.XP,
+      target: "scouting",
+      quantity: 150,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Reef Survey
+ * Mapping the coral reef.
+ */
+export const sideReefSurvey: Quest = {
+  id: "side_reef_survey",
+  name: "Reef Survey",
+  description:
+    "Coral needs help mapping the reef. Explore every corner and record what you find!",
+  type: QuestType.Side,
+  giverId: "explorer_coral",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Child,
+    },
+  ],
+  objectives: [
+    {
+      id: "explore_reef",
+      type: ObjectiveType.Explore,
+      description: "Survey the Coral Reef",
+      target: "coral_reef",
+      quantity: 5,
+    },
+    {
+      id: "defeat_creatures",
+      type: ObjectiveType.Defeat,
+      description: "Document reef creatures",
+      target: "any",
+      quantity: 6,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 250,
+    },
+    {
+      type: RewardType.XP,
+      target: "scouting",
+      quantity: 100,
+    },
+    {
+      type: RewardType.Item,
+      target: "drink_coconut",
+      quantity: 3,
+    },
+  ],
+};
+
+// ========================================
+// EXPLORATION NPC SIDE QUESTS
+// ========================================
+
+/**
+ * Side Quest: Rare Herbs
+ * Gathering rare herbs from the grove.
+ */
+export const sideRareHerbs: Quest = {
+  id: "side_rare_herbs",
+  name: "Rare Herbs",
+  description:
+    "Fern is looking for rare medicinal herbs. Help her gather them from the Ancient Grove.",
+  type: QuestType.Side,
+  giverId: "herbalist_fern",
+  requirements: [],
+  objectives: [
+    {
+      id: "visit_grove",
+      type: ObjectiveType.Visit,
+      description: "Visit the Ancient Grove",
+      target: "ancient_grove",
+      quantity: 1,
+    },
+    {
+      id: "collect_herbs",
+      type: ObjectiveType.Collect,
+      description: "Collect Wild Herbs",
+      target: "material_herb",
+      quantity: 15,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 150,
+    },
+    {
+      type: RewardType.Item,
+      target: "medicine_potion",
+      quantity: 5,
+    },
+    {
+      type: RewardType.XP,
+      target: "foraging",
+      quantity: 75,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Mushroom Mystery
+ * Investigating the Mushroom Hollow.
+ */
+export const sideMushroomMystery: Quest = {
+  id: "side_mushroom_mystery",
+  name: "Mushroom Mystery",
+  description:
+    "Strange mushrooms are appearing in the hollow. Fern wants samples for her research.",
+  type: QuestType.Side,
+  giverId: "herbalist_fern",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_rare_herbs",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Child,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_hollow",
+      type: ObjectiveType.Visit,
+      description: "Enter the Mushroom Hollow",
+      target: "mushroom_hollow",
+      quantity: 1,
+    },
+    {
+      id: "explore_hollow",
+      type: ObjectiveType.Explore,
+      description: "Explore the hollow",
+      target: "mushroom_hollow",
+      quantity: 4,
+    },
+    {
+      id: "collect_mushrooms",
+      type: ObjectiveType.Collect,
+      description: "Collect Mushrooms",
+      target: "food_mushroom",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 300,
+    },
+    {
+      type: RewardType.Item,
+      target: "medicine_super_potion",
+      quantity: 3,
+    },
+    {
+      type: RewardType.XP,
+      target: "foraging",
+      quantity: 125,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Trial by Fire
+ * Blaze's heat training challenge.
+ */
+export const sideTrialByFire: Quest = {
+  id: "side_trial_by_fire",
+  name: "Trial by Fire",
+  description:
+    "Blaze wants to test your pet's heat resistance. Survive the volcanic highlands!",
+  type: QuestType.Side,
+  giverId: "trainer_blaze",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Teen,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_highlands",
+      type: ObjectiveType.Visit,
+      description: "Enter the Scorched Highlands",
+      target: "scorched_highlands",
+      quantity: 1,
+    },
+    {
+      id: "defeat_fire",
+      type: ObjectiveType.Defeat,
+      description: "Defeat fire creatures",
+      target: "any",
+      quantity: 10,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 350,
+    },
+    {
+      type: RewardType.Item,
+      target: "battle_defense_boost",
+      quantity: 3,
+    },
+    {
+      type: RewardType.XP,
+      target: "scouting",
+      quantity: 100,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Volcanic Champion
+ * Conquering the caldera.
+ */
+export const sideVolcanicChampion: Quest = {
+  id: "side_volcanic_champion",
+  name: "Volcanic Champion",
+  description:
+    "Only the strongest pets can survive the Volcanic Caldera. Prove your worth!",
+  type: QuestType.Side,
+  giverId: "trainer_blaze",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_trial_by_fire",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_caldera",
+      type: ObjectiveType.Visit,
+      description: "Enter the Volcanic Caldera",
+      target: "volcanic_caldera",
+      quantity: 1,
+    },
+    {
+      id: "defeat_caldera",
+      type: ObjectiveType.Defeat,
+      description: "Defeat caldera creatures",
+      target: "any",
+      quantity: 15,
+    },
+    {
+      id: "explore_caldera",
+      type: ObjectiveType.Explore,
+      description: "Explore the caldera depths",
+      target: "volcanic_caldera",
+      quantity: 3,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 750,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_hunters_eye",
+      quantity: 1,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Cold Adaptation
+ * Dr. Frost's research assistance.
+ */
+export const sideColdAdaptation: Quest = {
+  id: "side_cold_adaptation",
+  name: "Cold Adaptation",
+  description:
+    "Dr. Frost needs data on how pets adapt to cold. Help with the research!",
+  type: QuestType.Side,
+  giverId: "researcher_frost",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Teen,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_peaks",
+      type: ObjectiveType.Visit,
+      description: "Explore the Frozen Peaks",
+      target: "frozen_peaks",
+      quantity: 1,
+    },
+    {
+      id: "explore_peaks",
+      type: ObjectiveType.Explore,
+      description: "Gather cold adaptation data",
+      target: "frozen_peaks",
+      quantity: 4,
+    },
+    {
+      id: "defeat_ice",
+      type: ObjectiveType.Defeat,
+      description: "Study ice creatures in battle",
+      target: "any",
+      quantity: 8,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 400,
+    },
+    {
+      type: RewardType.Item,
+      target: "medicine_antidote",
+      quantity: 5,
+    },
+    {
+      type: RewardType.XP,
+      target: "scouting",
+      quantity: 125,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Ice Sample Collection
+ * Gathering rare ice samples.
+ */
+export const sideIceSampleCollection: Quest = {
+  id: "side_ice_sample_collection",
+  name: "Ice Sample Collection",
+  description:
+    "Dr. Frost needs ice samples from the Glacial Cavern. Bring back pristine specimens!",
+  type: QuestType.Side,
+  giverId: "researcher_frost",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_cold_adaptation",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_cavern",
+      type: ObjectiveType.Visit,
+      description: "Enter the Glacial Cavern",
+      target: "glacial_cavern",
+      quantity: 1,
+    },
+    {
+      id: "explore_cavern",
+      type: ObjectiveType.Explore,
+      description: "Collect ice samples",
+      target: "glacial_cavern",
+      quantity: 5,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 700,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_guardians_pendant",
+      quantity: 1,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Embrace Darkness
+ * Learning from Gloom.
+ */
+export const sideEmbraceDarkness: Quest = {
+  id: "side_embrace_darkness",
+  name: "Embrace Darkness",
+  description:
+    "Gloom offers to teach the secrets of shadow. But first, you must prove you can survive the dark.",
+  type: QuestType.Side,
+  giverId: "shadow_gloom",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "explore_depths",
+      type: ObjectiveType.Explore,
+      description: "Navigate the Shadow Depths",
+      target: "shadow_depths",
+      quantity: 5,
+    },
+    {
+      id: "defeat_shadows",
+      type: ObjectiveType.Defeat,
+      description: "Defeat shadow creatures",
+      target: "any",
+      quantity: 12,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 600,
+    },
+    {
+      type: RewardType.Item,
+      target: "material_essence",
+      quantity: 3,
+    },
+    {
+      type: RewardType.XP,
+      target: "scouting",
+      quantity: 175,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Shadow Essence
+ * Collecting essence for Gloom.
+ */
+export const sideShadowEssence: Quest = {
+  id: "side_shadow_essence",
+  name: "Shadow Essence",
+  description:
+    "Gloom needs pure shadow essence for a ritual. Gather it from the darkest depths.",
+  type: QuestType.Side,
+  giverId: "shadow_gloom",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_embrace_darkness",
+    },
+  ],
+  objectives: [
+    {
+      id: "collect_essence",
+      type: ObjectiveType.Collect,
+      description: "Collect Essence Drops",
+      target: "material_essence",
+      quantity: 10,
+    },
+    {
+      id: "defeat_powerful",
+      type: ObjectiveType.Defeat,
+      description: "Defeat powerful shadows",
+      target: "any",
+      quantity: 20,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 1000,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_hunters_eye",
+      quantity: 1,
+    },
+  ],
+};
+
+// ========================================
+// STARFALL SANCTUARY SIDE QUESTS
+// ========================================
+
+/**
+ * Side Quest: Starlight Gathering
+ * Collecting cosmic energy.
+ */
+export const sideStarlightGathering: Quest = {
+  id: "side_starlight_gathering",
+  name: "Starlight Gathering",
+  description:
+    "Sage Lumina needs crystallized starlight for her research. It only appears in the highest places.",
+  type: QuestType.Side,
+  giverId: "sage_lumina",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_sanctuary",
+      type: ObjectiveType.Visit,
+      description: "Study at Starfall Sanctuary",
+      target: "starfall_sanctuary",
+      quantity: 1,
+    },
+    {
+      id: "collect_crystals",
+      type: ObjectiveType.Collect,
+      description: "Collect Crystal Shards",
+      target: "material_crystal",
+      quantity: 15,
+    },
+    {
+      id: "collect_essence",
+      type: ObjectiveType.Collect,
+      description: "Collect Essence Drops",
+      target: "material_essence",
+      quantity: 5,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 800,
+    },
+    {
+      type: RewardType.Item,
+      target: "food_feast",
+      quantity: 3,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Lost Knowledge
+ * Recovering ancient texts.
+ */
+export const sideLostKnowledge: Quest = {
+  id: "side_lost_knowledge",
+  name: "Lost Knowledge",
+  description:
+    "Archivist Echo has located fragments of ancient texts. Recover them from dangerous locations.",
+  type: QuestType.Side,
+  giverId: "archivist_echo",
+  requirements: [
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.YoungAdult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_temple",
+      type: ObjectiveType.Visit,
+      description: "Search the Sunken Temple",
+      target: "sunken_temple",
+      quantity: 1,
+    },
+    {
+      id: "visit_depths",
+      type: ObjectiveType.Visit,
+      description: "Search the Shadow Depths",
+      target: "shadow_depths",
+      quantity: 1,
+    },
+    {
+      id: "visit_cavern",
+      type: ObjectiveType.Visit,
+      description: "Search the Glacial Cavern",
+      target: "glacial_cavern",
+      quantity: 1,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 900,
+    },
+    {
+      type: RewardType.XP,
+      target: "social",
+      quantity: 200,
+    },
+  ],
+};
+
+/**
+ * Side Quest: Ancient Texts
+ * The ultimate knowledge quest.
+ */
+export const sideAncientTexts: Quest = {
+  id: "side_ancient_texts",
+  name: "Ancient Texts",
+  description:
+    "Echo believes the Celestial Spire holds the oldest texts. Brave its heights and return with knowledge.",
+  type: QuestType.Side,
+  giverId: "archivist_echo",
+  requirements: [
+    {
+      type: RequirementType.Quest,
+      target: "side_lost_knowledge",
+    },
+    {
+      type: RequirementType.Stage,
+      target: GrowthStage.Adult,
+    },
+  ],
+  objectives: [
+    {
+      id: "visit_spire",
+      type: ObjectiveType.Visit,
+      description: "Climb the Celestial Spire",
+      target: "celestial_spire",
+      quantity: 1,
+    },
+    {
+      id: "explore_spire",
+      type: ObjectiveType.Explore,
+      description: "Search for ancient knowledge",
+      target: "celestial_spire",
+      quantity: 5,
+    },
+    {
+      id: "defeat_guardians",
+      type: ObjectiveType.Defeat,
+      description: "Overcome the spire guardians",
+      target: "any",
+      quantity: 20,
+    },
+  ],
+  rewards: [
+    {
+      type: RewardType.Currency,
+      target: "coins",
+      quantity: 2000,
+    },
+    {
+      type: RewardType.Item,
+      target: "equip_hunters_eye",
+      quantity: 1,
+    },
+    {
+      type: RewardType.Item,
+      target: "food_feast",
+      quantity: 5,
+    },
+  ],
+};
+
 /**
  * All side quests indexed by ID.
  */
 export const sideQuests: Record<string, Quest> = {
+  // Willowbrook
   [sideCoastalExplorer.id]: sideCoastalExplorer,
   [sideMaterialGatherer.id]: sideMaterialGatherer,
   [sideMonsterHunter.id]: sideMonsterHunter,
   [sideRareCollector.id]: sideRareCollector,
   [sideGourmetChef.id]: sideGourmetChef,
+  // Ironhaven
+  [sideOreCollector.id]: sideOreCollector,
+  [sideForgeMaster.id]: sideForgeMaster,
+  [sideDeepMining.id]: sideDeepMining,
+  [sideCrystalHunter.id]: sideCrystalHunter,
+  // Tidecrest
+  [sideBigCatch.id]: sideBigCatch,
+  [sidePearlDiving.id]: sidePearlDiving,
+  [sideTreasureHunt.id]: sideTreasureHunt,
+  [sideTempleExpedition.id]: sideTempleExpedition,
+  [sideReefSurvey.id]: sideReefSurvey,
+  // Exploration NPCs
+  [sideRareHerbs.id]: sideRareHerbs,
+  [sideMushroomMystery.id]: sideMushroomMystery,
+  [sideTrialByFire.id]: sideTrialByFire,
+  [sideVolcanicChampion.id]: sideVolcanicChampion,
+  [sideColdAdaptation.id]: sideColdAdaptation,
+  [sideIceSampleCollection.id]: sideIceSampleCollection,
+  [sideEmbraceDarkness.id]: sideEmbraceDarkness,
+  [sideShadowEssence.id]: sideShadowEssence,
+  // Starfall Sanctuary
+  [sideStarlightGathering.id]: sideStarlightGathering,
+  [sideLostKnowledge.id]: sideLostKnowledge,
+  [sideAncientTexts.id]: sideAncientTexts,
 };

--- a/src/game/data/quests/side.ts
+++ b/src/game/data/quests/side.ts
@@ -590,7 +590,7 @@ export const sidePearlDiving: Quest = {
       id: "collect_materials",
       type: ObjectiveType.Collect,
       description: "Collect Coral Fragments",
-      target: "material_coral",
+      target: "material_crystal",
       quantity: 8,
     },
   ],
@@ -1017,7 +1017,7 @@ export const sideColdAdaptation: Quest = {
   description:
     "Dr. Frost needs data on how pets adapt to cold. Help with the research!",
   type: QuestType.Side,
-  giverId: "researcher_frost",
+  giverId: "dr_frost",
   requirements: [
     {
       type: RequirementType.Stage,
@@ -1076,7 +1076,7 @@ export const sideIceSampleCollection: Quest = {
   description:
     "Dr. Frost needs ice samples from the Glacial Cavern. Bring back pristine specimens!",
   type: QuestType.Side,
-  giverId: "researcher_frost",
+  giverId: "dr_frost",
   requirements: [
     {
       type: RequirementType.Quest,

--- a/src/game/data/shops.ts
+++ b/src/game/data/shops.ts
@@ -3,7 +3,15 @@
  */
 
 import type { Shop, ShopItem } from "@/game/types/shop";
-import { CLEANING_ITEMS, DRINK_ITEMS, FOOD_ITEMS, TOY_ITEMS } from "./items";
+import {
+  CLEANING_ITEMS,
+  DRINK_ITEMS,
+  EQUIPMENT_ITEMS,
+  FOOD_ITEMS,
+  MATERIAL_ITEMS,
+  MEDICINE_ITEMS,
+  TOY_ITEMS,
+} from "./items";
 
 /**
  * Helper to create a shop item entry.
@@ -46,10 +54,161 @@ export const willowbrookShop: Shop = {
 };
 
 /**
+ * Ironhaven Smithy - Grom's shop.
+ * Sells equipment and crafting materials.
+ */
+export const ironhavenShop: Shop = {
+  id: "ironhaven_shop",
+  name: "Grom's Smithy",
+  sellMultiplier: 0.6,
+  items: [
+    // Equipment
+    shopItem(EQUIPMENT_ITEMS.IRON_BANGLE.id, 150),
+    shopItem(EQUIPMENT_ITEMS.LUCKY_CHARM.id, 200),
+
+    // Materials (buy back from players)
+    shopItem(MATERIAL_ITEMS.IRON_ORE.id, 25),
+    shopItem(MATERIAL_ITEMS.STONE.id, 10),
+    shopItem(MATERIAL_ITEMS.CRYSTAL.id, 75),
+
+    // Medicine
+    shopItem(MEDICINE_ITEMS.POTION.id, 30),
+    shopItem(MEDICINE_ITEMS.BANDAGE.id, 15),
+
+    // Food for long mining trips
+    shopItem(FOOD_ITEMS.STEAK.id, 80),
+    shopItem(FOOD_ITEMS.MEAT.id, 35),
+  ],
+};
+
+/**
+ * Tidecrest Fish Market - Marina's shop.
+ * Sells seafood and aquatic supplies.
+ */
+export const tidecrestShop: Shop = {
+  id: "tidecrest_shop",
+  name: "Marina's Fish Market",
+  sellMultiplier: 0.55,
+  items: [
+    // Seafood
+    shopItem(FOOD_ITEMS.FISH.id, 30),
+    shopItem(DRINK_ITEMS.COCONUT.id, 25),
+
+    // Drinks
+    shopItem(DRINK_ITEMS.WATER.id, 5),
+    shopItem(DRINK_ITEMS.JUICE.id, 15),
+    shopItem(DRINK_ITEMS.SMOOTHIE.id, 45),
+
+    // Beach toys
+    shopItem(TOY_ITEMS.BALL.id, 25),
+    shopItem(TOY_ITEMS.FRISBEE.id, 40),
+
+    // Medicine for water activities
+    shopItem(MEDICINE_ITEMS.ANTIDOTE.id, 35),
+    shopItem(MEDICINE_ITEMS.POTION.id, 30),
+
+    // Cleaning
+    shopItem(CLEANING_ITEMS.WIPES.id, 15),
+  ],
+};
+
+/**
+ * Starfall Sanctuary Emporium - Echo's shop.
+ * Sells rare and high-quality items.
+ */
+export const sanctuaryShop: Shop = {
+  id: "sanctuary_shop",
+  name: "Echo's Emporium",
+  sellMultiplier: 0.7,
+  items: [
+    // High-tier equipment
+    shopItem(EQUIPMENT_ITEMS.HUNTERS_EYE.id, 500),
+    shopItem(EQUIPMENT_ITEMS.GUARDIANS_PENDANT.id, 400),
+    shopItem(EQUIPMENT_ITEMS.LUCKY_CHARM.id, 180),
+
+    // Premium food
+    shopItem(FOOD_ITEMS.FEAST.id, 150),
+    shopItem(FOOD_ITEMS.CAKE.id, 100),
+    shopItem(FOOD_ITEMS.STEAK.id, 75),
+
+    // Premium drinks
+    shopItem(DRINK_ITEMS.MINERAL_WATER.id, 60),
+    shopItem(DRINK_ITEMS.SMOOTHIE.id, 50),
+
+    // Premium medicine
+    shopItem(MEDICINE_ITEMS.SUPER_POTION.id, 80),
+    shopItem(MEDICINE_ITEMS.ANTIDOTE.id, 40),
+
+    // Rare materials
+    shopItem(MATERIAL_ITEMS.ESSENCE.id, 200),
+    shopItem(MATERIAL_ITEMS.CRYSTAL.id, 80),
+  ],
+};
+
+/**
+ * Fern's Traveling Remedies - Herbalist's mobile shop.
+ * Sells healing items and herbs.
+ */
+export const fernTravelingShop: Shop = {
+  id: "fern_traveling_shop",
+  name: "Fern's Remedies",
+  sellMultiplier: 0.5,
+  items: [
+    // Medicine
+    shopItem(MEDICINE_ITEMS.POTION.id, 25),
+    shopItem(MEDICINE_ITEMS.SUPER_POTION.id, 70),
+    shopItem(MEDICINE_ITEMS.ANTIDOTE.id, 30),
+    shopItem(MEDICINE_ITEMS.BANDAGE.id, 12),
+
+    // Herbs and natural items
+    shopItem(MATERIAL_ITEMS.HERB.id, 8),
+    shopItem(FOOD_ITEMS.APPLE.id, 12),
+    shopItem(FOOD_ITEMS.MUSHROOM.id, 20),
+    shopItem(FOOD_ITEMS.HONEY.id, 45),
+
+    // Drinks
+    shopItem(DRINK_ITEMS.TEA.id, 28),
+    shopItem(DRINK_ITEMS.JUICE.id, 15),
+  ],
+};
+
+/**
+ * Shadow Market - Gloom's mysterious shop.
+ * Sells rare shadow materials and essence.
+ */
+export const shadowShop: Shop = {
+  id: "shadow_shop",
+  name: "Shadow Market",
+  sellMultiplier: 0.65,
+  items: [
+    // Rare materials
+    shopItem(MATERIAL_ITEMS.ESSENCE.id, 180),
+    shopItem(MATERIAL_ITEMS.CRYSTAL.id, 70),
+    shopItem(MATERIAL_ITEMS.MONSTER_FANG.id, 40),
+
+    // Equipment
+    shopItem(EQUIPMENT_ITEMS.HUNTERS_EYE.id, 450),
+
+    // High-tier medicine
+    shopItem(MEDICINE_ITEMS.SUPER_POTION.id, 75),
+    shopItem(MEDICINE_ITEMS.ANTIDOTE.id, 35),
+
+    // Premium food
+    shopItem(FOOD_ITEMS.FEAST.id, 140),
+    shopItem(FOOD_ITEMS.STEAK.id, 70),
+  ],
+};
+
+/**
  * All shops indexed by ID.
  */
 export const shops: Record<string, Shop> = {
   [willowbrookShop.id]: willowbrookShop,
+  [ironhavenShop.id]: ironhavenShop,
+  [tidecrestShop.id]: tidecrestShop,
+  [sanctuaryShop.id]: sanctuaryShop,
+  [fernTravelingShop.id]: fernTravelingShop,
+  [shadowShop.id]: shadowShop,
 };
 
 /**

--- a/src/game/data/tables/encounters.ts
+++ b/src/game/data/tables/encounters.ts
@@ -184,6 +184,235 @@ export const depthsEncounters: EncounterTable = {
 };
 
 /**
+ * Ancient Grove encounter table - mystical forest.
+ */
+export const groveEncounters: EncounterTable = {
+  id: "grove_encounters",
+  baseEncounterChance: 0.3,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.7,
+      speciesIds: [SPECIES.FLORABIT.id],
+      levelOffset: [0, 3],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.3,
+      speciesIds: [SPECIES.FLORABIT.id, SPECIES.SPARKFIN.id],
+      levelOffset: [1, 4],
+    },
+  ],
+};
+
+/**
+ * Mushroom Hollow encounter table - fungal caves.
+ */
+export const hollowEncounters: EncounterTable = {
+  id: "hollow_encounters",
+  baseEncounterChance: 0.4,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.5,
+      speciesIds: [SPECIES.FLORABIT.id, SPECIES.ROCKPUP.id],
+      levelOffset: [0, 4],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [SPECIES.SHADOWMOTH.id],
+      levelOffset: [2, 5],
+      minStage: GrowthStage.Child,
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.15,
+      speciesIds: [SPECIES.CORALITE.id],
+      levelOffset: [3, 6],
+    },
+  ],
+};
+
+/**
+ * Coral Reef encounter table - underwater zone.
+ */
+export const reefEncounters: EncounterTable = {
+  id: "reef_encounters",
+  baseEncounterChance: 0.4,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.6,
+      speciesIds: [SPECIES.CORALITE.id, SPECIES.SPARKFIN.id],
+      levelOffset: [0, 4],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.3,
+      speciesIds: [SPECIES.CORALITE.id],
+      levelOffset: [2, 6],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.1,
+      speciesIds: [SPECIES.SPARKFIN.id],
+      levelOffset: [4, 8],
+      minStage: GrowthStage.Child,
+    },
+  ],
+};
+
+/**
+ * Frozen Peaks encounter table - icy mountains.
+ */
+export const peaksEncounters: EncounterTable = {
+  id: "peaks_encounters",
+  baseEncounterChance: 0.45,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.5,
+      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.CORALITE.id],
+      levelOffset: [0, 5],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [SPECIES.ROCKPUP.id],
+      levelOffset: [3, 7],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.15,
+      speciesIds: [SPECIES.SHADOWMOTH.id],
+      levelOffset: [5, 10],
+      minStage: GrowthStage.Teen,
+    },
+  ],
+};
+
+/**
+ * Volcanic Caldera encounter table - magma zone.
+ */
+export const calderaEncounters: EncounterTable = {
+  id: "caldera_encounters",
+  baseEncounterChance: 0.55,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.5,
+      speciesIds: [SPECIES.EMBERFOX.id],
+      levelOffset: [0, 6],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [SPECIES.EMBERFOX.id, SPECIES.ROCKPUP.id],
+      levelOffset: [3, 8],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.15,
+      speciesIds: [SPECIES.EMBERFOX.id],
+      levelOffset: [6, 12],
+      minStage: GrowthStage.YoungAdult,
+    },
+  ],
+};
+
+/**
+ * Sunken Temple encounter table - underwater ruins.
+ */
+export const templeEncounters: EncounterTable = {
+  id: "temple_encounters",
+  baseEncounterChance: 0.5,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.45,
+      speciesIds: [SPECIES.CORALITE.id, SPECIES.SPARKFIN.id],
+      levelOffset: [0, 5],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [SPECIES.CORALITE.id, SPECIES.SHADOWMOTH.id],
+      levelOffset: [3, 8],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.2,
+      speciesIds: [SPECIES.SHADOWMOTH.id],
+      levelOffset: [5, 10],
+      minStage: GrowthStage.Teen,
+    },
+  ],
+};
+
+/**
+ * Glacial Cavern encounter table - ice dungeon.
+ */
+export const glacialEncounters: EncounterTable = {
+  id: "glacial_encounters",
+  baseEncounterChance: 0.55,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.4,
+      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.CORALITE.id],
+      levelOffset: [0, 6],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.4,
+      speciesIds: [SPECIES.SHADOWMOTH.id, SPECIES.ROCKPUP.id],
+      levelOffset: [4, 9],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.2,
+      speciesIds: [SPECIES.SHADOWMOTH.id],
+      levelOffset: [6, 12],
+      minStage: GrowthStage.YoungAdult,
+    },
+  ],
+};
+
+/**
+ * Celestial Spire encounter table - ultimate challenge.
+ */
+export const spireEncounters: EncounterTable = {
+  id: "spire_encounters",
+  baseEncounterChance: 0.65,
+  entries: [
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [SPECIES.SHADOWMOTH.id, SPECIES.EMBERFOX.id],
+      levelOffset: [0, 8],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.35,
+      speciesIds: [
+        SPECIES.SHADOWMOTH.id,
+        SPECIES.CORALITE.id,
+        SPECIES.ROCKPUP.id,
+      ],
+      levelOffset: [5, 12],
+    },
+    {
+      encounterType: EncounterType.WildBattle,
+      probability: 0.3,
+      speciesIds: [SPECIES.SHADOWMOTH.id, SPECIES.EMBERFOX.id],
+      levelOffset: [8, 15],
+      minStage: GrowthStage.Adult,
+    },
+  ],
+};
+
+/**
  * All encounter tables indexed by ID.
  */
 export const ENCOUNTER_TABLES: Record<string, EncounterTable> = {
@@ -193,6 +422,14 @@ export const ENCOUNTER_TABLES: Record<string, EncounterTable> = {
   highlands_encounters: highlandsEncounters,
   caves_encounters: cavesEncounters,
   depths_encounters: depthsEncounters,
+  grove_encounters: groveEncounters,
+  hollow_encounters: hollowEncounters,
+  reef_encounters: reefEncounters,
+  peaks_encounters: peaksEncounters,
+  caldera_encounters: calderaEncounters,
+  temple_encounters: templeEncounters,
+  glacial_encounters: glacialEncounters,
+  spire_encounters: spireEncounters,
 };
 
 /**

--- a/src/game/data/tables/encounters.ts
+++ b/src/game/data/tables/encounters.ts
@@ -199,7 +199,7 @@ export const groveEncounters: EncounterTable = {
     {
       encounterType: EncounterType.WildBattle,
       probability: 0.3,
-      speciesIds: [SPECIES.FLORABIT.id, SPECIES.SPARKFIN.id],
+      speciesIds: [SPECIES.FLORABIT.id, SPECIES.ROCKPUP.id],
       levelOffset: [1, 4],
     },
   ],
@@ -228,7 +228,7 @@ export const hollowEncounters: EncounterTable = {
     {
       encounterType: EncounterType.WildBattle,
       probability: 0.15,
-      speciesIds: [SPECIES.CORALITE.id],
+      speciesIds: [SPECIES.ROCKPUP.id],
       levelOffset: [3, 6],
     },
   ],
@@ -273,7 +273,7 @@ export const peaksEncounters: EncounterTable = {
     {
       encounterType: EncounterType.WildBattle,
       probability: 0.5,
-      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.CORALITE.id],
+      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.FLORABIT.id],
       levelOffset: [0, 5],
     },
     {
@@ -360,7 +360,7 @@ export const glacialEncounters: EncounterTable = {
     {
       encounterType: EncounterType.WildBattle,
       probability: 0.4,
-      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.CORALITE.id],
+      speciesIds: [SPECIES.ROCKPUP.id, SPECIES.FLORABIT.id],
       levelOffset: [0, 6],
     },
     {
@@ -397,7 +397,7 @@ export const spireEncounters: EncounterTable = {
       probability: 0.35,
       speciesIds: [
         SPECIES.SHADOWMOTH.id,
-        SPECIES.CORALITE.id,
+        SPECIES.EMBERFOX.id,
         SPECIES.ROCKPUP.id,
       ],
       levelOffset: [5, 12],

--- a/src/game/data/tables/forage.ts
+++ b/src/game/data/tables/forage.ts
@@ -375,6 +375,430 @@ export const DEPTHS_FORAGE: ForageTable = {
 };
 
 /**
+ * Ancient Grove forage table - mystical herbs and natural items.
+ */
+export const GROVE_FORAGE: ForageTable = {
+  id: "grove_forage",
+  baseDurationTicks: 3,
+  baseEnergyCost: 6,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.HERB.id,
+      baseDropRate: 0.45,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [2, 4],
+    },
+    {
+      itemId: MATERIAL_ITEMS.WOOD.id,
+      baseDropRate: 0.35,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 3],
+    },
+    {
+      itemId: FOOD_ITEMS.APPLE.id,
+      baseDropRate: 0.3,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 3],
+    },
+    {
+      itemId: DRINK_ITEMS.JUICE.id,
+      baseDropRate: 0.2,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MEDICINE_ITEMS.POTION.id,
+      baseDropRate: 0.12,
+      rarity: "uncommon",
+      minSkillLevel: 1,
+      quantity: [1, 2],
+    },
+    {
+      itemId: FOOD_ITEMS.HONEY.id,
+      baseDropRate: 0.08,
+      rarity: "uncommon",
+      minSkillLevel: 2,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Mushroom Hollow forage table - unique fungi and rare materials.
+ */
+export const HOLLOW_FORAGE: ForageTable = {
+  id: "hollow_forage",
+  baseDurationTicks: 3,
+  baseEnergyCost: 8,
+  entries: [
+    {
+      itemId: FOOD_ITEMS.MUSHROOM.id,
+      baseDropRate: 0.5,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [2, 4],
+    },
+    {
+      itemId: MATERIAL_ITEMS.FIBER.id,
+      baseDropRate: 0.3,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 3],
+    },
+    {
+      itemId: MATERIAL_ITEMS.HERB.id,
+      baseDropRate: 0.25,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MEDICINE_ITEMS.ANTIDOTE.id,
+      baseDropRate: 0.15,
+      rarity: "uncommon",
+      minSkillLevel: 1,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.08,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 1],
+    },
+    {
+      itemId: MATERIAL_ITEMS.ESSENCE.id,
+      baseDropRate: 0.03,
+      rarity: "epic",
+      minSkillLevel: 4,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Coral Reef forage table - aquatic treasures.
+ */
+export const REEF_FORAGE: ForageTable = {
+  id: "reef_forage",
+  baseDurationTicks: 4,
+  baseEnergyCost: 9,
+  entries: [
+    {
+      itemId: FOOD_ITEMS.FISH.id,
+      baseDropRate: 0.4,
+      rarity: "uncommon",
+      minSkillLevel: 0,
+      quantity: [1, 3],
+    },
+    {
+      itemId: DRINK_ITEMS.COCONUT.id,
+      baseDropRate: 0.25,
+      rarity: "uncommon",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.STONE.id,
+      baseDropRate: 0.3,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.FIBER.id,
+      baseDropRate: 0.2,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.1,
+      rarity: "rare",
+      minSkillLevel: 2,
+      quantity: [1, 1],
+    },
+    {
+      itemId: TOY_ITEMS.FRISBEE.id,
+      baseDropRate: 0.05,
+      rarity: "uncommon",
+      minSkillLevel: 2,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Frozen Peaks forage table - ice and hardy plants.
+ */
+export const PEAKS_FORAGE: ForageTable = {
+  id: "peaks_forage",
+  baseDurationTicks: 4,
+  baseEnergyCost: 12,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.STONE.id,
+      baseDropRate: 0.35,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [2, 4],
+    },
+    {
+      itemId: MATERIAL_ITEMS.IRON_ORE.id,
+      baseDropRate: 0.2,
+      rarity: "uncommon",
+      minSkillLevel: 2,
+      quantity: [1, 2],
+    },
+    {
+      itemId: DRINK_ITEMS.MINERAL_WATER.id,
+      baseDropRate: 0.15,
+      rarity: "rare",
+      minSkillLevel: 2,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.12,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MEDICINE_ITEMS.ANTIDOTE.id,
+      baseDropRate: 0.1,
+      rarity: "uncommon",
+      minSkillLevel: 1,
+      quantity: [1, 1],
+    },
+    {
+      itemId: FOOD_ITEMS.STEAK.id,
+      baseDropRate: 0.08,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Volcanic Caldera forage table - magma materials.
+ */
+export const CALDERA_FORAGE: ForageTable = {
+  id: "caldera_forage",
+  baseDurationTicks: 5,
+  baseEnergyCost: 15,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.STONE.id,
+      baseDropRate: 0.4,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [2, 5],
+    },
+    {
+      itemId: MATERIAL_ITEMS.IRON_ORE.id,
+      baseDropRate: 0.3,
+      rarity: "uncommon",
+      minSkillLevel: 2,
+      quantity: [2, 3],
+    },
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.15,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.MONSTER_FANG.id,
+      baseDropRate: 0.2,
+      rarity: "uncommon",
+      minSkillLevel: 2,
+      quantity: [1, 3],
+    },
+    {
+      itemId: MATERIAL_ITEMS.ESSENCE.id,
+      baseDropRate: 0.08,
+      rarity: "epic",
+      minSkillLevel: 5,
+      quantity: [1, 1],
+    },
+    {
+      itemId: EQUIPMENT_ITEMS.IRON_BANGLE.id,
+      baseDropRate: 0.02,
+      rarity: "rare",
+      minSkillLevel: 4,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Sunken Temple forage table - ancient treasures.
+ */
+export const TEMPLE_FORAGE: ForageTable = {
+  id: "temple_forage",
+  baseDurationTicks: 5,
+  baseEnergyCost: 12,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.STONE.id,
+      baseDropRate: 0.3,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [1, 3],
+    },
+    {
+      itemId: FOOD_ITEMS.FISH.id,
+      baseDropRate: 0.25,
+      rarity: "uncommon",
+      minSkillLevel: 0,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.2,
+      rarity: "rare",
+      minSkillLevel: 2,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.ESSENCE.id,
+      baseDropRate: 0.1,
+      rarity: "epic",
+      minSkillLevel: 4,
+      quantity: [1, 1],
+    },
+    {
+      itemId: EQUIPMENT_ITEMS.GUARDIANS_PENDANT.id,
+      baseDropRate: 0.03,
+      rarity: "rare",
+      minSkillLevel: 5,
+      quantity: [1, 1],
+    },
+    {
+      itemId: MEDICINE_ITEMS.SUPER_POTION.id,
+      baseDropRate: 0.12,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Glacial Cavern forage table - ice crystals and frozen materials.
+ */
+export const GLACIAL_FORAGE: ForageTable = {
+  id: "glacial_forage",
+  baseDurationTicks: 5,
+  baseEnergyCost: 14,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.35,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 3],
+    },
+    {
+      itemId: MATERIAL_ITEMS.STONE.id,
+      baseDropRate: 0.3,
+      rarity: "common",
+      minSkillLevel: 0,
+      quantity: [2, 4],
+    },
+    {
+      itemId: DRINK_ITEMS.MINERAL_WATER.id,
+      baseDropRate: 0.2,
+      rarity: "rare",
+      minSkillLevel: 2,
+      quantity: [1, 2],
+    },
+    {
+      itemId: MATERIAL_ITEMS.ESSENCE.id,
+      baseDropRate: 0.12,
+      rarity: "epic",
+      minSkillLevel: 5,
+      quantity: [1, 1],
+    },
+    {
+      itemId: MEDICINE_ITEMS.SUPER_POTION.id,
+      baseDropRate: 0.1,
+      rarity: "rare",
+      minSkillLevel: 3,
+      quantity: [1, 1],
+    },
+    {
+      itemId: EQUIPMENT_ITEMS.LUCKY_CHARM.id,
+      baseDropRate: 0.03,
+      rarity: "uncommon",
+      minSkillLevel: 4,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
+ * Celestial Spire forage table - ultimate rewards.
+ */
+export const SPIRE_FORAGE: ForageTable = {
+  id: "spire_forage",
+  baseDurationTicks: 6,
+  baseEnergyCost: 18,
+  entries: [
+    {
+      itemId: MATERIAL_ITEMS.CRYSTAL.id,
+      baseDropRate: 0.4,
+      rarity: "rare",
+      minSkillLevel: 4,
+      quantity: [2, 4],
+    },
+    {
+      itemId: MATERIAL_ITEMS.ESSENCE.id,
+      baseDropRate: 0.2,
+      rarity: "epic",
+      minSkillLevel: 5,
+      quantity: [1, 2],
+    },
+    {
+      itemId: FOOD_ITEMS.FEAST.id,
+      baseDropRate: 0.1,
+      rarity: "epic",
+      minSkillLevel: 5,
+      quantity: [1, 1],
+    },
+    {
+      itemId: MEDICINE_ITEMS.SUPER_POTION.id,
+      baseDropRate: 0.15,
+      rarity: "rare",
+      minSkillLevel: 4,
+      quantity: [1, 2],
+    },
+    {
+      itemId: EQUIPMENT_ITEMS.HUNTERS_EYE.id,
+      baseDropRate: 0.05,
+      rarity: "epic",
+      minSkillLevel: 6,
+      quantity: [1, 1],
+    },
+    {
+      itemId: EQUIPMENT_ITEMS.GUARDIANS_PENDANT.id,
+      baseDropRate: 0.05,
+      rarity: "rare",
+      minSkillLevel: 5,
+      quantity: [1, 1],
+    },
+  ],
+};
+
+/**
  * All forage tables indexed by ID.
  */
 export const FORAGE_TABLES: Record<string, ForageTable> = {
@@ -384,6 +808,14 @@ export const FORAGE_TABLES: Record<string, ForageTable> = {
   highlands_forage: HIGHLANDS_FORAGE,
   caves_forage: CAVES_FORAGE,
   depths_forage: DEPTHS_FORAGE,
+  grove_forage: GROVE_FORAGE,
+  hollow_forage: HOLLOW_FORAGE,
+  reef_forage: REEF_FORAGE,
+  peaks_forage: PEAKS_FORAGE,
+  caldera_forage: CALDERA_FORAGE,
+  temple_forage: TEMPLE_FORAGE,
+  glacial_forage: GLACIAL_FORAGE,
+  spire_forage: SPIRE_FORAGE,
 };
 
 /**


### PR DESCRIPTION
Added new locations:
- Towns: Ironhaven (mining), Tidecrest (fishing), Starfall Sanctuary (end-game)
- Wild Areas: Ancient Grove, Mushroom Hollow, Coral Reef, Frozen Peaks
- Dungeons: Volcanic Caldera, Sunken Temple, Glacial Cavern, Celestial Spire

Added 11 new NPCs with full dialogue trees:
- Ironhaven: Blacksmith Grom, Miner Delva
- Tidecrest: Fisher Marina, Captain Torrent
- Starfall Sanctuary: Sage Lumina, Archivist Echo
- Exploration NPCs: Herbalist Fern, Trainer Blaze, Dr. Frost, Explorer Coral, Shadow Gloom

Added new quests:
- 3 new main quests (Sunken Secrets, Frozen Ascent, Celestial Trial)
- 21 new side quests across all locations and NPCs

Added shops for new towns with appropriate inventory Added forage and encounter tables for all new locations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded world: 3 new towns and 8 new exploration zones with updated travel connections.
  * Added ~11 named NPCs with new dialogue trees; several now act as quest givers.
  * Added 3 new main quests and ~20 new side quests, integrated into quest chains.
  * New shops in towns offering equipment, materials, medicine, and local goods.
  * New encounter and forage tables for the added zones, increasing monsters and gatherables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->