### PR TITLE
fix: display item names and effects in quest and shop pages

### DIFF
--- a/src/components/quests/QuestDetail.tsx
+++ b/src/components/quests/QuestDetail.tsx
@@ -5,6 +5,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { areAllRequiredObjectivesComplete } from "@/game/core/quests";
+import { getItemById } from "@/game/data/items";
 import type { Quest, QuestProgress, QuestReward } from "@/game/types/quest";
 import { ObjectiveList } from "./ObjectiveList";
 
@@ -22,8 +23,11 @@ function formatReward(reward: QuestReward): string {
   switch (reward.type) {
     case "currency":
       return `${reward.quantity} coins`;
-    case "item":
-      return `${reward.quantity}x ${reward.target}`;
+    case "item": {
+      const item = getItemById(reward.target);
+      const itemName = item?.name ?? reward.target;
+      return `${reward.quantity}x ${itemName}`;
+    }
     case "xp":
       return `${reward.quantity} ${reward.target} XP`;
     case "unlock":

--- a/src/components/shop/ShopInventory.tsx
+++ b/src/components/shop/ShopInventory.tsx
@@ -2,8 +2,19 @@
  * Shop inventory component displaying items available for purchase.
  */
 
+import { toDisplay } from "@/game/types/common";
 import type { Rarity } from "@/game/types/constants";
 import type { Item } from "@/game/types/item";
+import {
+  isBattleItem,
+  isCleaningItem,
+  isDrinkItem,
+  isEquipmentItem,
+  isFoodItem,
+  isMaterialItem,
+  isMedicineItem,
+  isToyItem,
+} from "@/game/types/item";
 import type { ShopItem } from "@/game/types/shop";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +44,50 @@ function getRarityClass(rarity: Rarity): string {
     case "legendary":
       return "border-yellow-500";
   }
+}
+
+/**
+ * Get the effect text for an item based on its category.
+ */
+function getItemEffect(item: Item): string | null {
+  if (isFoodItem(item)) {
+    return `+${toDisplay(item.satietyRestore)} Satiety`;
+  }
+  if (isDrinkItem(item)) {
+    const parts = [`+${toDisplay(item.hydrationRestore)} Hydration`];
+    if (item.energyRestore) {
+      parts.push(`+${toDisplay(item.energyRestore)} Energy`);
+    }
+    return parts.join(", ");
+  }
+  if (isToyItem(item)) {
+    return `+${toDisplay(item.happinessRestore)} Happiness`;
+  }
+  if (isCleaningItem(item)) {
+    return `Removes ${item.poopRemoved} poop`;
+  }
+  if (isMedicineItem(item)) {
+    const parts: string[] = [];
+    if (item.isFullRestore) {
+      parts.push("Full HP restore");
+    } else if (item.healAmount) {
+      parts.push(`+${item.healAmount} HP`);
+    }
+    if (item.cureStatus && item.cureStatus.length > 0) {
+      parts.push(`Cures: ${item.cureStatus.join(", ")}`);
+    }
+    return parts.length > 0 ? parts.join(", ") : null;
+  }
+  if (isBattleItem(item)) {
+    return `+${item.modifierValue}% ${item.statModifier} (${item.duration} turns)`;
+  }
+  if (isEquipmentItem(item)) {
+    return item.effect;
+  }
+  if (isMaterialItem(item)) {
+    return "Crafting material";
+  }
+  return null;
 }
 
 /**
@@ -75,6 +130,11 @@ export function ShopInventory({
             <span className="text-xs font-medium truncate max-w-full">
               {itemDef.name}
             </span>
+            {getItemEffect(itemDef) && (
+              <span className="text-xs text-muted-foreground truncate max-w-full">
+                {getItemEffect(itemDef)}
+              </span>
+            )}
             <span
               className={cn(
                 "text-xs",

--- a/src/components/shop/ShopInventory.tsx
+++ b/src/components/shop/ShopInventory.tsx
@@ -2,7 +2,7 @@
  * Shop inventory component displaying items available for purchase.
  */
 
-import { toDisplay } from "@/game/types/common";
+import { toDisplay, toDisplayCare } from "@/game/types/common";
 import type { Rarity } from "@/game/types/constants";
 import type { Item } from "@/game/types/item";
 import {
@@ -47,21 +47,34 @@ function getRarityClass(rarity: Rarity): string {
 }
 
 /**
+ * Format a care stat value as a range if floor and ceil differ.
+ * Shows `+(min)~(max)` if there's a difference, otherwise just `+(value)`.
+ */
+function formatCareStatRange(microValue: number): string {
+  const min = toDisplay(microValue);
+  const max = toDisplayCare(microValue);
+  if (min === max) {
+    return `+${min}`;
+  }
+  return `+${min}~${max}`;
+}
+
+/**
  * Get the effect text for an item based on its category.
  */
 function getItemEffect(item: Item): string | null {
   if (isFoodItem(item)) {
-    return `+${toDisplay(item.satietyRestore)} Satiety`;
+    return `${formatCareStatRange(item.satietyRestore)} Satiety`;
   }
   if (isDrinkItem(item)) {
-    const parts = [`+${toDisplay(item.hydrationRestore)} Hydration`];
+    const parts = [`${formatCareStatRange(item.hydrationRestore)} Hydration`];
     if (item.energyRestore) {
       parts.push(`+${toDisplay(item.energyRestore)} Energy`);
     }
     return parts.join(", ");
   }
   if (isToyItem(item)) {
-    return `+${toDisplay(item.happinessRestore)} Happiness`;
+    return `${formatCareStatRange(item.happinessRestore)} Happiness`;
   }
   if (isCleaningItem(item)) {
     return `Removes ${item.poopRemoved} poop`;
@@ -112,6 +125,7 @@ export function ShopInventory({
       {items.map(({ shopItem, itemDef }) => {
         const isSelected = selectedItemId === shopItem.itemId;
         const canAfford = playerCoins >= shopItem.buyPrice;
+        const itemEffect = getItemEffect(itemDef);
 
         return (
           <button
@@ -130,9 +144,9 @@ export function ShopInventory({
             <span className="text-xs font-medium truncate max-w-full">
               {itemDef.name}
             </span>
-            {getItemEffect(itemDef) && (
+            {itemEffect && (
               <span className="text-xs text-muted-foreground truncate max-w-full">
-                {getItemEffect(itemDef)}
+                {itemEffect}
               </span>
             )}
             <span

--- a/src/components/shop/ShopInventory.tsx
+++ b/src/components/shop/ShopInventory.tsx
@@ -2,19 +2,8 @@
  * Shop inventory component displaying items available for purchase.
  */
 
-import { toDisplay, toDisplayCare } from "@/game/types/common";
 import type { Rarity } from "@/game/types/constants";
 import type { Item } from "@/game/types/item";
-import {
-  isBattleItem,
-  isCleaningItem,
-  isDrinkItem,
-  isEquipmentItem,
-  isFoodItem,
-  isMaterialItem,
-  isMedicineItem,
-  isToyItem,
-} from "@/game/types/item";
 import type { ShopItem } from "@/game/types/shop";
 import { cn } from "@/lib/utils";
 
@@ -47,63 +36,6 @@ function getRarityClass(rarity: Rarity): string {
 }
 
 /**
- * Format a care stat value as a range if floor and ceil differ.
- * Shows `+(min)~(max)` if there's a difference, otherwise just `+(value)`.
- */
-function formatCareStatRange(microValue: number): string {
-  const min = toDisplay(microValue);
-  const max = toDisplayCare(microValue);
-  if (min === max) {
-    return `+${min}`;
-  }
-  return `+${min}~${max}`;
-}
-
-/**
- * Get the effect text for an item based on its category.
- */
-function getItemEffect(item: Item): string | null {
-  if (isFoodItem(item)) {
-    return `${formatCareStatRange(item.satietyRestore)} Satiety`;
-  }
-  if (isDrinkItem(item)) {
-    const parts = [`${formatCareStatRange(item.hydrationRestore)} Hydration`];
-    if (item.energyRestore) {
-      parts.push(`+${toDisplay(item.energyRestore)} Energy`);
-    }
-    return parts.join(", ");
-  }
-  if (isToyItem(item)) {
-    return `${formatCareStatRange(item.happinessRestore)} Happiness`;
-  }
-  if (isCleaningItem(item)) {
-    return `Removes ${item.poopRemoved} poop`;
-  }
-  if (isMedicineItem(item)) {
-    const parts: string[] = [];
-    if (item.isFullRestore) {
-      parts.push("Full HP restore");
-    } else if (item.healAmount) {
-      parts.push(`+${item.healAmount} HP`);
-    }
-    if (item.cureStatus && item.cureStatus.length > 0) {
-      parts.push(`Cures: ${item.cureStatus.join(", ")}`);
-    }
-    return parts.length > 0 ? parts.join(", ") : null;
-  }
-  if (isBattleItem(item)) {
-    return `+${item.modifierValue}% ${item.statModifier} (${item.duration} turns)`;
-  }
-  if (isEquipmentItem(item)) {
-    return item.effect;
-  }
-  if (isMaterialItem(item)) {
-    return "Crafting material";
-  }
-  return null;
-}
-
-/**
  * Displays a grid of items available for purchase in a shop.
  */
 export function ShopInventory({
@@ -125,7 +57,6 @@ export function ShopInventory({
       {items.map(({ shopItem, itemDef }) => {
         const isSelected = selectedItemId === shopItem.itemId;
         const canAfford = playerCoins >= shopItem.buyPrice;
-        const itemEffect = getItemEffect(itemDef);
 
         return (
           <button
@@ -144,11 +75,6 @@ export function ShopInventory({
             <span className="text-xs font-medium truncate max-w-full">
               {itemDef.name}
             </span>
-            {itemEffect && (
-              <span className="text-xs text-muted-foreground truncate max-w-full">
-                {itemEffect}
-              </span>
-            )}
             <span
               className={cn(
                 "text-xs",


### PR DESCRIPTION
- Quest rewards now show item names instead of internal IDs
- Shop inventory now displays item effects (stat boosts, healing, etc.)

Players can now make informed decisions when viewing rewards and shopping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quest rewards now display resolved item names for improved clarity.
  * Shop items show concise effect descriptions beneath names, including formatted care‑stat ranges where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->