### PR TITLE
fix: suppress console.warn output in battleReducer test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,11 +154,11 @@ Follow this workflow when implementing new features:
 1. **Create a feature branch** if on main: `git checkout -b feature/<name>`
 2. **Implement the feature**, making commits as you go (pre-commit hooks will validate each commit) so there is no need to manually validate
 3. **Push and open a PR** for the branch using the `gh` cli
-4. **Wait ~10 minutes** for PR feedback comments
+4. **Wait ~10 minutes** for PR feedback comments by using `sleep`
 5. **Fetch and review PR feedback** comments left after your latest commit using the `github` MCP server
 6. **Evaluate each review comment** and determine if it's valid
 7. **Address valid issues** with code changes
 8. **Commit and push** to the current branch
 9. **Request re-review** from Copilot using the `gh pr edit` with the `--add-reviewer` flag
-10. **Wait ~10 minutes** again for PR feedback comments
+10. **Wait ~10 minutes** again for PR feedback comments by using `sleep`
 11. **Repeat from step 5** until the PR is approved

--- a/src/game/core/battle/battleReducer.test.ts
+++ b/src/game/core/battle/battleReducer.test.ts
@@ -2,7 +2,7 @@
  * Tests for battle reducer.
  */
 
-import { expect, type Mock, mock, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
 import { basicAttack } from "@/game/data/moves";
 import { SPECIES } from "@/game/data/species";
 import { createDefaultBattleStats } from "@/game/testing/createTestPet";
@@ -83,9 +83,7 @@ test("battleReducer returns unchanged state when not player turn", () => {
 });
 
 test("battleReducer returns unchanged state when move not found", () => {
-  const originalWarn = console.warn;
-  const mockWarn: Mock<(...args: unknown[]) => void> = mock();
-  console.warn = mockWarn;
+  const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
   try {
     const battleState = createTestBattleState();
@@ -98,9 +96,9 @@ test("battleReducer returns unchanged state when move not found", () => {
     const newState = battleReducer(state, action, 1000);
 
     expect(newState).toBe(state);
-    expect(mockWarn).toHaveBeenCalledWith("Move not found: Nonexistent Move");
+    expect(warnSpy).toHaveBeenCalledWith("Move not found: Nonexistent Move");
   } finally {
-    console.warn = originalWarn;
+    warnSpy.mockRestore();
   }
 });
 

--- a/src/game/core/battle/battleReducer.test.ts
+++ b/src/game/core/battle/battleReducer.test.ts
@@ -2,7 +2,7 @@
  * Tests for battle reducer.
  */
 
-import { expect, mock, spyOn, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { basicAttack } from "@/game/data/moves";
 import { SPECIES } from "@/game/data/species";
 import { createDefaultBattleStats } from "@/game/testing/createTestPet";


### PR DESCRIPTION
Mock console.warn in the 'move not found' test to prevent polluting test output while also verifying the warning is correctly emitted.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked console.warn with bun:test spyOn in the battleReducer "move not found" test to prevent noisy output and verify the warning message. Restores the original console.warn after the test to avoid side effects.

<sup>Written for commit 5194710622f0c32d89c14fd39fc9603cbbfacd77. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





