### PR TITLE
fix: auto-activate and reset daily quests on daily refresh

### DIFF
--- a/src/game/context/GameContext.tsx
+++ b/src/game/context/GameContext.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import type { BattleAction } from "@/game/core/battle/battleActions";
+import { refreshDailyQuests } from "@/game/core/quests/quests";
 import { processOfflineCatchup } from "@/game/core/tickProcessor";
 import { calculateElapsedTicks, MAX_OFFLINE_TICKS } from "@/game/core/time";
 import {
@@ -261,7 +262,7 @@ export function GameProvider({ children }: GameProviderProps) {
       }
 
       // Create initial game state with pet and starting items
-      const newState: GameState = {
+      let newState: GameState = {
         ...createInitialGameState(),
         pet,
         player: {
@@ -272,6 +273,9 @@ export function GameProvider({ children }: GameProviderProps) {
         },
         isInitialized: true,
       };
+
+      // Initialize daily quests (auto-activated)
+      newState = refreshDailyQuests(newState);
 
       // Start the game with the new state
       // Note: setHasSaveData is set after startGame for consistency,

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -8,7 +8,10 @@ import {
   processExplorationTick,
 } from "@/game/core/exploration/forage";
 import { calculatePetMaxStats } from "@/game/core/petStats";
-import { updateQuestProgress } from "@/game/core/quests/quests";
+import {
+  refreshDailyQuests,
+  updateQuestProgress,
+} from "@/game/core/quests/quests";
 import { resetDailySleep } from "@/game/core/sleep";
 import { processPetTick } from "@/game/core/tick";
 import { getMidnightTimestamp, shouldDailyReset } from "@/game/core/time";
@@ -41,6 +44,7 @@ import { SkillType } from "@/game/types/skill";
 /**
  * Apply daily reset if needed.
  * Resets daily counters like sleepTicksToday at midnight local time.
+ * Also refreshes daily quests.
  */
 function applyDailyResetIfNeeded(
   state: GameState,
@@ -51,7 +55,7 @@ function applyDailyResetIfNeeded(
   }
 
   const todayMidnight = getMidnightTimestamp(currentTime);
-  return {
+  let updatedState: GameState = {
     ...state,
     lastDailyReset: todayMidnight,
     pet: state.pet
@@ -61,6 +65,11 @@ function applyDailyResetIfNeeded(
         }
       : null,
   };
+
+  // Refresh daily quests on daily reset
+  updatedState = refreshDailyQuests(updatedState);
+
+  return updatedState;
 }
 
 /**

--- a/src/game/data/quests/index.ts
+++ b/src/game/data/quests/index.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Quest } from "@/game/types/quest";
+import { QuestType } from "@/game/types/quest";
 import { dailyQuests } from "./daily";
 import { mainQuests } from "./main";
 import { sideQuests } from "./side";
@@ -37,4 +38,13 @@ export function getQuestsByType(type: string): Quest[] {
  */
 export function getQuestsByGiver(giverId: string): Quest[] {
   return Object.values(quests).filter((quest) => quest.giverId === giverId);
+}
+
+/**
+ * Get all daily quests.
+ */
+export function getDailyQuests(): Quest[] {
+  return Object.values(quests).filter(
+    (quest) => quest.type === QuestType.Daily,
+  );
 }


### PR DESCRIPTION
- Daily quests now start in Active state (no manual acceptance needed)
- Daily quests refresh automatically at midnight with the daily reset
- Completed/in-progress daily quests are reset to fresh Active state
- New games initialize with all daily quests auto-activated
- Added getDailyQuests() helper and refreshDailyQuests() function
- Added tests for daily quest reset functionality