### PR TITLE
feat: implement event bus for game notifications

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,67 @@
+# Architecture Review: Frontend & Game Logic Separation
+
+## Executive Summary
+
+The "Digital Pets" codebase demonstrates a **robust and well-structured separation of concerns**, effectively decoupling the presentation layer (`src/components`) from the business logic (`src/game`). The architecture adheres to modern React best practices, treating the game engine as a pure state management system while the UI acts largely as a deterministic reflection of that state.
+
+While the separation is generally excellent, there is a minor architectural "leak" within the `GameContext` provider regarding event/notification handling, which could be improved for better scalability.
+
+## Strengths
+
+### 1. Strict Directory Separation
+The codebase enforces a clear physical boundary:
+- **`src/game/`**: Contains all domain logic, data definitions, and state transformations. It has zero dependencies on UI code (JSX, CSS).
+- **`src/components/`**: Contains only visual components. It never imports directly from `src/game/core` logic but interacts through defined interfaces.
+
+### 2. The "Action" Pattern
+Components do not implement game rules. For example, `FeedButton.tsx` does not calculate how much hunger is reduced. Instead, it calls a pure action function (`feedPet` from `src/game/state/actions/care.ts`). This makes the game logic testable in isolation without rendering React components.
+
+### 3. Pure Functional Core
+The game logic relies heavily on pure functions (e.g., `processGameTick`, `feedPet`) that take a state and return a new state. This "Redux-like" approach ensures predictability and easier debugging.
+
+### 4. Abstraction Layer
+`GameContext` and `useGameState` provide a clear API for the UI. Components consume `state` and dispatch `actions`, oblivious to the underlying "tick" mechanism or storage persistence details.
+
+## Areas for Improvement
+
+### 1. Notification Logic in `GameContext` (The "Leak")
+In `src/game/context/GameContext.tsx`, there are several `useEffect` hooks that monitor state changes to trigger notifications:
+
+```typescript
+// src/game/context/GameContext.tsx
+useEffect(() => {
+  const currentStage = state?.pet?.growth.stage ?? null;
+  const previousStage = previousStageRef.current;
+  // ... logic to compare and setNotification
+}, [state?.pet]);
+```
+
+**Issue:** This places "interpretation" logic (deciding *when* a user should be notified) inside the data provider. While currently manageable, this pattern scales poorly. As the game grows (e.g., adding achievements, quest completions, rare drops), `GameContext` will become cluttered with dozens of `useEffect` hooks comparing previous vs. current state.
+
+### 2. Lack of Explicit Event System
+The system currently relies on state diffing to detect events (like "Training Complete"). A more robust approach would be for the game engine to emit transient "events" or "side effects" alongside state updates, which the UI could consume directly.
+
+## Refactoring Suggestions
+
+### Recommendation 1: Extract Notification Logic (High Priority)
+Move the state-diffing logic out of `GameContext.tsx` and into a dedicated hook.
+
+**Action:** Create `src/game/hooks/useGameNotifications.ts`.
+This hook should listen to the state and manage the side effects (notifications), keeping `GameContext` purely focused on state provision.
+
+```typescript
+// Example structure
+export function useGameNotifications(state: GameState | null, notify: (n: Notification) => void) {
+  useStageTransitionListener(state, notify);
+  useTrainingCompletionListener(state, notify);
+  // ... other listeners
+}
+```
+
+### Recommendation 2: Standardize Selectors (Medium Priority)
+While `selectors.ts` exists, ensure all components use it. Instead of `state.pet.stats.energy`, components should use `selectPetEnergy(state)`. This decouples the UI structure from the state shape, making future state refactors easier.
+
+### Recommendation 3: Event Bus (Long-term)
+If the complexity of "one-off events" grows, consider adding an event queue to the `GameState` or a simple event emitter to `GameManager`.
+- **Idea:** Actions return `{ state: NewState, events: GameEvent[] }`.
+- **Benefit:** Removes the need for "previous state refs" and diffing entirely. The UI simply consumes the `events` array produced by the last tick/action.

--- a/src/game/core/events.test.ts
+++ b/src/game/core/events.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for event bus utilities.
+ */
+
+import { expect, test } from "bun:test";
+import {
+  clearEvents,
+  emitEvent,
+  emitEvents,
+  getEventsByType,
+  hasPendingEvents,
+} from "@/game/core/events";
+import {
+  createTestGameState,
+  createTestPet,
+} from "@/game/testing/createTestPet";
+import { GrowthStage } from "@/game/types/constants";
+import {
+  createEvent,
+  type ExplorationCompleteEvent,
+  type StageTransitionEvent,
+  type TrainingCompleteEvent,
+} from "@/game/types/event";
+
+test("emitEvents appends events to the queue", () => {
+  const state = createTestGameState(createTestPet());
+  expect(state.pendingEvents).toHaveLength(0);
+
+  const event1 = createEvent<StageTransitionEvent>({
+    type: "stageTransition",
+    previousStage: GrowthStage.Baby,
+    newStage: GrowthStage.Child,
+    petName: "Test Pet",
+  });
+
+  const event2 = createEvent<TrainingCompleteEvent>({
+    type: "trainingComplete",
+    facilityName: "Gym",
+    statsGained: { strength: 5 },
+    petName: "Test Pet",
+  });
+
+  const newState = emitEvents(state, event1, event2);
+
+  expect(newState.pendingEvents).toHaveLength(2);
+  expect(newState.pendingEvents[0]).toBe(event1);
+  expect(newState.pendingEvents[1]).toBe(event2);
+  // Original state unchanged
+  expect(state.pendingEvents).toHaveLength(0);
+});
+
+test("emitEvents returns same state for empty events", () => {
+  const state = createTestGameState(createTestPet());
+  const newState = emitEvents(state);
+
+  expect(newState).toBe(state);
+});
+
+test("emitEvent appends a single event", () => {
+  const state = createTestGameState(createTestPet());
+
+  const event = createEvent<StageTransitionEvent>({
+    type: "stageTransition",
+    previousStage: GrowthStage.Baby,
+    newStage: GrowthStage.Child,
+    petName: "Test Pet",
+  });
+
+  const newState = emitEvent(state, event);
+
+  expect(newState.pendingEvents).toHaveLength(1);
+  expect(newState.pendingEvents[0]).toBe(event);
+});
+
+test("clearEvents removes all pending events", () => {
+  const event = createEvent<StageTransitionEvent>({
+    type: "stageTransition",
+    previousStage: GrowthStage.Baby,
+    newStage: GrowthStage.Child,
+    petName: "Test Pet",
+  });
+
+  const state = createTestGameState(createTestPet(), {
+    pendingEvents: [event],
+  });
+
+  expect(state.pendingEvents).toHaveLength(1);
+
+  const clearedState = clearEvents(state);
+
+  expect(clearedState.pendingEvents).toHaveLength(0);
+  // Original state unchanged
+  expect(state.pendingEvents).toHaveLength(1);
+});
+
+test("clearEvents returns same state when already empty", () => {
+  const state = createTestGameState(createTestPet());
+  expect(state.pendingEvents).toHaveLength(0);
+
+  const clearedState = clearEvents(state);
+
+  expect(clearedState).toBe(state);
+});
+
+test("getEventsByType filters events by type correctly", () => {
+  const stageEvent = createEvent<StageTransitionEvent>({
+    type: "stageTransition",
+    previousStage: GrowthStage.Baby,
+    newStage: GrowthStage.Child,
+    petName: "Test Pet",
+  });
+
+  const trainingEvent = createEvent<TrainingCompleteEvent>({
+    type: "trainingComplete",
+    facilityName: "Gym",
+    statsGained: { strength: 5 },
+    petName: "Test Pet",
+  });
+
+  const explorationEvent = createEvent<ExplorationCompleteEvent>({
+    type: "explorationComplete",
+    locationName: "Forest",
+    itemsFound: [],
+    message: "Nothing found",
+    petName: "Test Pet",
+  });
+
+  const state = createTestGameState(createTestPet(), {
+    pendingEvents: [stageEvent, trainingEvent, explorationEvent],
+  });
+
+  const stageEvents = getEventsByType<StageTransitionEvent>(
+    state,
+    "stageTransition",
+  );
+  expect(stageEvents).toHaveLength(1);
+  expect(stageEvents[0]).toBe(stageEvent);
+
+  const trainingEvents = getEventsByType<TrainingCompleteEvent>(
+    state,
+    "trainingComplete",
+  );
+  expect(trainingEvents).toHaveLength(1);
+  expect(trainingEvents[0]).toBe(trainingEvent);
+});
+
+test("getEventsByType returns empty array for non-existent type", () => {
+  const state = createTestGameState(createTestPet());
+
+  const events = getEventsByType<StageTransitionEvent>(
+    state,
+    "stageTransition",
+  );
+
+  expect(events).toHaveLength(0);
+});
+
+test("hasPendingEvents returns true when events exist", () => {
+  const event = createEvent<StageTransitionEvent>({
+    type: "stageTransition",
+    previousStage: GrowthStage.Baby,
+    newStage: GrowthStage.Child,
+    petName: "Test Pet",
+  });
+
+  const state = createTestGameState(createTestPet(), {
+    pendingEvents: [event],
+  });
+
+  expect(hasPendingEvents(state)).toBe(true);
+});
+
+test("hasPendingEvents returns false when no events", () => {
+  const state = createTestGameState(createTestPet());
+
+  expect(hasPendingEvents(state)).toBe(false);
+});

--- a/src/game/core/events.ts
+++ b/src/game/core/events.ts
@@ -1,0 +1,60 @@
+/**
+ * Event bus utilities for managing game events.
+ *
+ * Provides functions to emit, consume, and clear events from the game state.
+ */
+
+import type { GameEvent } from "@/game/types/event";
+import type { GameState } from "@/game/types/gameState";
+
+/**
+ * Emit one or more events to the game state's pending events queue.
+ */
+export function emitEvents(
+  state: GameState,
+  ...events: GameEvent[]
+): GameState {
+  if (events.length === 0) return state;
+
+  return {
+    ...state,
+    pendingEvents: [...state.pendingEvents, ...events],
+  };
+}
+
+/**
+ * Emit a single event to the game state.
+ */
+export function emitEvent(state: GameState, event: GameEvent): GameState {
+  return emitEvents(state, event);
+}
+
+/**
+ * Clear all pending events from the game state.
+ * Should be called after the UI has consumed the events.
+ */
+export function clearEvents(state: GameState): GameState {
+  if (state.pendingEvents.length === 0) return state;
+
+  return {
+    ...state,
+    pendingEvents: [],
+  };
+}
+
+/**
+ * Get pending events of a specific type.
+ */
+export function getEventsByType<T extends GameEvent>(
+  state: GameState,
+  type: T["type"],
+): T[] {
+  return state.pendingEvents.filter((e) => e.type === type) as T[];
+}
+
+/**
+ * Check if there are any pending events.
+ */
+export function hasPendingEvents(state: GameState): boolean {
+  return state.pendingEvents.length > 0;
+}

--- a/src/game/core/events.ts
+++ b/src/game/core/events.ts
@@ -31,7 +31,8 @@ export function emitEvent(state: GameState, event: GameEvent): GameState {
 
 /**
  * Clear all pending events from the game state.
- * Should be called after the UI has consumed the events.
+ * Note: Currently events are cleared at the start of each tick in tickProcessor.
+ * This function is provided for future use if explicit clearing is needed.
  */
 export function clearEvents(state: GameState): GameState {
   if (state.pendingEvents.length === 0) return state;

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -75,6 +75,7 @@ function createTestState(): GameState {
     },
     quests: [],
     isInitialized: true,
+    pendingEvents: [],
   };
 }
 

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -118,18 +118,21 @@ export function processGameTick(
     (updatedPet.activityState !== ActivityState.Training ||
       updatedPet.activeTraining === undefined);
 
-  // Events to emit this tick
+  // Events to emit this tick (use currentTime for consistent timestamps)
   const tickEvents: GameEvent[] = [];
 
   // Detect stage transition
   if (updatedPet.growth.stage !== previousStage) {
     tickEvents.push(
-      createEvent<StageTransitionEvent>({
-        type: "stageTransition",
-        previousStage,
-        newStage: updatedPet.growth.stage,
-        petName,
-      }),
+      createEvent<StageTransitionEvent>(
+        {
+          type: "stageTransition",
+          previousStage,
+          newStage: updatedPet.growth.stage,
+          petName,
+        },
+        currentTime,
+      ),
     );
   }
 
@@ -198,13 +201,16 @@ export function processGameTick(
 
       // Emit exploration complete event
       tickEvents.push(
-        createEvent<ExplorationCompleteEvent>({
-          type: "explorationComplete",
-          locationName,
-          itemsFound: result.itemsFound,
-          message: result.message,
-          petName,
-        }),
+        createEvent<ExplorationCompleteEvent>(
+          {
+            type: "explorationComplete",
+            locationName,
+            itemsFound: result.itemsFound,
+            message: result.message,
+            petName,
+          },
+          currentTime,
+        ),
       );
     } else {
       updatedState = {
@@ -239,12 +245,15 @@ export function processGameTick(
 
       // Emit training complete event using statsGained from the result
       tickEvents.push(
-        createEvent<TrainingCompleteEvent>({
-          type: "trainingComplete",
-          facilityName,
-          statsGained: trainingResultBeforeCompletion.statsGained ?? {},
-          petName,
-        }),
+        createEvent<TrainingCompleteEvent>(
+          {
+            type: "trainingComplete",
+            facilityName,
+            statsGained: trainingResultBeforeCompletion.statsGained ?? {},
+            petName,
+          },
+          currentTime,
+        ),
       );
     }
   }

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -76,7 +76,7 @@ export function processGameTick(
   // Check for daily reset first
   const workingState = applyDailyResetIfNeeded(state, currentTime);
 
-  // Clear events from the previous tick (new events are added at the end of this tick)
+  // Clear pending events at the start of this tick (new events are added at the end)
   let updatedState: GameState = {
     ...workingState,
     pendingEvents: [],

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -76,7 +76,7 @@ export function processGameTick(
   // Check for daily reset first
   const workingState = applyDailyResetIfNeeded(state, currentTime);
 
-  // Clear pending events at the start of each tick (events are consumed per-tick)
+  // Clear events from the previous tick (new events are added at the end of this tick)
   let updatedState: GameState = {
     ...workingState,
     pendingEvents: [],

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -188,9 +188,12 @@ export function processGameTick(
       }
 
       // Store the result for UI notification (legacy support)
-      updatedState.lastExplorationResult = {
-        ...result,
-        locationName,
+      updatedState = {
+        ...updatedState,
+        lastExplorationResult: {
+          ...result,
+          locationName,
+        },
       };
 
       // Emit exploration complete event
@@ -226,9 +229,12 @@ export function processGameTick(
     if (trainingResultBeforeCompletion && facilityId) {
       const facility = getFacility(facilityId);
       const facilityName = facility?.name ?? "Unknown Facility";
-      updatedState.lastTrainingResult = {
-        ...trainingResultBeforeCompletion,
-        facilityName,
+      updatedState = {
+        ...updatedState,
+        lastTrainingResult: {
+          ...trainingResultBeforeCompletion,
+          facilityName,
+        },
       };
 
       // Emit training complete event using statsGained from the result

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -1,42 +1,21 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
-import * as facilitiesData from "@/game/data/facilities";
 import type {
-  ActiveTraining,
-  ExplorationResult,
+  ExplorationCompleteEvent,
   GameNotification,
   GameState,
   Pet,
+  StageTransitionEvent,
+  TrainingCompleteEvent,
 } from "@/game/types";
-import { GrowthStage, TrainingSessionType } from "@/game/types";
+import { GrowthStage } from "@/game/types";
+import { createEvent } from "@/game/types/event";
 import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { useGameNotifications } from "./useGameNotifications";
 
 describe("useGameNotifications", () => {
   const mockSetNotification = mock((_n: GameNotification) => {});
-  let getFacilitySpy: ReturnType<typeof spyOn>;
-  let getSessionSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    mockSetNotification.mockClear();
-    // Spy on the facility methods
-    getFacilitySpy = spyOn(facilitiesData, "getFacility");
-    getSessionSpy = spyOn(facilitiesData, "getSession");
-  });
-
-  afterEach(() => {
-    getFacilitySpy.mockRestore();
-    getSessionSpy.mockRestore();
-  });
 
   const createMockState = (overrides: Partial<GameState> = {}): GameState => {
     const defaultPet: Pet = {
@@ -118,38 +97,29 @@ describe("useGameNotifications", () => {
         currentLocationId: "home",
         skills: createInitialSkills(),
       },
+      pendingEvents: [],
       ...overrides,
     };
   };
 
   describe("Stage Transitions", () => {
-    test("notifies when growth stage changes", () => {
-      const baseState = createMockState();
-      if (!baseState.pet) throw new Error("Pet missing in mock state");
+    test("notifies when stageTransition event is in pendingEvents", () => {
+      mockSetNotification.mockClear();
 
-      const initialState = {
-        ...baseState,
-        pet: {
-          ...baseState.pet,
-          growth: { ...baseState.pet.growth, stage: GrowthStage.Baby },
-        },
-      };
+      const stateWithEvent = createMockState({
+        pendingEvents: [
+          createEvent<StageTransitionEvent>({
+            type: "stageTransition",
+            previousStage: GrowthStage.Baby,
+            newStage: GrowthStage.Child,
+            petName: "Fluffy",
+          }),
+        ],
+      });
 
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
+      renderHook(() =>
+        useGameNotifications(stateWithEvent, mockSetNotification),
       );
-
-      // Update stage
-      const newState = {
-        ...initialState,
-        pet: {
-          ...initialState.pet,
-          growth: { ...initialState.pet.growth, stage: GrowthStage.Child },
-        },
-      };
-
-      rerender({ state: newState });
 
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       expect(mockSetNotification).toHaveBeenCalledWith({
@@ -160,97 +130,37 @@ describe("useGameNotifications", () => {
       });
     });
 
-    test("does not notify if stage remains the same", () => {
-      const initialState = createMockState();
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
+    test("does not notify if pendingEvents is empty", () => {
+      mockSetNotification.mockClear();
+
+      const stateNoEvents = createMockState({ pendingEvents: [] });
+
+      renderHook(() =>
+        useGameNotifications(stateNoEvents, mockSetNotification),
       );
-
-      rerender({ state: initialState });
-
-      expect(mockSetNotification).not.toHaveBeenCalled();
-    });
-
-    test("does not notify if pet is null", () => {
-      const initialState = createMockState();
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
-      );
-
-      // Set pet to null (e.g. reset)
-      const newState = { ...initialState, pet: null };
-      rerender({ state: newState });
 
       expect(mockSetNotification).not.toHaveBeenCalled();
     });
   });
 
   describe("Training Completion", () => {
-    const mockFacility = {
-      id: "gym",
-      name: "Gym",
-      primaryStat: "strength",
-      secondaryStat: "endurance",
-      facilityType: "strength",
-      description: "Test Gym",
-      sessions: [],
-      emoji: "🏋️",
-    };
-    const mockSession = {
-      type: TrainingSessionType.Basic,
-      name: "Basic",
-      description: "Desc",
-      durationTicks: 10,
-      energyCost: 10,
-      primaryStatGain: 10,
-      secondaryStatGain: 5,
-    };
+    test("notifies when trainingComplete event is in pendingEvents", () => {
+      mockSetNotification.mockClear();
 
-    beforeEach(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
-      getFacilitySpy.mockReturnValue(mockFacility as any);
-      // biome-ignore lint/suspicious/noExplicitAny: Accessing mock methods
-      getSessionSpy.mockReturnValue(mockSession as any);
-    });
+      const stateWithEvent = createMockState({
+        pendingEvents: [
+          createEvent<TrainingCompleteEvent>({
+            type: "trainingComplete",
+            facilityName: "Gym",
+            statsGained: { strength: 10, endurance: 5 },
+            petName: "Fluffy",
+          }),
+        ],
+      });
 
-    test("notifies on natural completion (ticks <= 1 -> null)", () => {
-      const trainingState: ActiveTraining = {
-        facilityId: "gym",
-        sessionType: TrainingSessionType.Basic,
-        startTick: 100,
-        durationTicks: 10,
-        ticksRemaining: 1,
-        energyCost: 10,
-      };
-
-      const baseState = createMockState();
-      if (!baseState.pet) throw new Error("Pet missing in mock state");
-
-      const initialState = {
-        ...baseState,
-        pet: {
-          ...baseState.pet,
-          activeTraining: trainingState,
-        },
-      };
-
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
+      renderHook(() =>
+        useGameNotifications(stateWithEvent, mockSetNotification),
       );
-
-      // Complete training
-      const newState = {
-        ...initialState,
-        pet: {
-          ...initialState.pet,
-          activeTraining: undefined,
-        },
-      };
-
-      rerender({ state: newState });
 
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       expect(mockSetNotification).toHaveBeenCalledWith({
@@ -260,69 +170,27 @@ describe("useGameNotifications", () => {
         petName: "Fluffy",
       });
     });
-
-    test("does not notify if training was cancelled (ticks > 1 -> null)", () => {
-      const trainingState: ActiveTraining = {
-        facilityId: "gym",
-        sessionType: TrainingSessionType.Basic,
-        startTick: 100,
-        durationTicks: 10,
-        ticksRemaining: 5,
-        energyCost: 10,
-      };
-
-      const baseState = createMockState();
-      if (!baseState.pet) throw new Error("Pet missing in mock state");
-
-      const initialState = {
-        ...baseState,
-        pet: {
-          ...baseState.pet,
-          activeTraining: trainingState,
-        },
-      };
-
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
-      );
-
-      // Cancel training
-      const newState = {
-        ...initialState,
-        pet: {
-          ...initialState.pet,
-          activeTraining: undefined,
-        },
-      };
-
-      rerender({ state: newState });
-
-      expect(mockSetNotification).not.toHaveBeenCalled();
-    });
   });
 
   describe("Exploration Completion", () => {
-    test("notifies when new exploration result appears", () => {
-      const initialState = createMockState({
-        lastExplorationResult: undefined,
+    test("notifies when explorationComplete event is in pendingEvents", () => {
+      mockSetNotification.mockClear();
+
+      const stateWithEvent = createMockState({
+        pendingEvents: [
+          createEvent<ExplorationCompleteEvent>({
+            type: "explorationComplete",
+            locationName: "Forest",
+            itemsFound: [],
+            message: "Found nothing",
+            petName: "Fluffy",
+          }),
+        ],
       });
 
-      const { rerender } = renderHook<void, { state: GameState | null }>(
-        ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
+      renderHook(() =>
+        useGameNotifications(stateWithEvent, mockSetNotification),
       );
-
-      const result: ExplorationResult & { locationName: string } = {
-        success: true,
-        itemsFound: [],
-        message: "Found nothing",
-        locationName: "Forest",
-      };
-
-      const newState = createMockState({ lastExplorationResult: result });
-
-      rerender({ state: newState });
 
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       expect(mockSetNotification).toHaveBeenCalledWith({
@@ -334,27 +202,33 @@ describe("useGameNotifications", () => {
       });
     });
 
-    test("does not duplicate notification for same result object", () => {
-      const result: ExplorationResult & { locationName: string } = {
-        success: true,
+    test("does not duplicate notification for already-processed events", () => {
+      mockSetNotification.mockClear();
+
+      // Create event with a specific timestamp
+      const event = createEvent<ExplorationCompleteEvent>({
+        type: "explorationComplete",
+        locationName: "Forest",
         itemsFound: [],
         message: "Found nothing",
-        locationName: "Forest",
-      };
+        petName: "Fluffy",
+      });
 
-      const initialState = createMockState({ lastExplorationResult: result });
+      const stateWithEvent = createMockState({
+        pendingEvents: [event],
+      });
 
       const { rerender } = renderHook<void, { state: GameState | null }>(
         ({ state }) => useGameNotifications(state, mockSetNotification),
-        { initialProps: { state: initialState } },
+        { initialProps: { state: stateWithEvent } },
       );
 
-      // First render triggers notification because currentResult !== previousResult (result !== null)
+      // First render triggers notification
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       mockSetNotification.mockClear();
 
-      // Rerender with SAME state/object
-      rerender({ state: initialState });
+      // Rerender with SAME events (same timestamps) should not re-trigger
+      rerender({ state: stateWithEvent });
       expect(mockSetNotification).not.toHaveBeenCalled();
     });
   });

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -206,13 +206,17 @@ describe("useGameNotifications", () => {
       mockSetNotification.mockClear();
 
       // Create event with a specific timestamp
-      const event = createEvent<ExplorationCompleteEvent>({
-        type: "explorationComplete",
-        locationName: "Forest",
-        itemsFound: [],
-        message: "Found nothing",
-        petName: "Fluffy",
-      });
+      const eventTimestamp = Date.now();
+      const event = createEvent<ExplorationCompleteEvent>(
+        {
+          type: "explorationComplete",
+          locationName: "Forest",
+          itemsFound: [],
+          message: "Found nothing",
+          petName: "Fluffy",
+        },
+        eventTimestamp,
+      );
 
       const stateWithEvent = createMockState({
         pendingEvents: [event],
@@ -227,8 +231,13 @@ describe("useGameNotifications", () => {
       expect(mockSetNotification).toHaveBeenCalledTimes(1);
       mockSetNotification.mockClear();
 
-      // Rerender with SAME events (same timestamps) should not re-trigger
-      rerender({ state: stateWithEvent });
+      // Create a NEW state object with the SAME event (same timestamp)
+      // This tests that the timestamp-based filter prevents duplicates
+      const newStateWithSameEvent = createMockState({
+        pendingEvents: [event],
+      });
+
+      rerender({ state: newStateWithSameEvent });
       expect(mockSetNotification).not.toHaveBeenCalled();
     });
   });

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -1,15 +1,19 @@
 import { useEffect, useRef } from "react";
-import { getFacility, getSession } from "@/game/data/facilities";
 import type {
-  ActiveTraining,
-  ExplorationResult,
+  ExplorationCompleteEvent,
+  GameEvent,
   GameNotification,
   GameState,
-  GrowthStage,
+  StageTransitionEvent,
+  TrainingCompleteEvent,
 } from "@/game/types";
 
 /**
- * Hook to handle side effects and generate notifications based on state changes.
+ * Hook to handle side effects and generate notifications based on game events.
+ *
+ * This hook consumes events from the event bus (state.pendingEvents) instead of
+ * diffing state to detect changes. This is more robust and scales better as
+ * the game grows with more event types.
  *
  * @param state The current game state
  * @param setNotification callback to set a new notification
@@ -18,107 +22,70 @@ export function useGameNotifications(
   state: GameState | null,
   setNotification: (notification: GameNotification) => void,
 ) {
-  const previousStageRef = useRef<GrowthStage | null>(null);
-  const previousTrainingRef = useRef<ActiveTraining | null>(null);
-  const previousExplorationResultRef = useRef<
-    (ExplorationResult & { locationName: string }) | null
-  >(null);
+  // Track processed events to avoid duplicate notifications
+  const lastProcessedTimestampRef = useRef<number>(0);
 
-  const petName = state?.pet?.identity.name;
-  const stage = state?.pet?.growth.stage;
-  const training = state?.pet?.activeTraining;
-  const explorationResult = state?.lastExplorationResult;
-
-  // Detect stage transitions
   useEffect(() => {
-    const currentStage = stage ?? null;
-    const previousStage = previousStageRef.current;
+    if (!state?.pendingEvents?.length) return;
 
-    // Reset ref when pet is null (game reset or no pet yet)
-    if (!petName) {
-      previousStageRef.current = null;
-      return;
-    }
+    // Process new events (those with timestamp > last processed)
+    const newEvents = state.pendingEvents.filter(
+      (event) => event.timestamp > lastProcessedTimestampRef.current,
+    );
 
-    if (currentStage && previousStage && currentStage !== previousStage) {
-      setNotification({
-        type: "stageTransition",
-        previousStage: previousStage,
-        newStage: currentStage,
-        petName: petName,
-      });
-    }
+    if (newEvents.length === 0) return;
 
-    previousStageRef.current = currentStage;
-  }, [stage, petName, setNotification]);
+    // Update the last processed timestamp
+    const maxTimestamp = Math.max(...newEvents.map((e) => e.timestamp));
+    lastProcessedTimestampRef.current = maxTimestamp;
 
-  // Detect training completion
-  useEffect(() => {
-    const currentTraining = training ?? null;
-    const previousTraining = previousTrainingRef.current;
-
-    // Reset ref when pet is null
-    if (!petName) {
-      previousTrainingRef.current = null;
-      return;
-    }
-
-    // Training completed: was training before, not training now, and was on last tick
-    // If ticksRemaining > 1, training was cancelled, not completed
-    const wasNaturalCompletion =
-      previousTraining &&
-      !currentTraining &&
-      previousTraining.ticksRemaining <= 1;
-
-    if (wasNaturalCompletion) {
-      const facility = getFacility(previousTraining.facilityId);
-      const session = getSession(
-        previousTraining.facilityId,
-        previousTraining.sessionType,
-      );
-
-      if (facility && session) {
-        const statsGained: Record<string, number> = {
-          [facility.primaryStat]: session.primaryStatGain,
-        };
-        if (session.secondaryStatGain > 0) {
-          statsGained[facility.secondaryStat] = session.secondaryStatGain;
-        }
-
-        setNotification({
-          type: "trainingComplete",
-          facilityName: facility.name,
-          statsGained,
-          petName: petName,
-        });
+    // Process each event and create notifications
+    for (const event of newEvents) {
+      const notification = eventToNotification(event);
+      if (notification) {
+        setNotification(notification);
+        // Only show one notification at a time (first one wins)
+        break;
       }
     }
+  }, [state?.pendingEvents, setNotification]);
+}
 
-    previousTrainingRef.current = currentTraining;
-  }, [training, petName, setNotification]);
-
-  // Detect exploration completion
-  useEffect(() => {
-    const currentResult = explorationResult ?? null;
-    const previousResult = previousExplorationResultRef.current;
-
-    // Reset ref when pet is null
-    if (!petName) {
-      previousExplorationResultRef.current = null;
-      return;
+/**
+ * Convert a game event to a notification for UI display.
+ */
+function eventToNotification(event: GameEvent): GameNotification | null {
+  switch (event.type) {
+    case "stageTransition": {
+      const e = event as StageTransitionEvent;
+      return {
+        type: "stageTransition",
+        previousStage: e.previousStage,
+        newStage: e.newStage,
+        petName: e.petName,
+      };
     }
-
-    // Only show notification for new results (avoid duplicates on re-renders)
-    if (currentResult && currentResult !== previousResult) {
-      setNotification({
+    case "trainingComplete": {
+      const e = event as TrainingCompleteEvent;
+      return {
+        type: "trainingComplete",
+        facilityName: e.facilityName,
+        statsGained: e.statsGained,
+        petName: e.petName,
+      };
+    }
+    case "explorationComplete": {
+      const e = event as ExplorationCompleteEvent;
+      return {
         type: "explorationComplete",
-        locationName: currentResult.locationName,
-        itemsFound: currentResult.itemsFound,
-        message: currentResult.message,
-        petName: petName,
-      });
+        locationName: e.locationName,
+        itemsFound: e.itemsFound,
+        message: e.message,
+        petName: e.petName,
+      };
     }
-
-    previousExplorationResultRef.current = currentResult;
-  }, [explorationResult, petName, setNotification]);
+    // Other event types don't have corresponding notifications yet
+    default:
+      return null;
+  }
 }

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -1,12 +1,5 @@
 import { useEffect, useRef } from "react";
-import type {
-  ExplorationCompleteEvent,
-  GameEvent,
-  GameNotification,
-  GameState,
-  StageTransitionEvent,
-  TrainingCompleteEvent,
-} from "@/game/types";
+import type { GameEvent, GameNotification, GameState } from "@/game/types";
 
 /**
  * Hook to handle side effects and generate notifications based on game events.
@@ -62,34 +55,28 @@ export function useGameNotifications(
  */
 function eventToNotification(event: GameEvent): GameNotification | null {
   switch (event.type) {
-    case "stageTransition": {
-      const e = event as StageTransitionEvent;
+    case "stageTransition":
       return {
         type: "stageTransition",
-        previousStage: e.previousStage,
-        newStage: e.newStage,
-        petName: e.petName,
+        previousStage: event.previousStage,
+        newStage: event.newStage,
+        petName: event.petName,
       };
-    }
-    case "trainingComplete": {
-      const e = event as TrainingCompleteEvent;
+    case "trainingComplete":
       return {
         type: "trainingComplete",
-        facilityName: e.facilityName,
-        statsGained: e.statsGained,
-        petName: e.petName,
+        facilityName: event.facilityName,
+        statsGained: event.statsGained,
+        petName: event.petName,
       };
-    }
-    case "explorationComplete": {
-      const e = event as ExplorationCompleteEvent;
+    case "explorationComplete":
       return {
         type: "explorationComplete",
-        locationName: e.locationName,
-        itemsFound: e.itemsFound,
-        message: e.message,
-        petName: e.petName,
+        locationName: event.locationName,
+        itemsFound: event.itemsFound,
+        message: event.message,
+        petName: event.petName,
       };
-    }
     // Other event types don't have corresponding notifications yet
     default:
       return null;

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -35,8 +35,8 @@ export function useGameNotifications(
 
     if (newEvents.length === 0) return;
 
-    // Update the last processed timestamp (use reduce to avoid stack overflow with large arrays)
-    // Safe to use 0 as initial value since we only process events with timestamp > lastProcessed
+    // Find the maximum timestamp using reduce (avoids potential stack overflow
+    // from Math.max(...array) with very large arrays)
     const maxTimestamp = newEvents.reduce(
       (max, e) => Math.max(max, e.timestamp),
       0,

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -64,6 +64,7 @@ function createTestState(quests: QuestProgress[] = []): GameState {
     },
     quests,
     isInitialized: true,
+    pendingEvents: [],
   };
 }
 

--- a/src/game/state/actions/sleep.test.ts
+++ b/src/game/state/actions/sleep.test.ts
@@ -65,6 +65,7 @@ function createTestGameState(isSleeping: boolean): GameState {
     },
     quests: [],
     isInitialized: true,
+    pendingEvents: [],
   };
 }
 
@@ -83,6 +84,7 @@ function createEmptyGameState(): GameState {
     },
     quests: [],
     isInitialized: true,
+    pendingEvents: [],
   };
 }
 

--- a/src/game/state/persistence.ts
+++ b/src/game/state/persistence.ts
@@ -24,10 +24,8 @@ export type LoadResult =
  */
 export function saveGame(state: GameState): boolean {
   try {
-    // Exclude pendingEvents from save - they are transient
-    const { pendingEvents: _, ...persistableState } = state;
     const stateToSave: GameState = {
-      ...persistableState,
+      ...state,
       pendingEvents: [],
       lastSaveTime: Date.now(),
     };

--- a/src/game/testing/createTestPet.ts
+++ b/src/game/testing/createTestPet.ts
@@ -5,7 +5,9 @@
 import { createDefaultBonusMaxStats } from "@/game/core/petStats";
 import { SPECIES } from "@/game/data/species";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
+import type { GameState } from "@/game/types/gameState";
 import type { Pet } from "@/game/types/pet";
+import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 
 /**
@@ -127,4 +129,38 @@ export function createSleepingTestPet(overrides: DeepPartial<Pet> = {}): Pet {
     },
     activityState: ActivityState.Sleeping,
   });
+}
+
+/**
+ * Create a test game state with a pet and optional overrides.
+ */
+export function createTestGameState(
+  pet: Pet | null = createTestPet(),
+  overrides: Partial<
+    Omit<GameState, "pet" | "player"> & {
+      player?: Partial<GameState["player"]>;
+    }
+  > = {},
+): GameState {
+  const now = Date.now();
+  const { player: playerOverrides, ...stateOverrides } = overrides;
+
+  return {
+    version: 1,
+    lastSaveTime: now,
+    totalTicks: 0,
+    pet,
+    player: {
+      inventory: { items: [] },
+      currency: { coins: 0 },
+      currentLocationId: "home",
+      skills: createInitialSkills(),
+      ...playerOverrides,
+    },
+    quests: [],
+    isInitialized: true,
+    lastDailyReset: now,
+    pendingEvents: [],
+    ...stateOverrides,
+  };
 }

--- a/src/game/types/event.ts
+++ b/src/game/types/event.ts
@@ -104,13 +104,16 @@ export interface ActionResult<T> {
 }
 
 /**
- * Create a new event with the current timestamp.
+ * Create a new event with the specified or current timestamp.
+ * @param event The event data without timestamp
+ * @param timestamp Optional timestamp (defaults to Date.now())
  */
 export function createEvent<T extends GameEvent>(
   event: Omit<T, "timestamp">,
+  timestamp: number = Date.now(),
 ): T {
   return {
     ...event,
-    timestamp: Date.now(),
+    timestamp,
   } as T;
 }

--- a/src/game/types/event.ts
+++ b/src/game/types/event.ts
@@ -1,0 +1,116 @@
+/**
+ * Game event types for the event bus system.
+ *
+ * Events are transient notifications emitted by actions and the game tick.
+ * They replace state-diffing for detecting "one-off" occurrences like
+ * training completion, exploration results, or stage transitions.
+ */
+
+import type { ExplorationDrop } from "./activity";
+import type { GrowthStage } from "./constants";
+import type { BattleStats } from "./stats";
+
+/**
+ * Base event interface.
+ */
+interface BaseGameEvent {
+  /** Unique event type identifier */
+  type: string;
+  /** Timestamp when the event occurred */
+  timestamp: number;
+}
+
+/**
+ * Event emitted when a pet evolves to a new growth stage.
+ */
+export interface StageTransitionEvent extends BaseGameEvent {
+  type: "stageTransition";
+  previousStage: GrowthStage;
+  newStage: GrowthStage;
+  petName: string;
+}
+
+/**
+ * Event emitted when training completes.
+ */
+export interface TrainingCompleteEvent extends BaseGameEvent {
+  type: "trainingComplete";
+  facilityName: string;
+  statsGained: Partial<BattleStats>;
+  petName: string;
+}
+
+/**
+ * Event emitted when exploration completes.
+ */
+export interface ExplorationCompleteEvent extends BaseGameEvent {
+  type: "explorationComplete";
+  locationName: string;
+  itemsFound: ExplorationDrop[];
+  message: string;
+  petName: string;
+}
+
+/**
+ * Event emitted when a care action is performed.
+ */
+export interface CareActionEvent extends BaseGameEvent {
+  type: "careAction";
+  action: "feed" | "water" | "clean" | "play";
+  itemId: string;
+  petName: string;
+  message: string;
+}
+
+/**
+ * Event emitted when travel occurs.
+ */
+export interface TravelEvent extends BaseGameEvent {
+  type: "travel";
+  fromLocationId: string;
+  toLocationId: string;
+  toLocationName: string;
+}
+
+/**
+ * Event emitted when skill level increases.
+ */
+export interface SkillLevelUpEvent extends BaseGameEvent {
+  type: "skillLevelUp";
+  skillType: string;
+  newLevel: number;
+}
+
+/**
+ * Union type of all game events.
+ */
+export type GameEvent =
+  | StageTransitionEvent
+  | TrainingCompleteEvent
+  | ExplorationCompleteEvent
+  | CareActionEvent
+  | TravelEvent
+  | SkillLevelUpEvent;
+
+/**
+ * Result type for actions that produce events.
+ * Actions return both the new state and any events that occurred.
+ */
+export interface ActionResult<T> {
+  /** Updated game state */
+  state: T;
+  /** Events emitted by this action */
+  events: GameEvent[];
+}
+
+/**
+ * Create a new event with the current timestamp.
+ */
+export function createEvent<T extends GameEvent>(
+  event: Omit<T, "timestamp">,
+): T {
+  return {
+    ...event,
+    timestamp: Date.now(),
+  } as T;
+}

--- a/src/game/types/event.ts
+++ b/src/game/types/event.ts
@@ -95,6 +95,9 @@ export type GameEvent =
 /**
  * Result type for actions that produce events.
  * Actions return both the new state and any events that occurred.
+ *
+ * Note: This interface is defined for future use when actions are refactored
+ * to emit events directly. Currently, events are emitted by the tick processor.
  */
 export interface ActionResult<T> {
   /** Updated game state */

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -100,7 +100,8 @@ export interface GameState {
   lastDailyReset: Timestamp;
   /**
    * Event queue containing transient events from the last tick or action.
-   * Events are consumed by the UI and cleared after processing.
+   * Events are cleared at the start of each tick. The UI tracks processed
+   * events by timestamp to avoid duplicates.
    * Not persisted to storage.
    */
   pendingEvents: GameEvent[];

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -5,6 +5,7 @@
 import type { BattleState } from "@/game/core/battle/battle";
 import type { ExplorationResult, TrainingResult } from "./activity";
 import type { Tick, Timestamp } from "./common";
+import type { GameEvent } from "./event";
 import type { Pet } from "./pet";
 import type { QuestProgress } from "./quest";
 import { createInitialSkills, type PlayerSkills } from "./skill";
@@ -97,6 +98,12 @@ export interface GameState {
    * Per spec (time-mechanics.md): Daily reset occurs at midnight local time.
    */
   lastDailyReset: Timestamp;
+  /**
+   * Event queue containing transient events from the last tick or action.
+   * Events are consumed by the UI and cleared after processing.
+   * Not persisted to storage.
+   */
+  pendingEvents: GameEvent[];
 }
 
 /**
@@ -123,5 +130,6 @@ export function createInitialGameState(): GameState {
     quests: [],
     isInitialized: false,
     lastDailyReset: currentTime,
+    pendingEvents: [],
   };
 }

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -5,6 +5,7 @@
 export * from "./activity";
 export * from "./common";
 export * from "./constants";
+export * from "./event";
 export * from "./gameState";
 export * from "./item";
 export * from "./location";


### PR DESCRIPTION
Implements Recommendation 3 from REVIEW.md by adding an event bus system. Actions and tick processor now emit events instead of relying on state diffing for detecting one-off occurrences like training completion, exploration results, or stage transitions.

Changes:
- Add GameEvent types and createEvent helper (src/game/types/event.ts)
- Add emitEvents/clearEvents utilities (src/game/core/events.ts)
- Add pendingEvents queue to GameState
- Update tick processor to emit events for stage transitions, training completion, and exploration completion
- Refactor useGameNotifications hook to consume events from the event bus
- Update persistence to not persist transient events
- Update tests for new event-based approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed event system and createEvent helper; GameState now carries pendingEvents and ticks emit stage, training, and exploration events.

* **Refactor**
  * Notifications now use event-driven processing with timestamp deduplication instead of state diffing.

* **Tests**
  * New tests for event utilities and updated notification tests using injected events; test helpers updated to include pendingEvents.

* **Chores**
  * Save/load now initialize/clear pendingEvents to avoid persisting transient events.

* **Documentation**
  * Added architecture review describing the event-driven approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->