### PR TITLE
fix: optimize battle screen for mobile and persist battle on navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,9 +56,12 @@ function GameContent({
   } | null>(null);
 
   // Redirect to exploration if battle tab is accessed without battle info
+  // Also redirect back to battle if navigating to exploration during an active battle
   useEffect(() => {
     if (activeTab === "battle" && !battleInfo) {
       onTabChange("exploration");
+    } else if (activeTab === "exploration" && battleInfo) {
+      onTabChange("battle");
     }
   }, [activeTab, battleInfo, onTabChange]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,10 @@ import { Button } from "@/components/ui/button";
 import { GameProvider } from "@/game/context/GameContext";
 import {
   type BattleRewards,
+  type BattleState,
   createCombatantFromPet,
   createWildCombatant,
+  initializeBattle,
 } from "@/game/core/battle/battle";
 import { updateQuestProgress } from "@/game/core/quests/quests";
 import { useGameState } from "@/game/hooks/useGameState";
@@ -49,21 +51,22 @@ function GameContent({
   const { state, isLoading, loadError, offlineReport, notification, actions } =
     useGameState();
 
-  // Battle state
-  const [battleInfo, setBattleInfo] = useState<{
+  // Battle state - stores full battle state for persistence across navigation
+  const [activeBattle, setActiveBattle] = useState<{
     enemySpeciesId: string;
     enemyLevel: number;
+    battleState: BattleState;
   } | null>(null);
 
   // Redirect to exploration if battle tab is accessed without battle info
   // Also redirect back to battle if navigating to exploration during an active battle
   useEffect(() => {
-    if (activeTab === "battle" && !battleInfo) {
+    if (activeTab === "battle" && !activeBattle) {
       onTabChange("exploration");
-    } else if (activeTab === "exploration" && battleInfo) {
+    } else if (activeTab === "exploration" && activeBattle) {
       onTabChange("battle");
     }
-  }, [activeTab, battleInfo, onTabChange]);
+  }, [activeTab, activeBattle, onTabChange]);
 
   // Show loading state
   if (isLoading) {
@@ -91,63 +94,104 @@ function GameContent({
 
   // Handle starting a battle
   const handleStartBattle = (enemySpeciesId: string, enemyLevel: number) => {
-    setBattleInfo({ enemySpeciesId, enemyLevel });
+    if (!state?.pet) return;
+
+    // Set pet activity state to Battling
+    actions.updateState((prev) => ({
+      ...prev,
+      pet: prev.pet
+        ? { ...prev.pet, activityState: "battling" as const }
+        : prev.pet,
+    }));
+
+    // Initialize battle state
+    const playerCombatant = createCombatantFromPet(state.pet, true);
+    const enemyCombatant = createWildCombatant(enemySpeciesId, enemyLevel);
+    const battleState = initializeBattle(playerCombatant, enemyCombatant);
+
+    setActiveBattle({ enemySpeciesId, enemyLevel, battleState });
     onTabChange("battle");
+  };
+
+  // Handle battle state changes (from BattleScreen)
+  const handleBattleStateChange = (newBattleState: BattleState) => {
+    setActiveBattle((prev) =>
+      prev ? { ...prev, battleState: newBattleState } : null,
+    );
   };
 
   // Handle battle end
   const handleBattleEnd = (victory: boolean, rewards: BattleRewards) => {
-    if (victory && state) {
-      // Award coins and update quest progress for Defeat objectives
-      actions.updateState((prev) => {
-        let newState = {
-          ...prev,
-          player: {
-            ...prev.player,
-            currency: {
-              ...prev.player.currency,
-              coins: prev.player.currency.coins + rewards.coins,
-            },
+    // Reset pet activity state and apply rewards
+    actions.updateState((prev) => {
+      // First reset activity state
+      const stateWithIdlePet = {
+        ...prev,
+        pet: prev.pet
+          ? { ...prev.pet, activityState: "idle" as const }
+          : prev.pet,
+      };
+
+      if (!victory) {
+        return stateWithIdlePet;
+      }
+
+      // Award coins
+      const stateWithCoins = {
+        ...stateWithIdlePet,
+        player: {
+          ...stateWithIdlePet.player,
+          currency: {
+            ...stateWithIdlePet.player.currency,
+            coins: stateWithIdlePet.player.currency.coins + rewards.coins,
           },
-        };
+        },
+      };
 
-        // Update quest progress for defeating any enemy
-        newState = updateQuestProgress(newState, ObjectiveType.Defeat, "any");
+      // Update quest progress for defeating any enemy
+      let finalState = updateQuestProgress(
+        stateWithCoins,
+        ObjectiveType.Defeat,
+        "any",
+      );
 
-        // Also update for the specific species if battleInfo is available
-        if (battleInfo?.enemySpeciesId) {
-          newState = updateQuestProgress(
-            newState,
-            ObjectiveType.Defeat,
-            battleInfo.enemySpeciesId,
-          );
-        }
+      // Also update for the specific species if activeBattle is available
+      if (activeBattle?.enemySpeciesId) {
+        finalState = updateQuestProgress(
+          finalState,
+          ObjectiveType.Defeat,
+          activeBattle.enemySpeciesId,
+        );
+      }
 
-        return newState;
-      });
-    }
-    setBattleInfo(null);
+      return finalState;
+    });
+
+    setActiveBattle(null);
     onTabChange("exploration");
   };
 
   // Handle fleeing from battle
   const handleFlee = () => {
-    setBattleInfo(null);
+    // Reset pet activity state
+    actions.updateState((prev) => ({
+      ...prev,
+      pet: prev.pet
+        ? { ...prev.pet, activityState: "idle" as const }
+        : prev.pet,
+    }));
+
+    setActiveBattle(null);
     onTabChange("exploration");
   };
 
   const renderScreen = () => {
     // Battle screen (special case - not in normal navigation)
-    if (activeTab === "battle" && battleInfo && state?.pet) {
-      const playerCombatant = createCombatantFromPet(state.pet, true);
-      const enemyCombatant = createWildCombatant(
-        battleInfo.enemySpeciesId,
-        battleInfo.enemyLevel,
-      );
+    if (activeTab === "battle" && activeBattle) {
       return (
         <BattleScreen
-          playerCombatant={playerCombatant}
-          enemyCombatant={enemyCombatant}
+          battleState={activeBattle.battleState}
+          onBattleStateChange={handleBattleStateChange}
           onBattleEnd={handleBattleEnd}
           onFlee={handleFlee}
         />
@@ -179,9 +223,12 @@ function GameContent({
     }
   };
 
+  // Check if we're in battle mode (for layout adjustments)
+  const isBattleActive = activeTab === "battle" && activeBattle !== null;
+
   return (
     <Layout activeTab={activeTab} onTabChange={onTabChange}>
-      <div className="pb-20">{renderScreen()}</div>
+      <div className={isBattleActive ? "" : "pb-20"}>{renderScreen()}</div>
       {offlineReport && (
         <OfflineReport
           report={offlineReport}

--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -31,34 +31,32 @@ export function BattleArena({
   return (
     <div
       className={cn(
-        "flex flex-col md:flex-row md:items-center md:justify-around gap-4 md:gap-4 p-2 sm:p-4",
+        "flex flex-row items-center justify-around gap-2 sm:gap-4 p-1 sm:p-4",
         className,
       )}
     >
-      {/* Enemy (top on mobile, right on desktop) */}
-      <div className="flex justify-end md:order-3">
-        <PetBattleCard
-          combatant={enemy}
-          position="enemy"
-          isAttacking={enemyAttacking}
-          isHit={enemyHit}
-        />
-      </div>
+      {/* Player (left) */}
+      <PetBattleCard
+        combatant={player}
+        position="player"
+        isAttacking={playerAttacking}
+        isHit={playerHit}
+      />
 
       {/* VS indicator */}
-      <div className="flex justify-center md:order-2">
-        <span className="text-2xl font-bold text-muted-foreground">⚔️</span>
+      <div className="flex justify-center shrink-0">
+        <span className="text-lg sm:text-2xl font-bold text-muted-foreground">
+          ⚔️
+        </span>
       </div>
 
-      {/* Player (bottom on mobile, left on desktop) */}
-      <div className="flex justify-start md:order-1">
-        <PetBattleCard
-          combatant={player}
-          position="player"
-          isAttacking={playerAttacking}
-          isHit={playerHit}
-        />
-      </div>
+      {/* Enemy (right) */}
+      <PetBattleCard
+        combatant={enemy}
+        position="enemy"
+        isAttacking={enemyAttacking}
+        isHit={enemyHit}
+      />
     </div>
   );
 }

--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -31,7 +31,7 @@ export function BattleArena({
   return (
     <div
       className={cn(
-        "flex flex-col md:flex-row md:items-center md:justify-around gap-8 md:gap-4 p-4",
+        "flex flex-col md:flex-row md:items-center md:justify-around gap-4 md:gap-4 p-2 sm:p-4",
         className,
       )}
     >

--- a/src/components/battle/BattleLog.tsx
+++ b/src/components/battle/BattleLog.tsx
@@ -39,8 +39,11 @@ export function BattleLog({ entries, maxEntries = 8 }: BattleLogProps) {
           Battle Log
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <div ref={scrollRef} className="h-32 overflow-y-auto space-y-1 text-sm">
+      <CardContent className="py-2 sm:py-4">
+        <div
+          ref={scrollRef}
+          className="h-16 sm:h-32 overflow-y-auto space-y-1 text-sm"
+        >
           {visibleEntries.map((entry, index) => (
             <LogEntry key={`${entry.turn}-${index}`} entry={entry} />
           ))}

--- a/src/components/battle/BattleLog.tsx
+++ b/src/components/battle/BattleLog.tsx
@@ -33,16 +33,16 @@ export function BattleLog({ entries, maxEntries = 8 }: BattleLogProps) {
 
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base flex items-center gap-2">
-          <span>📜</span>
-          Battle Log
+      <CardHeader className="py-1.5 sm:pb-2">
+        <CardTitle className="text-sm sm:text-base flex items-center gap-1.5 sm:gap-2">
+          <span className="text-sm sm:text-base">📜</span>
+          Log
         </CardTitle>
       </CardHeader>
-      <CardContent className="py-2 sm:py-4">
+      <CardContent className="py-1.5 sm:py-4">
         <div
           ref={scrollRef}
-          className="h-16 sm:h-32 overflow-y-auto space-y-1 text-sm"
+          className="h-12 sm:h-32 overflow-y-auto space-y-0.5 sm:space-y-1 text-xs sm:text-sm"
         >
           {visibleEntries.map((entry, index) => (
             <LogEntry key={`${entry.turn}-${index}`} entry={entry} />
@@ -74,9 +74,11 @@ function LogEntry({ entry }: LogEntryProps) {
   };
 
   return (
-    <div className={cn("leading-snug", getEntryStyle(entry.type))}>
+    <div
+      className={cn("leading-tight sm:leading-snug", getEntryStyle(entry.type))}
+    >
       {entry.turn > 0 && (
-        <span className="text-muted-foreground text-xs mr-1">
+        <span className="text-muted-foreground text-[10px] sm:text-xs mr-0.5 sm:mr-1">
           [{entry.turn}]
         </span>
       )}

--- a/src/components/battle/MoveSelect.tsx
+++ b/src/components/battle/MoveSelect.tsx
@@ -37,10 +37,10 @@ export function MoveSelect({
 }: MoveSelectProps) {
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base">Select Move</CardTitle>
+      <CardHeader className="py-2 sm:pb-2">
+        <CardTitle className="text-sm sm:text-base">Select Move</CardTitle>
       </CardHeader>
-      <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <CardContent className="grid grid-cols-2 gap-1.5 sm:gap-2 py-2 sm:py-4">
         {combatant.moveSlots.map((slot) => (
           <MoveButton
             key={slot.move.id}
@@ -71,7 +71,7 @@ function MoveButton({ slot, combatant, onSelect, disabled }: MoveButtonProps) {
     <Button
       variant="outline"
       className={cn(
-        "h-auto py-2 px-3 flex flex-col items-start text-left gap-1",
+        "h-auto py-1.5 px-2 sm:py-2 sm:px-3 flex flex-col items-start text-left gap-0.5 sm:gap-1",
         !canUse && "opacity-50",
       )}
       onClick={onSelect}
@@ -79,16 +79,20 @@ function MoveButton({ slot, combatant, onSelect, disabled }: MoveButtonProps) {
       title={reason}
     >
       <div className="flex items-center gap-1 w-full">
-        <span className="text-sm">{getDamageTypeEmoji(move.damageType)}</span>
-        <span className="font-medium text-sm flex-1">{move.name}</span>
+        <span className="text-xs sm:text-sm">
+          {getDamageTypeEmoji(move.damageType)}
+        </span>
+        <span className="font-medium text-xs sm:text-sm flex-1 truncate">
+          {move.name}
+        </span>
         {currentCooldown > 0 && (
-          <span className="text-xs text-muted-foreground">
+          <span className="text-[10px] sm:text-xs text-muted-foreground">
             ({currentCooldown})
           </span>
         )}
       </div>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground w-full">
-        {move.power > 0 && <span>Power: {move.power.toFixed(1)}</span>}
+      <div className="flex items-center gap-1 sm:gap-2 text-[10px] sm:text-xs text-muted-foreground w-full">
+        {move.power > 0 && <span>Pwr: {move.power.toFixed(1)}</span>}
         {move.staminaCost !== 0 && (
           <span
             className={cn(

--- a/src/components/battle/PetBattleCard.tsx
+++ b/src/components/battle/PetBattleCard.tsx
@@ -51,30 +51,34 @@ export function PetBattleCard({
   return (
     <Card
       className={cn(
-        "w-full max-w-48 transition-all duration-200",
+        "w-full max-w-40 sm:max-w-48 transition-all duration-200",
         position === "enemy" ? "bg-red-50 dark:bg-red-950/20" : "",
         isAttacking && "animate-battle-attack",
         isHit && "animate-battle-hit",
       )}
     >
-      <CardContent className="pt-4 pb-3 px-4">
+      <CardContent className="pt-2 pb-2 px-2 sm:pt-4 sm:pb-3 sm:px-4">
         {/* Name and emoji */}
-        <div className="flex items-center gap-2 mb-2">
-          <span className={cn("text-2xl", isHit && "animate-pet-shake")}>
+        <div className="flex items-center gap-1.5 sm:gap-2 mb-1.5 sm:mb-2">
+          <span
+            className={cn("text-xl sm:text-2xl", isHit && "animate-pet-shake")}
+          >
             {emoji}
           </span>
-          <span className="font-semibold text-sm truncate">{name}</span>
+          <span className="font-semibold text-xs sm:text-sm truncate">
+            {name}
+          </span>
         </div>
 
         {/* HP Bar */}
-        <div className="mb-2">
-          <div className="flex justify-between text-xs mb-1">
+        <div className="mb-1.5 sm:mb-2">
+          <div className="flex justify-between text-[10px] sm:text-xs mb-0.5 sm:mb-1">
             <span>HP</span>
             <span>
               {derivedStats.currentHealth}/{derivedStats.maxHealth}
             </span>
           </div>
-          <div className="h-3 bg-muted rounded-full overflow-hidden">
+          <div className="h-2 sm:h-3 bg-muted rounded-full overflow-hidden">
             <div
               className={cn(
                 "h-full transition-all duration-300",
@@ -90,14 +94,14 @@ export function PetBattleCard({
         </div>
 
         {/* Stamina Bar */}
-        <div className="mb-2">
-          <div className="flex justify-between text-xs mb-1">
-            <span>Stamina</span>
+        <div className="mb-1 sm:mb-2">
+          <div className="flex justify-between text-[10px] sm:text-xs mb-0.5 sm:mb-1">
+            <span>SP</span>
             <span>
               {derivedStats.currentStamina}/{derivedStats.maxStamina}
             </span>
           </div>
-          <div className="h-2 bg-muted rounded-full overflow-hidden">
+          <div className="h-1.5 sm:h-2 bg-muted rounded-full overflow-hidden">
             <div
               className="h-full bg-blue-500 transition-all duration-300"
               style={{ width: `${staminaPercent}%` }}
@@ -107,29 +111,29 @@ export function PetBattleCard({
 
         {/* Status Effects */}
         {statusEffects.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
+          <div className="flex flex-wrap gap-0.5 sm:gap-1 mt-1 sm:mt-2">
             {buffs.map((effect) => (
               <span
                 key={effect.id}
-                className="text-xs px-1.5 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300"
+                className="text-[10px] sm:text-xs px-1 sm:px-1.5 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300"
                 title={`${effect.name} (${effect.duration} turns)`}
               >
-                ↑ {effect.stat?.slice(0, 3)}
+                ↑{effect.stat?.slice(0, 3)}
               </span>
             ))}
             {debuffs.map((effect) => (
               <span
                 key={effect.id}
-                className="text-xs px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+                className="text-[10px] sm:text-xs px-1 sm:px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
                 title={`${effect.name} (${effect.duration} turns)`}
               >
-                ↓ {effect.stat?.slice(0, 3) ?? "DoT"}
+                ↓{effect.stat?.slice(0, 3) ?? "DoT"}
               </span>
             ))}
             {other.map((effect) => (
               <span
                 key={effect.id}
-                className="text-xs px-1.5 py-0.5 rounded bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                className="text-[10px] sm:text-xs px-1 sm:px-1.5 py-0.5 rounded bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
                 title={`${effect.name} (${effect.duration} turns)`}
               >
                 ⚡

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -164,55 +164,63 @@ export function BattleScreen({
   const isPlayerTurn = battleState.phase === BattlePhase.PlayerTurn;
 
   return (
-    <div className="flex flex-col gap-4 pb-4">
-      {/* Turn indicator */}
-      <Card>
-        <CardContent className="py-2 px-4 flex items-center justify-between">
+    <div className="flex flex-col h-[calc(100dvh-8rem)] sm:h-auto sm:gap-4 sm:pb-4">
+      {/* Turn indicator - compact */}
+      <Card className="shrink-0">
+        <CardContent className="py-1.5 px-3 sm:py-2 sm:px-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-lg">⚔️</span>
-            <span className="font-medium">Turn {battleState.turn}</span>
+            <span className="text-base sm:text-lg">⚔️</span>
+            <span className="font-medium text-sm sm:text-base">
+              Turn {battleState.turn}
+            </span>
           </div>
           <span
-            className={`text-sm ${isPlayerTurn ? "text-green-600" : "text-red-600"}`}
+            className={`text-xs sm:text-sm ${isPlayerTurn ? "text-green-600" : "text-red-600"}`}
           >
             {isPlayerTurn ? "Your turn" : "Enemy's turn..."}
           </span>
         </CardContent>
       </Card>
 
-      {/* Battle arena */}
-      <BattleArena
-        player={battleState.player}
-        enemy={battleState.enemy}
-        playerAttacking={animationState.playerAttacking}
-        enemyAttacking={animationState.enemyAttacking}
-        playerHit={animationState.playerHit}
-        enemyHit={animationState.enemyHit}
-      />
-
-      {/* Battle log */}
-      <BattleLog entries={battleState.log} />
-
-      {/* Move selection (player's turn only) */}
-      {isPlayerTurn && (
-        <MoveSelect
-          combatant={battleState.player}
-          onSelectMove={handleSelectMove}
-          disabled={isProcessing}
+      {/* Scrollable middle section: Arena + Log */}
+      <div className="flex-1 overflow-y-auto min-h-0 space-y-2 sm:space-y-4 py-2 sm:py-0">
+        {/* Battle arena */}
+        <BattleArena
+          player={battleState.player}
+          enemy={battleState.enemy}
+          playerAttacking={animationState.playerAttacking}
+          enemyAttacking={animationState.enemyAttacking}
+          playerHit={animationState.playerHit}
+          enemyHit={animationState.enemyHit}
         />
-      )}
 
-      {/* Flee button */}
-      {onFlee && isPlayerTurn && (
-        <Button
-          variant="outline"
-          onClick={onFlee}
-          disabled={isProcessing}
-          className="w-full"
-        >
-          🏃 Flee
-        </Button>
-      )}
+        {/* Battle log */}
+        <BattleLog entries={battleState.log} />
+      </div>
+
+      {/* Fixed bottom: Move selection + Flee */}
+      <div className="shrink-0 space-y-2 pt-2 bg-background">
+        {/* Move selection (player's turn only) */}
+        {isPlayerTurn && (
+          <MoveSelect
+            combatant={battleState.player}
+            onSelectMove={handleSelectMove}
+            disabled={isProcessing}
+          />
+        )}
+
+        {/* Flee button */}
+        {onFlee && isPlayerTurn && (
+          <Button
+            variant="outline"
+            onClick={onFlee}
+            disabled={isProcessing}
+            className="w-full"
+          >
+            🏃 Flee
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -2,6 +2,7 @@
  * Game state types for overall game and player state.
  */
 
+import type { BattleState } from "@/game/core/battle/battle";
 import type { ExplorationResult, TrainingResult } from "./activity";
 import type { Tick, Timestamp } from "./common";
 import type { Pet } from "./pet";
@@ -10,14 +11,15 @@ import { createInitialSkills, type PlayerSkills } from "./skill";
 
 /**
  * Active battle state stored in game state.
+ * Includes the full battle state for persistence across page refreshes.
  */
 export interface ActiveBattle {
   /** Enemy species ID */
   enemySpeciesId: string;
   /** Enemy level */
   enemyLevel: number;
-  /** Location where battle started */
-  locationId: string;
+  /** Full battle state for resuming battle */
+  battleState: BattleState;
 }
 
 /**
@@ -86,7 +88,7 @@ export interface GameState {
   lastTrainingResult?: TrainingResult & { facilityName: string };
   /**
    * Active battle (if in combat).
-   * Reserved for future use: currently, battle state is managed locally in BattleScreen.
+   * Persisted to allow resuming battle after page refresh.
    */
   activeBattle?: ActiveBattle;
   /**


### PR DESCRIPTION
- Restructure BattleScreen layout using fixed viewport height for mobile
- Make moves and controls fixed at bottom so battle UI stays visible
- Compact spacing in BattleArena, BattleLog, and MoveSelect for mobile
- Auto-redirect to battle screen when navigating to exploration during active battle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent battle state with resume after refresh and automatic tab redirects when entering/exiting battles.
  * Improved battle lifecycle: start, turn updates, rewards/quest progress, flee handling, and end-of-battle cleanup.

* **UI/UX Improvements**
  * Redesigned battle screen: horizontal arena ordering (player/Vs/enemy), fixed controls, compact turn indicator.
  * Condensed, responsive move cards, pet cards, and battle log for better small-screen readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->