### PR TITLE
Shorten long button texts for mobile view

### DIFF
--- a/src/components/game/StageTransitionNotification.tsx
+++ b/src/components/game/StageTransitionNotification.tsx
@@ -11,7 +11,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { GrowthStage } from "@/game/types/constants";
+import {
+  GROWTH_STAGE_DISPLAY_NAMES,
+  type GrowthStage,
+} from "@/game/types/constants";
 import { cn } from "@/lib/utils";
 
 interface StageTransitionNotificationProps {
@@ -20,17 +23,6 @@ interface StageTransitionNotificationProps {
   petName: string;
   onDismiss: () => void;
 }
-
-/**
- * Display names for each growth stage.
- */
-const STAGE_DISPLAY_NAMES: Record<GrowthStage, string> = {
-  baby: "Baby",
-  child: "Child",
-  teen: "Teen",
-  youngAdult: "Young Adult",
-  adult: "Adult",
-};
 
 /**
  * Emojis for each growth stage.
@@ -47,7 +39,7 @@ const STAGE_EMOJIS: Record<GrowthStage, string> = {
  * Get display name for a growth stage.
  */
 function getStageDisplayName(stage: GrowthStage): string {
-  return STAGE_DISPLAY_NAMES[stage];
+  return GROWTH_STAGE_DISPLAY_NAMES[stage];
 }
 
 /**

--- a/src/game/core/quests/quests.test.ts
+++ b/src/game/core/quests/quests.test.ts
@@ -733,9 +733,7 @@ test("startQuest fails when not at required start location", () => {
     const result = startQuest(state, "location_start_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe(
-      "You must be at the quest's starting location to accept it.",
-    );
+    expect(result.message).toBe("Go to start location");
   } finally {
     delete quests.location_start_quest;
   }
@@ -791,9 +789,7 @@ test("completeQuest fails when not at required complete location", () => {
     const result = completeQuest(state, "location_complete_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe(
-      "You must be at the quest's turn-in location to complete it.",
-    );
+    expect(result.message).toBe("Go to turn-in location");
   } finally {
     delete quests.location_complete_quest;
   }
@@ -851,9 +847,7 @@ test("quest with different start and complete locations works correctly", () => 
       "different_locations_quest",
     );
     expect(failCompleteResult.success).toBe(false);
-    expect(failCompleteResult.message).toBe(
-      "You must be at the quest's turn-in location to complete it.",
-    );
+    expect(failCompleteResult.message).toBe("Go to turn-in location");
 
     // Move to guild_hall and complete
     const movedState = {
@@ -885,9 +879,7 @@ test("startTimedQuest fails when not at required start location", () => {
     const result = startTimedQuest(state, "timed_location_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe(
-      "You must be at the quest's starting location to accept it.",
-    );
+    expect(result.message).toBe("Go to start location");
   } finally {
     delete quests.timed_location_quest;
   }

--- a/src/game/core/quests/quests.ts
+++ b/src/game/core/quests/quests.ts
@@ -38,7 +38,7 @@ function validateStartLocation(
   if (quest.startLocationId && currentLocationId !== quest.startLocationId) {
     return {
       valid: false,
-      message: "You must be at the quest's starting location to accept it.",
+      message: "Go to start location",
     };
   }
   return { valid: true };
@@ -57,7 +57,7 @@ function validateCompleteLocation(
   ) {
     return {
       valid: false,
-      message: "You must be at the quest's turn-in location to complete it.",
+      message: "Go to turn-in location",
     };
   }
   return { valid: true };

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -67,7 +67,7 @@ test("checkLocationRequirements returns not met when stage insufficient", () => 
   });
   const result = checkLocationRequirements(state, { stage: GrowthStage.Child });
   expect(result.met).toBe(false);
-  expect(result.reason).toContain("Requires");
+  expect(result.reason).toBe(`Requires ${GrowthStage.Child} stage`);
 });
 
 test("checkLocationRequirements returns met when stage sufficient", () => {
@@ -92,7 +92,7 @@ test("checkLocationRequirements returns not met for incomplete quest", () => {
   });
   const result = checkLocationRequirements(state, { questId: "test-quest" });
   expect(result.met).toBe(false);
-  expect(result.reason).toContain("Quest required");
+  expect(result.reason).toBe("Quest required");
 });
 
 test("checkLocationRequirements returns met for completed quest", () => {
@@ -180,7 +180,7 @@ test("canTravel fails for disconnected locations", () => {
   const state = createTestState({});
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
-  expect(result.message).toContain("Not connected");
+  expect(result.message).toBe("Not connected");
 });
 
 test("canTravel fails when energy insufficient", () => {
@@ -213,7 +213,7 @@ test("canTravel fails when stage requirement not met", () => {
   });
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
-  expect(result.message).toContain("Requires");
+  expect(result.message).toBe(`Requires ${GrowthStage.Child} stage`);
 });
 
 test("canTravel succeeds when stage requirement met", () => {

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -8,7 +8,11 @@ import {
   createTestPet,
 } from "@/game/testing/createTestPet";
 import { toMicro } from "@/game/types/common";
-import { ActivityState, GrowthStage } from "@/game/types/constants";
+import {
+  ActivityState,
+  GROWTH_STAGE_DISPLAY_NAMES,
+  GrowthStage,
+} from "@/game/types/constants";
 import { createInitialGameState, type GameState } from "@/game/types/gameState";
 import type { Pet } from "@/game/types/pet";
 import {
@@ -67,7 +71,9 @@ test("checkLocationRequirements returns not met when stage insufficient", () => 
   });
   const result = checkLocationRequirements(state, { stage: GrowthStage.Child });
   expect(result.met).toBe(false);
-  expect(result.reason).toBe(`Requires ${GrowthStage.Child} stage`);
+  expect(result.reason).toBe(
+    `Requires ${GROWTH_STAGE_DISPLAY_NAMES[GrowthStage.Child]} stage`,
+  );
 });
 
 test("checkLocationRequirements returns met when stage sufficient", () => {
@@ -213,7 +219,9 @@ test("canTravel fails when stage requirement not met", () => {
   });
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
-  expect(result.message).toBe(`Requires ${GrowthStage.Child} stage`);
+  expect(result.message).toBe(
+    `Requires ${GROWTH_STAGE_DISPLAY_NAMES[GrowthStage.Child]} stage`,
+  );
 });
 
 test("canTravel succeeds when stage requirement met", () => {

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -58,7 +58,7 @@ test("checkLocationRequirements returns not met when pet is null and stage requi
   const state = createTestState({ pet: null });
   const result = checkLocationRequirements(state, { stage: GrowthStage.Child });
   expect(result.met).toBe(false);
-  expect(result.reason).toBe("You need a pet to access this location.");
+  expect(result.reason).toBe("Pet required");
 });
 
 test("checkLocationRequirements returns not met when stage insufficient", () => {
@@ -67,7 +67,7 @@ test("checkLocationRequirements returns not met when stage insufficient", () => 
   });
   const result = checkLocationRequirements(state, { stage: GrowthStage.Child });
   expect(result.met).toBe(false);
-  expect(result.reason).toContain("must be at least");
+  expect(result.reason).toContain("Requires");
 });
 
 test("checkLocationRequirements returns met when stage sufficient", () => {
@@ -92,7 +92,7 @@ test("checkLocationRequirements returns not met for incomplete quest", () => {
   });
   const result = checkLocationRequirements(state, { questId: "test-quest" });
   expect(result.met).toBe(false);
-  expect(result.reason).toContain("complete a required quest");
+  expect(result.reason).toContain("Quest required");
 });
 
 test("checkLocationRequirements returns met for completed quest", () => {
@@ -132,7 +132,7 @@ test("canTravel fails when no pet", () => {
   const state = createTestState({ pet: null });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
-  expect(result.message).toBe("You need a pet to travel.");
+  expect(result.message).toBe("Pet required");
 });
 
 test("canTravel fails when pet is sleeping", () => {
@@ -180,7 +180,7 @@ test("canTravel fails for disconnected locations", () => {
   const state = createTestState({});
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
-  expect(result.message).toContain("cannot travel there directly");
+  expect(result.message).toContain("Not connected");
 });
 
 test("canTravel fails when energy insufficient", () => {
@@ -213,7 +213,7 @@ test("canTravel fails when stage requirement not met", () => {
   });
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
-  expect(result.message).toContain("must be at least");
+  expect(result.message).toContain("Requires");
 });
 
 test("canTravel succeeds when stage requirement met", () => {

--- a/src/game/core/travel.ts
+++ b/src/game/core/travel.ts
@@ -43,13 +43,13 @@ export function checkLocationRequirements(
     if (!state.pet) {
       return {
         met: false,
-        reason: "You need a pet to access this location.",
+        reason: "Pet required",
       };
     }
     if (!meetsStageRequirement(state.pet.growth.stage, requirements.stage)) {
       return {
         met: false,
-        reason: `Your pet must be at least ${requirements.stage} stage to access this location.`,
+        reason: `Requires ${requirements.stage} stage`,
       };
     }
   }
@@ -62,7 +62,7 @@ export function checkLocationRequirements(
     if (!questCompleted) {
       return {
         met: false,
-        reason: "You need to complete a required quest first.",
+        reason: "Quest required",
       };
     }
   }
@@ -102,7 +102,7 @@ export function canTravel(
 ): TravelResult {
   // Must have a pet
   if (!state.pet) {
-    return { success: false, message: "You need a pet to travel." };
+    return { success: false, message: "Pet required" };
   }
 
   const currentLocationId = state.player.currentLocationId;
@@ -117,7 +117,7 @@ export function canTravel(
   if (!areLocationsConnected(currentLocationId, destinationId)) {
     return {
       success: false,
-      message: "You cannot travel there directly from here.",
+      message: "Not connected",
     };
   }
 

--- a/src/game/core/travel.ts
+++ b/src/game/core/travel.ts
@@ -6,7 +6,11 @@ import { checkActivityIdle, checkEnergy } from "@/game/core/activityGating";
 import { updateQuestProgress } from "@/game/core/quests/quests";
 import { areLocationsConnected, getLocation } from "@/game/data/locations";
 import { toMicro } from "@/game/types/common";
-import { GROWTH_STAGE_ORDER, type GrowthStage } from "@/game/types/constants";
+import {
+  GROWTH_STAGE_DISPLAY_NAMES,
+  GROWTH_STAGE_ORDER,
+  type GrowthStage,
+} from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import type { LocationRequirement, TravelResult } from "@/game/types/location";
 import { ObjectiveType } from "@/game/types/quest";
@@ -49,7 +53,7 @@ export function checkLocationRequirements(
     if (!meetsStageRequirement(state.pet.growth.stage, requirements.stage)) {
       return {
         met: false,
-        reason: `Requires ${requirements.stage} stage`,
+        reason: `Requires ${GROWTH_STAGE_DISPLAY_NAMES[requirements.stage]} stage`,
       };
     }
   }

--- a/src/game/types/constants.ts
+++ b/src/game/types/constants.ts
@@ -18,6 +18,17 @@ export const GrowthStage = {
 export type GrowthStage = (typeof GrowthStage)[keyof typeof GrowthStage];
 
 /**
+ * Human-friendly display names for growth stages.
+ */
+export const GROWTH_STAGE_DISPLAY_NAMES: Record<GrowthStage, string> = {
+  baby: "Baby",
+  child: "Child",
+  teen: "Teen",
+  youngAdult: "Young Adult",
+  adult: "Adult",
+} as const;
+
+/**
  * Ordered array of growth stages for iteration.
  */
 export const GROWTH_STAGE_ORDER: readonly GrowthStage[] = [


### PR DESCRIPTION
## Summary
Shortened long button texts that were too long for mobile view.

## Changes
- Travel requirement messages shortened:
  - "You need a pet to access this location." → "Pet required"
  - "Your pet must be at least X stage to access this location." → "Requires X stage"
  - "You need to complete a required quest first." → "Quest required"
  - "You need a pet to travel." → "Pet required"
  - "You cannot travel there directly from here." → "Not connected"
- Quest location messages shortened:
  - "You must be at the quest's starting location to accept it." → "Go to start location"
  - "You must be at the quest's turn-in location to complete it." → "Go to turn-in location"

## Testing
All tests updated and passing.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened travel and quest button texts for mobile to prevent overflow and improve readability. Messages now use growth stage display names and tests assert exact strings.

Replacements: Pet required, Requires X stage, Quest required, Not connected, Go to start location, Go to turn-in location.

<sup>Written for commit 620fc34884e7155d1ac254c5f55c189189cd7339. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Quest location prompts shortened to concise, action-oriented messages (e.g., "Go to start location", "Go to turn-in location").
  * Travel and access feedback simplified to brief notices: "Pet required", "Quest required", "Not connected", and explicit stage-requirement phrasing.

* **New Features**
  * Standardized human-friendly growth-stage display names used across notifications and travel messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->