### PR TITLE
Fix battle win advancing quest progress by 2 instead of 1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,21 +155,15 @@ function GameContent({
         },
       };
 
-      // Update quest progress for defeating any enemy
-      let finalState = updateQuestProgress(
+      // Update quest progress for defeating the enemy
+      // Use specific species ID if available, otherwise use "any"
+      // Note: objectives with target "any" will match any species ID
+      const defeatedTarget = prev.activeBattle?.enemySpeciesId ?? "any";
+      const finalState = updateQuestProgress(
         stateWithCoins,
         ObjectiveType.Defeat,
-        "any",
+        defeatedTarget,
       );
-
-      // Also update for the specific species if activeBattle is available
-      if (prev.activeBattle?.enemySpeciesId) {
-        finalState = updateQuestProgress(
-          finalState,
-          ObjectiveType.Defeat,
-          prev.activeBattle.enemySpeciesId,
-        );
-      }
 
       return finalState;
     });


### PR DESCRIPTION
The issue was that updateQuestProgress was called twice on battle victory:
1. Once with target 'any'
2. Once with the specific enemy species ID

Since findMatchingObjectives matches objectives when obj.target === 'any', both calls would match and update objectives with target 'any', resulting in double progress increment.

Fixed by using only a single updateQuestProgress call with the specific species ID (falling back to 'any' if unavailable), which will still match objectives with target 'any'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved quest progress tracking for defeating enemies to ensure more consistent and reliable objective updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->