### PR TITLE
Remove legacy lastExplorationResult and lastTrainingResult fields

### DIFF
--- a/src/game/core/events.test.ts
+++ b/src/game/core/events.test.ts
@@ -37,6 +37,7 @@ test("emitEvents appends events to the queue", () => {
     type: "trainingComplete",
     facilityName: "Gym",
     statsGained: { strength: 5 },
+    message: "Training complete! +5 strength",
     petName: "Test Pet",
   });
 
@@ -114,6 +115,7 @@ test("getEventsByType filters events by type correctly", () => {
     type: "trainingComplete",
     facilityName: "Gym",
     statsGained: { strength: 5 },
+    message: "Training complete! +5 strength",
     petName: "Test Pet",
   });
 

--- a/src/game/core/tickProcessor.test.ts
+++ b/src/game/core/tickProcessor.test.ts
@@ -620,6 +620,7 @@ test("processGameTick emits trainingComplete event when training completes", () 
   if (trainingEvent?.type === "trainingComplete") {
     expect(trainingEvent.facilityName).toBe("Strength Gym");
     expect(trainingEvent.statsGained.strength).toBeGreaterThan(0);
+    expect(trainingEvent.message).toBeDefined();
   }
 });
 

--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -276,6 +276,7 @@ export function processGameTick(
             type: "trainingComplete",
             facilityName,
             statsGained: trainingResultBeforeCompletion.statsGained ?? {},
+            message: trainingResultBeforeCompletion.message,
             petName,
           },
           currentTime,
@@ -412,7 +413,7 @@ export function processOfflineCatchup(
             facilityName: event.facilityName,
             result: {
               success: true,
-              message: `Completed training at ${event.facilityName}`,
+              message: event.message,
               statsGained: event.statsGained,
             },
           });

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -87,7 +87,6 @@ describe("useGameNotifications", () => {
       totalTicks: 0,
       quests: [],
       pet: defaultPet,
-      lastExplorationResult: undefined,
       isInitialized: true,
       lastSaveTime: Date.now(),
       lastDailyReset: Date.now(),

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -168,6 +168,7 @@ describe("useGameNotifications", () => {
         type: "trainingComplete",
         facilityName: "Gym",
         statsGained: { strength: 10, endurance: 5 },
+        message: "Training complete! +10 strength, +5 endurance",
         petName: "Fluffy",
       });
     });

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -153,6 +153,7 @@ describe("useGameNotifications", () => {
             type: "trainingComplete",
             facilityName: "Gym",
             statsGained: { strength: 10, endurance: 5 },
+            message: "Training complete! +10 strength, +5 endurance",
             petName: "Fluffy",
           }),
         ],

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -67,6 +67,7 @@ function eventToNotification(event: GameEvent): GameNotification | null {
         type: "trainingComplete",
         facilityName: event.facilityName,
         statsGained: event.statsGained,
+        message: event.message,
         petName: event.petName,
       };
     case "explorationComplete":

--- a/src/game/types/event.ts
+++ b/src/game/types/event.ts
@@ -37,6 +37,7 @@ export interface TrainingCompleteEvent extends BaseGameEvent {
   type: "trainingComplete";
   facilityName: string;
   statsGained: Partial<BattleStats>;
+  message: string;
   petName: string;
 }
 

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -3,7 +3,6 @@
  */
 
 import type { BattleState } from "@/game/core/battle/battle";
-import type { ExplorationResult, TrainingResult } from "./activity";
 import type { Tick, Timestamp } from "./common";
 import type { GameEvent } from "./event";
 import type { Pet } from "./pet";
@@ -83,10 +82,6 @@ export interface GameState {
   quests: QuestProgress[];
   /** Whether the game has been initialized */
   isInitialized: boolean;
-  /** Last exploration result (for UI notification, cleared after display) */
-  lastExplorationResult?: ExplorationResult & { locationName: string };
-  /** Last training result (for UI notification, cleared after display) */
-  lastTrainingResult?: TrainingResult & { facilityName: string };
   /**
    * Active battle (if in combat).
    * Persisted to allow resuming battle after page refresh.

--- a/src/game/types/notification.ts
+++ b/src/game/types/notification.ts
@@ -28,6 +28,8 @@ export interface TrainingCompleteNotification {
   facilityName: string;
   /** Stats gained from training */
   statsGained: Partial<BattleStats>;
+  /** Result message */
+  message: string;
   /** Pet name */
   petName: string;
 }


### PR DESCRIPTION
- Remove lastExplorationResult and lastTrainingResult from GameState type
- Update processGameTick to no longer set legacy fields (events are already emitted)
- Refactor processOfflineCatchup to collect results from pendingEvents instead
- Update tests to verify behavior via pendingEvents
- Remove unused ExplorationResult/TrainingResult imports from gameState.ts

Addresses REVIEW.md recommendation to consolidate notification system to use only the event system (pendingEvents with typed events).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Notifications for exploration and training now flow via events instead of transient result fields in game state.

* **New Features**
  * Training completion events and notifications now include a message field for richer UI messaging.

* **Tests**
  * Tests updated to assert emission and payloads of completion events (including message) rather than checking legacy transient result fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->