### PR TITLE
Fix flaky battleEnd event test by ensuring attack always hits

### DIFF
--- a/src/game/core/battle/battleReducer.test.ts
+++ b/src/game/core/battle/battleReducer.test.ts
@@ -156,7 +156,7 @@ test("battleReducer emits battleEnd event when battle completes", () => {
     },
   };
   // Give enemy very low health so attack will defeat them
-  // Set dodgeChance to 0 to ensure the attack always hits
+  // Set dodgeChance to 0 and high precision to guarantee hit
   const lowHealthEnemy: Combatant = {
     ...battleState.enemy,
     derivedStats: {

--- a/src/game/core/battle/battleReducer.test.ts
+++ b/src/game/core/battle/battleReducer.test.ts
@@ -147,6 +147,14 @@ test("battleReducer emits playerAttack event", () => {
 
 test("battleReducer emits battleEnd event when battle completes", () => {
   const battleState = createTestBattleState();
+  // Give player high precision to guarantee hit (need 30+ for 100% hit chance)
+  const highPrecisionPlayer: Combatant = {
+    ...battleState.player,
+    battleStats: {
+      ...battleState.player.battleStats,
+      precision: 50,
+    },
+  };
   // Give enemy very low health so attack will defeat them
   // Set dodgeChance to 0 to ensure the attack always hits
   const lowHealthEnemy: Combatant = {
@@ -161,6 +169,7 @@ test("battleReducer emits battleEnd event when battle completes", () => {
   const nearEndState: BattleState = {
     ...battleState,
     phase: BattlePhase.PlayerTurn,
+    player: highPrecisionPlayer,
     enemy: lowHealthEnemy,
   };
   const state = createTestGameState(nearEndState);


### PR DESCRIPTION
The test was flaky because the player's attack had only ~90% hit chance (85% base + 5% from precision). Set player precision to 50 to guarantee 100% hit chance, making the test deterministic.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the battleEnd test deterministic by guaranteeing the player's attack hits. Set player precision to 50 (30+ yields 100% hit chance) so the enemy is reliably defeated and the event is emitted.

<sup>Written for commit bf606ce1144893c79de292f682c174711f678046. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved battle-end test reliability by making outcomes deterministic: increased attacker precision and tightened opponent dodge/health conditions so a finishing hit is guaranteed, reducing flakiness in end-state scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->