### PR TITLE
Refactor: Notification logic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,9 +20,11 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.7",
+        "@testing-library/react": "^16.3.0",
         "@types/bun": "latest",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "happy-dom": "^20.0.11",
         "tailwindcss": "^4.1.11",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
@@ -30,6 +32,12 @@
     },
   },
   "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.3.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.7", "@biomejs/cli-darwin-x64": "2.3.7", "@biomejs/cli-linux-arm64": "2.3.7", "@biomejs/cli-linux-arm64-musl": "2.3.7", "@biomejs/cli-linux-x64": "2.3.7", "@biomejs/cli-linux-x64-musl": "2.3.7", "@biomejs/cli-win32-arm64": "2.3.7", "@biomejs/cli-win32-x64": "2.3.7" }, "bin": { "biome": "bin/biome" } }, "sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA=="],
@@ -140,15 +148,29 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
 
-    "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+    "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "bun": ["bun@1.3.3", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.3", "@oven/bun-darwin-x64": "1.3.3", "@oven/bun-darwin-x64-baseline": "1.3.3", "@oven/bun-linux-aarch64": "1.3.3", "@oven/bun-linux-aarch64-musl": "1.3.3", "@oven/bun-linux-x64": "1.3.3", "@oven/bun-linux-x64-baseline": "1.3.3", "@oven/bun-linux-x64-musl": "1.3.3", "@oven/bun-linux-x64-musl-baseline": "1.3.3", "@oven/bun-windows-x64": "1.3.3", "@oven/bun-windows-x64-baseline": "1.3.3" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-2hJ4ocTZ634/Ptph4lysvO+LbbRZq8fzRvMwX0/CqaLBxrF2UB5D1LdMB8qGcdtCer4/VR9Bx5ORub0yn+yzmw=="],
 
@@ -162,15 +184,31 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
+    "happy-dom": ["happy-dom@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "lucide-react": ["lucide-react@0.545.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
 
     "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.1", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA=="],
 
@@ -190,11 +228,13 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -205,5 +245,9 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,6 @@
 [serve.static]
 plugins = ["bun-plugin-tailwind"]
 env = "BUN_PUBLIC_*"
+
+[test]
+preload = ["./src/test-setup.ts"]

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.7",
+    "@testing-library/react": "^16.3.0",
     "@types/bun": "latest",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "happy-dom": "^20.0.11",
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -8,7 +8,6 @@ import {
   test,
 } from "bun:test";
 import { renderHook } from "@testing-library/react";
-import { Window } from "happy-dom";
 import * as facilitiesData from "@/game/data/facilities";
 import type {
   ActiveTraining,
@@ -21,17 +20,6 @@ import { GrowthStage, TrainingSessionType } from "@/game/types";
 import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { useGameNotifications } from "./useGameNotifications";
-
-// Setup DOM environment for React hooks
-if (typeof window === "undefined") {
-  const window = new Window();
-  // biome-ignore lint/suspicious/noExplicitAny: Mocking global window
-  global.window = window as any;
-  // biome-ignore lint/suspicious/noExplicitAny: Mocking global document
-  global.document = window.document as any;
-  // biome-ignore lint/suspicious/noExplicitAny: Mocking global navigator
-  global.navigator = window.navigator as any;
-}
 
 describe("useGameNotifications", () => {
   const mockSetNotification = mock((_n: GameNotification) => {});
@@ -148,7 +136,8 @@ describe("useGameNotifications", () => {
       };
 
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -161,8 +150,7 @@ describe("useGameNotifications", () => {
         },
       };
 
-      // biome-ignore lint/suspicious/noExplicitAny: casting to avoid strict type inference issues in test
-      rerender({ state: newState as any });
+      rerender({ state: newState });
 
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       expect(mockSetNotification).toHaveBeenCalledWith({
@@ -176,7 +164,8 @@ describe("useGameNotifications", () => {
     test("does not notify if stage remains the same", () => {
       const initialState = createMockState();
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -188,14 +177,14 @@ describe("useGameNotifications", () => {
     test("does not notify if pet is null", () => {
       const initialState = createMockState();
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
       // Set pet to null (e.g. reset)
       const newState = { ...initialState, pet: null };
-      // biome-ignore lint/suspicious/noExplicitAny: Simulating null pet in state type
-      rerender({ state: newState as any });
+      rerender({ state: newState });
 
       expect(mockSetNotification).not.toHaveBeenCalled();
     });
@@ -251,7 +240,8 @@ describe("useGameNotifications", () => {
       };
 
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -264,8 +254,7 @@ describe("useGameNotifications", () => {
         },
       };
 
-      // biome-ignore lint/suspicious/noExplicitAny: casting to avoid strict type inference issues in test
-      rerender({ state: newState as any });
+      rerender({ state: newState });
 
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       expect(mockSetNotification).toHaveBeenCalledWith({
@@ -298,7 +287,8 @@ describe("useGameNotifications", () => {
       };
 
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -311,8 +301,7 @@ describe("useGameNotifications", () => {
         },
       };
 
-      // biome-ignore lint/suspicious/noExplicitAny: casting to avoid strict type inference issues in test
-      rerender({ state: newState as any });
+      rerender({ state: newState });
 
       expect(mockSetNotification).not.toHaveBeenCalled();
     });
@@ -325,7 +314,8 @@ describe("useGameNotifications", () => {
       });
 
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -361,7 +351,8 @@ describe("useGameNotifications", () => {
       const initialState = createMockState({ lastExplorationResult: result });
 
       const { rerender } = renderHook(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
+        ({ state }: { state: GameState | null }) =>
+          useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -349,7 +349,7 @@ describe("useGameNotifications", () => {
         { initialProps: { state: initialState } },
       );
 
-      // First render triggers notification because ref was null
+      // First render triggers notification because currentResult !== previousResult (result !== null)
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       mockSetNotification.mockClear();
 

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -7,6 +7,8 @@ import {
   spyOn,
   test,
 } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { Window } from "happy-dom";
 import * as facilitiesData from "@/game/data/facilities";
 import type {
   ActiveTraining,
@@ -16,8 +18,6 @@ import type {
   Pet,
 } from "@/game/types";
 import { GrowthStage, TrainingSessionType } from "@/game/types";
-import { renderHook } from "@testing-library/react";
-import { Window } from "happy-dom";
 import { useGameNotifications } from "./useGameNotifications";
 
 // Setup DOM environment for React hooks
@@ -156,7 +156,7 @@ describe("useGameNotifications", () => {
       primaryStat: "strength",
       secondaryStat: "endurance",
       // Added required fields for TrainingFacility type satisfaction if needed by the hook or simple return
-      facilityType: "strength", 
+      facilityType: "strength",
       description: "Test Gym",
       sessions: [],
       emoji: "🏋️",

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -292,7 +292,7 @@ describe("useGameNotifications", () => {
         ...initialState,
         pet: {
           ...initialState.pet,
-          activeTraining: undefined as ActiveTraining | undefined,
+          activeTraining: undefined,
         },
       };
 

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -135,9 +135,8 @@ describe("useGameNotifications", () => {
         },
       };
 
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -163,9 +162,8 @@ describe("useGameNotifications", () => {
 
     test("does not notify if stage remains the same", () => {
       const initialState = createMockState();
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -176,9 +174,8 @@ describe("useGameNotifications", () => {
 
     test("does not notify if pet is null", () => {
       const initialState = createMockState();
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -239,9 +236,8 @@ describe("useGameNotifications", () => {
         },
       };
 
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -286,9 +282,8 @@ describe("useGameNotifications", () => {
         },
       };
 
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -313,9 +308,8 @@ describe("useGameNotifications", () => {
         lastExplorationResult: undefined,
       });
 
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 
@@ -350,9 +344,8 @@ describe("useGameNotifications", () => {
 
       const initialState = createMockState({ lastExplorationResult: result });
 
-      const { rerender } = renderHook(
-        ({ state }: { state: GameState | null }) =>
-          useGameNotifications(state, mockSetNotification),
+      const { rerender } = renderHook<void, { state: GameState | null }>(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
         { initialProps: { state: initialState } },
       );
 

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { Window } from "happy-dom";
+import * as facilitiesData from "@/game/data/facilities";
+import type {
+  ActiveTraining,
+  ExplorationResult,
+  GameNotification,
+  GameState,
+  Pet,
+} from "@/game/types";
+import { GrowthStage, TrainingSessionType } from "@/game/types";
+import { useGameNotifications } from "./useGameNotifications";
+
+// Setup DOM environment for React hooks
+if (typeof window === "undefined") {
+  const window = new Window();
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global window
+  global.window = window as any;
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global document
+  global.document = window.document as any;
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global navigator
+  global.navigator = window.navigator as any;
+}
+
+// Mock dependencies
+mock.module("@/game/data/facilities", () => ({
+  getFacility: mock(),
+  getSession: mock(),
+}));
+
+describe("useGameNotifications", () => {
+  const mockSetNotification = mock((_n: GameNotification) => {});
+
+  beforeEach(() => {
+    mockSetNotification.mockClear();
+    // Reset mocks
+    // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
+    (facilitiesData.getFacility as any).mockClear();
+    // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
+    (facilitiesData.getSession as any).mockClear();
+  });
+
+  const createMockState = (overrides: Partial<GameState> = {}): GameState => {
+    const defaultPet: Pet = {
+      id: "test-pet",
+      identity: { name: "Fluffy", speciesId: "dog", speciesName: "Dog" },
+      growth: { stage: GrowthStage.Baby, progress: 0 },
+      stats: {
+        energy: 100,
+        hunger: 0,
+        happiness: 100,
+        hygiene: 100,
+        strength: 0,
+        endurance: 0,
+        agility: 0,
+        precision: 0,
+        fortitude: 0,
+        cunning: 0,
+      },
+      status: { isSick: false, isAsleep: false },
+      activeTraining: null,
+    };
+
+    return {
+      pet: defaultPet,
+      lastExplorationResult: null,
+      isInitialized: true,
+      lastSaveTime: Date.now(),
+      player: {
+        inventory: { items: [] },
+        currency: { coins: 0 },
+        currentLocationId: "home",
+      },
+      ...overrides,
+    };
+  };
+
+  describe("Stage Transitions", () => {
+    test("notifies when growth stage changes", () => {
+      const baseState = createMockState();
+      // Ensure pet exists
+      if (!baseState.pet) throw new Error("Pet missing in mock state");
+
+      const initialState = {
+        ...baseState,
+        pet: {
+          ...baseState.pet,
+          growth: { stage: GrowthStage.Baby, progress: 0 },
+        },
+      };
+
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      // Update stage
+      const newState = {
+        ...initialState,
+        pet: {
+          ...initialState.pet,
+          growth: { stage: GrowthStage.Child, progress: 0 },
+        },
+      };
+
+      rerender({ state: newState });
+
+      expect(mockSetNotification).toHaveBeenCalledTimes(1);
+      expect(mockSetNotification).toHaveBeenCalledWith({
+        type: "stageTransition",
+        previousStage: GrowthStage.Baby,
+        newStage: GrowthStage.Child,
+        petName: "Fluffy",
+      });
+    });
+
+    test("does not notify if stage remains the same", () => {
+      const initialState = createMockState();
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      rerender({ state: initialState });
+
+      expect(mockSetNotification).not.toHaveBeenCalled();
+    });
+
+    test("does not notify if pet is null", () => {
+      const initialState = createMockState();
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      // Set pet to null (e.g. reset)
+      const newState = { ...initialState, pet: null };
+      // biome-ignore lint/suspicious/noExplicitAny: Simulating null pet in state type
+      rerender({ state: newState as any });
+
+      expect(mockSetNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Training Completion", () => {
+    const mockFacility = {
+      id: "gym",
+      name: "Gym",
+      primaryStat: "strength",
+      secondaryStat: "endurance",
+    };
+    const mockSession = {
+      primaryStatGain: 10,
+      secondaryStatGain: 5,
+    };
+
+    beforeEach(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
+      (facilitiesData.getFacility as any).mockReturnValue(mockFacility);
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
+      (facilitiesData.getSession as any).mockReturnValue(mockSession);
+    });
+
+    test("notifies on natural completion (ticks <= 1 -> null)", () => {
+      const trainingState: ActiveTraining = {
+        facilityId: "gym",
+        sessionType: TrainingSessionType.Basic,
+        startTime: Date.now(),
+        ticksRemaining: 1,
+        originalDuration: 10,
+      };
+
+      const baseState = createMockState();
+      if (!baseState.pet) throw new Error("Pet missing in mock state");
+
+      const initialState = {
+        ...baseState,
+        pet: {
+          ...baseState.pet,
+          activeTraining: trainingState,
+        },
+      };
+
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      // Complete training
+      const newState = {
+        ...initialState,
+        pet: {
+          ...initialState.pet,
+          activeTraining: null,
+        },
+      };
+
+      rerender({ state: newState });
+
+      expect(mockSetNotification).toHaveBeenCalledTimes(1);
+      expect(mockSetNotification).toHaveBeenCalledWith({
+        type: "trainingComplete",
+        facilityName: "Gym",
+        statsGained: { strength: 10, endurance: 5 },
+        petName: "Fluffy",
+      });
+    });
+
+    test("does not notify if training was cancelled (ticks > 1 -> null)", () => {
+      const trainingState: ActiveTraining = {
+        facilityId: "gym",
+        sessionType: TrainingSessionType.Basic,
+        startTime: Date.now(),
+        ticksRemaining: 5, // > 1 means cancelled
+        originalDuration: 10,
+      };
+
+      const baseState = createMockState();
+      if (!baseState.pet) throw new Error("Pet missing in mock state");
+
+      const initialState = {
+        ...baseState,
+        pet: {
+          ...baseState.pet,
+          activeTraining: trainingState,
+        },
+      };
+
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      // Cancel training
+      const newState = {
+        ...initialState,
+        pet: {
+          ...initialState.pet,
+          activeTraining: null,
+        },
+      };
+
+      rerender({ state: newState });
+
+      expect(mockSetNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Exploration Completion", () => {
+    test("notifies when new exploration result appears", () => {
+      const initialState = createMockState({ lastExplorationResult: null });
+
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      const result: ExplorationResult & { locationName: string } = {
+        itemsFound: [],
+        message: "Found nothing",
+        locationName: "Forest",
+      };
+
+      const newState = createMockState({ lastExplorationResult: result });
+
+      rerender({ state: newState });
+
+      expect(mockSetNotification).toHaveBeenCalledTimes(1);
+      expect(mockSetNotification).toHaveBeenCalledWith({
+        type: "explorationComplete",
+        locationName: "Forest",
+        itemsFound: [],
+        message: "Found nothing",
+        petName: "Fluffy",
+      });
+    });
+
+    test("does not duplicate notification for same result object", () => {
+      const result: ExplorationResult & { locationName: string } = {
+        itemsFound: [],
+        message: "Found nothing",
+        locationName: "Forest",
+      };
+
+      const initialState = createMockState({ lastExplorationResult: result });
+
+      const { rerender } = renderHook(
+        ({ state }) => useGameNotifications(state, mockSetNotification),
+        { initialProps: { state: initialState } },
+      );
+
+      // First render triggers notification because ref was null
+      expect(mockSetNotification).toHaveBeenCalledTimes(1);
+      mockSetNotification.mockClear();
+
+      // Rerender with SAME state/object
+      rerender({ state: initialState });
+      expect(mockSetNotification).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -246,7 +246,7 @@ describe("useGameNotifications", () => {
         ...initialState,
         pet: {
           ...initialState.pet,
-          activeTraining: undefined as ActiveTraining | undefined,
+          activeTraining: undefined,
         },
       };
 

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from "react";
+import { getFacility, getSession } from "@/game/data/facilities";
+import type {
+  ActiveTraining,
+  ExplorationResult,
+  GameNotification,
+  GameState,
+  GrowthStage,
+} from "@/game/types";
+
+/**
+ * Hook to handle side effects and generate notifications based on state changes.
+ *
+ * @param state The current game state
+ * @param setNotification callback to set a new notification
+ */
+export function useGameNotifications(
+  state: GameState | null,
+  setNotification: (notification: GameNotification) => void,
+) {
+  const previousStageRef = useRef<GrowthStage | null>(null);
+  const previousTrainingRef = useRef<ActiveTraining | null>(null);
+  const previousExplorationResultRef = useRef<
+    (ExplorationResult & { locationName: string }) | null
+  >(null);
+
+  // Detect stage transitions
+  useEffect(() => {
+    const currentStage = state?.pet?.growth.stage ?? null;
+    const previousStage = previousStageRef.current;
+
+    // Reset ref when pet is null (game reset or no pet yet)
+    if (!state?.pet) {
+      previousStageRef.current = null;
+      return;
+    }
+
+    if (currentStage && previousStage && currentStage !== previousStage) {
+      setNotification({
+        type: "stageTransition",
+        previousStage: previousStage,
+        newStage: currentStage,
+        petName: state.pet.identity.name,
+      });
+    }
+
+    previousStageRef.current = currentStage;
+  }, [state?.pet, setNotification]);
+
+  // Detect training completion
+  useEffect(() => {
+    const currentTraining = state?.pet?.activeTraining ?? null;
+    const previousTraining = previousTrainingRef.current;
+
+    // Reset ref when pet is null
+    if (!state?.pet) {
+      previousTrainingRef.current = null;
+      return;
+    }
+
+    // Training completed: was training before, not training now, and was on last tick
+    // If ticksRemaining > 1, training was cancelled, not completed
+    const wasNaturalCompletion =
+      previousTraining &&
+      !currentTraining &&
+      previousTraining.ticksRemaining <= 1;
+
+    if (wasNaturalCompletion) {
+      const facility = getFacility(previousTraining.facilityId);
+      const session = getSession(
+        previousTraining.facilityId,
+        previousTraining.sessionType,
+      );
+
+      if (facility && session) {
+        const statsGained: Record<string, number> = {
+          [facility.primaryStat]: session.primaryStatGain,
+        };
+        if (session.secondaryStatGain > 0) {
+          statsGained[facility.secondaryStat] = session.secondaryStatGain;
+        }
+
+        setNotification({
+          type: "trainingComplete",
+          facilityName: facility.name,
+          statsGained,
+          petName: state.pet.identity.name,
+        });
+      }
+    }
+
+    previousTrainingRef.current = currentTraining;
+  }, [state?.pet, setNotification]);
+
+  // Detect exploration completion
+  useEffect(() => {
+    const currentResult = state?.lastExplorationResult ?? null;
+    const previousResult = previousExplorationResultRef.current;
+
+    // Reset ref when pet is null
+    if (!state?.pet) {
+      previousExplorationResultRef.current = null;
+      return;
+    }
+
+    // Only show notification for new results (avoid duplicates on re-renders)
+    if (currentResult && currentResult !== previousResult) {
+      setNotification({
+        type: "explorationComplete",
+        locationName: currentResult.locationName,
+        itemsFound: currentResult.itemsFound,
+        message: currentResult.message,
+        petName: state.pet.identity.name,
+      });
+    }
+
+    previousExplorationResultRef.current = currentResult;
+  }, [state?.lastExplorationResult, state?.pet, setNotification]);
+}

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -24,13 +24,18 @@ export function useGameNotifications(
     (ExplorationResult & { locationName: string }) | null
   >(null);
 
+  const petName = state?.pet?.identity.name;
+  const stage = state?.pet?.growth.stage;
+  const training = state?.pet?.activeTraining;
+  const explorationResult = state?.lastExplorationResult;
+
   // Detect stage transitions
   useEffect(() => {
-    const currentStage = state?.pet?.growth.stage ?? null;
+    const currentStage = stage ?? null;
     const previousStage = previousStageRef.current;
 
     // Reset ref when pet is null (game reset or no pet yet)
-    if (!state?.pet) {
+    if (!petName) {
       previousStageRef.current = null;
       return;
     }
@@ -40,20 +45,20 @@ export function useGameNotifications(
         type: "stageTransition",
         previousStage: previousStage,
         newStage: currentStage,
-        petName: state.pet.identity.name,
+        petName: petName,
       });
     }
 
     previousStageRef.current = currentStage;
-  }, [state?.pet, setNotification]);
+  }, [stage, petName, setNotification]);
 
   // Detect training completion
   useEffect(() => {
-    const currentTraining = state?.pet?.activeTraining ?? null;
+    const currentTraining = training ?? null;
     const previousTraining = previousTrainingRef.current;
 
     // Reset ref when pet is null
-    if (!state?.pet) {
+    if (!petName) {
       previousTrainingRef.current = null;
       return;
     }
@@ -84,21 +89,21 @@ export function useGameNotifications(
           type: "trainingComplete",
           facilityName: facility.name,
           statsGained,
-          petName: state.pet.identity.name,
+          petName: petName,
         });
       }
     }
 
     previousTrainingRef.current = currentTraining;
-  }, [state?.pet, setNotification]);
+  }, [training, petName, setNotification]);
 
   // Detect exploration completion
   useEffect(() => {
-    const currentResult = state?.lastExplorationResult ?? null;
+    const currentResult = explorationResult ?? null;
     const previousResult = previousExplorationResultRef.current;
 
     // Reset ref when pet is null
-    if (!state?.pet) {
+    if (!petName) {
       previousExplorationResultRef.current = null;
       return;
     }
@@ -110,10 +115,10 @@ export function useGameNotifications(
         locationName: currentResult.locationName,
         itemsFound: currentResult.itemsFound,
         message: currentResult.message,
-        petName: state.pet.identity.name,
+        petName: petName,
       });
     }
 
     previousExplorationResultRef.current = currentResult;
-  }, [state?.lastExplorationResult, state?.pet, setNotification]);
+  }, [explorationResult, petName, setNotification]);
 }

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,12 @@
+import { Window } from "happy-dom";
+
+// Setup DOM environment for React hooks
+if (typeof window === "undefined") {
+  const window = new Window();
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global window
+  global.window = window as any;
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global document
+  global.document = window.document as any;
+  // biome-ignore lint/suspicious/noExplicitAny: Mocking global navigator
+  global.navigator = window.navigator as any;
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -2,11 +2,11 @@ import { Window } from "happy-dom";
 
 // Setup DOM environment for React hooks
 if (typeof window === "undefined") {
-  const window = new Window();
+  const happyWindow = new Window();
   // biome-ignore lint/suspicious/noExplicitAny: Mocking global window
-  global.window = window as any;
+  global.window = happyWindow as any;
   // biome-ignore lint/suspicious/noExplicitAny: Mocking global document
-  global.document = window.document as any;
+  global.document = happyWindow.document as any;
   // biome-ignore lint/suspicious/noExplicitAny: Mocking global navigator
-  global.navigator = window.navigator as any;
+  global.navigator = happyWindow.navigator as any;
 }


### PR DESCRIPTION
This pull request refactors how game state-based notifications are handled in the application. The main change is the extraction of notification side effects from the `GameContext` provider into a new custom hook, `useGameNotifications`, which improves code organization and testability. Additionally, a comprehensive test suite for the new hook has been added, and new testing dependencies are introduced to support React hook testing.

**Notification logic refactor:**

* Extracted all notification-related side effects (stage transitions, training completion, and exploration completion) from `GameContext.tsx` into a new reusable hook, `useGameNotifications`, making the context provider cleaner and the notification logic easier to test and maintain. [[1]](diffhunk://#diff-20a257db7337d76262dd16a6a3343f1252643e70b4d5e08e168cd176f32f4c6bL15-L34) [[2]](diffhunk://#diff-20a257db7337d76262dd16a6a3343f1252643e70b4d5e08e168cd176f32f4c6bL108-L112) [[3]](diffhunk://#diff-20a257db7337d76262dd16a6a3343f1252643e70b4d5e08e168cd176f32f4c6bL125-R118) [[4]](diffhunk://#diff-824e85e96252672c40dd699e7d8c66df82e3b80f65af303f64e94e5ff974ef4dR1-R124)

**Testing improvements:**

* Added a new test file, `useGameNotifications.test.ts`, providing comprehensive unit tests for the notification logic, including edge cases for stage transition, training, and exploration notifications.

**Development tooling:**

* Added `@testing-library/react` and `happy-dom` to `devDependencies` in `package.json` to enable React hook testing in a simulated DOM environment.