### PR TITLE
fix: improve battle screen UX for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,9 +56,12 @@ function GameContent({
   } | null>(null);
 
   // Redirect to exploration if battle tab is accessed without battle info
+  // Redirect back to battle if user navigates away while battle is ongoing
   useEffect(() => {
     if (activeTab === "battle" && !battleInfo) {
       onTabChange("exploration");
+    } else if (battleInfo && activeTab !== "battle") {
+      onTabChange("battle");
     }
   }, [activeTab, battleInfo, onTabChange]);
 

--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -31,7 +31,7 @@ export function BattleArena({
   return (
     <div
       className={cn(
-        "flex flex-col md:flex-row md:items-center md:justify-around gap-8 md:gap-4 p-4",
+        "flex flex-col md:flex-row md:items-center md:justify-around gap-2 md:gap-4 p-2 md:p-4",
         className,
       )}
     >

--- a/src/components/battle/BattleLog.tsx
+++ b/src/components/battle/BattleLog.tsx
@@ -40,7 +40,10 @@ export function BattleLog({ entries, maxEntries = 8 }: BattleLogProps) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div ref={scrollRef} className="h-32 overflow-y-auto space-y-1 text-sm">
+        <div
+          ref={scrollRef}
+          className="h-20 md:h-32 overflow-y-auto space-y-1 text-sm"
+        >
           {visibleEntries.map((entry, index) => (
             <LogEntry key={`${entry.turn}-${index}`} entry={entry} />
           ))}

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -164,16 +164,18 @@ export function BattleScreen({
   const isPlayerTurn = battleState.phase === BattlePhase.PlayerTurn;
 
   return (
-    <div className="flex flex-col gap-4 pb-4">
+    <div className="flex flex-col gap-2 md:gap-4 pb-4 min-h-[calc(100dvh-8rem)]">
       {/* Turn indicator */}
       <Card>
-        <CardContent className="py-2 px-4 flex items-center justify-between">
+        <CardContent className="py-1.5 md:py-2 px-3 md:px-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-lg">⚔️</span>
-            <span className="font-medium">Turn {battleState.turn}</span>
+            <span className="text-base md:text-lg">⚔️</span>
+            <span className="font-medium text-sm md:text-base">
+              Turn {battleState.turn}
+            </span>
           </div>
           <span
-            className={`text-sm ${isPlayerTurn ? "text-green-600" : "text-red-600"}`}
+            className={`text-xs md:text-sm ${isPlayerTurn ? "text-green-600" : "text-red-600"}`}
           >
             {isPlayerTurn ? "Your turn" : "Enemy's turn..."}
           </span>
@@ -193,26 +195,32 @@ export function BattleScreen({
       {/* Battle log */}
       <BattleLog entries={battleState.log} />
 
-      {/* Move selection (player's turn only) */}
-      {isPlayerTurn && (
-        <MoveSelect
-          combatant={battleState.player}
-          onSelectMove={handleSelectMove}
-          disabled={isProcessing}
-        />
-      )}
+      {/* Spacer to push actions to bottom on mobile */}
+      <div className="flex-1" />
 
-      {/* Flee button */}
-      {onFlee && isPlayerTurn && (
-        <Button
-          variant="outline"
-          onClick={onFlee}
-          disabled={isProcessing}
-          className="w-full"
-        >
-          🏃 Flee
-        </Button>
-      )}
+      {/* Move selection and flee button - sticky on mobile */}
+      <div className="sticky bottom-20 bg-background pt-2 space-y-2">
+        {/* Move selection (player's turn only) */}
+        {isPlayerTurn && (
+          <MoveSelect
+            combatant={battleState.player}
+            onSelectMove={handleSelectMove}
+            disabled={isProcessing}
+          />
+        )}
+
+        {/* Flee button */}
+        {onFlee && isPlayerTurn && (
+          <Button
+            variant="outline"
+            onClick={onFlee}
+            disabled={isProcessing}
+            className="w-full"
+          >
+            🏃 Flee
+          </Button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Reduce spacing in BattleArena for compact mobile layout
- Make BattleLog shorter on mobile (h-20 vs h-32)
- Add sticky move selection at bottom of viewport
- Redirect user back to battle when navigating away during combat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic battle continuity enforcement to redirect users between battle and exploration states appropriately.

* **Style**
  * Improved responsive mobile layout with adjusted spacing and padding.
  * Battle log height now adapts to screen size.
  * Action buttons repositioned to sticky bottom area for better mobile usability.
  * Turn indicator styling optimized for mobile and desktop views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->