### PR TITLE
Add tutorial quest requirements for travel

### DIFF
--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -142,7 +142,10 @@ test("canTravel fails when no pet", () => {
 });
 
 test("canTravel fails when pet is sleeping", () => {
-  const state = createTestState({ pet: createSleepingTestPet() });
+  const state = createTestState({
+    pet: createSleepingTestPet(),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
+  });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
   expect(result.message).toContain("sleeping");
@@ -151,6 +154,7 @@ test("canTravel fails when pet is sleeping", () => {
 test("canTravel fails when pet is training", () => {
   const state = createTestState({
     pet: createTestPet({ activityState: ActivityState.Training }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
@@ -160,6 +164,7 @@ test("canTravel fails when pet is training", () => {
 test("canTravel fails when pet is exploring", () => {
   const state = createTestState({
     pet: createTestPet({ activityState: ActivityState.Exploring }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
@@ -169,6 +174,7 @@ test("canTravel fails when pet is exploring", () => {
 test("canTravel fails when pet is battling", () => {
   const state = createTestState({
     pet: createTestPet({ activityState: ActivityState.Battling }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
@@ -192,6 +198,7 @@ test("canTravel fails for disconnected locations", () => {
 test("canTravel fails when energy insufficient", () => {
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(2) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(false);
@@ -202,6 +209,7 @@ test("canTravel fails when energy insufficient", () => {
 test("canTravel succeeds with sufficient energy", () => {
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = canTravel(state, "meadow");
   expect(result.success).toBe(true);
@@ -216,6 +224,7 @@ test("canTravel fails when stage requirement not met", () => {
       energyStats: { energy: toMicro(50) },
     }),
     currentLocationId: "meadow",
+    quests: [{ questId: "tutorial_training", isCompleted: true }],
   });
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(false);
@@ -231,6 +240,7 @@ test("canTravel succeeds when stage requirement met", () => {
       energyStats: { energy: toMicro(50) },
     }),
     currentLocationId: "meadow",
+    quests: [{ questId: "tutorial_training", isCompleted: true }],
   });
   const result = canTravel(state, "misty_woods");
   expect(result.success).toBe(true);
@@ -249,6 +259,7 @@ test("travel succeeds and deducts energy", () => {
   const initialEnergy = toMicro(50);
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: initialEnergy } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = travel(state, "meadow");
 
@@ -261,6 +272,7 @@ test("travel succeeds and deducts energy", () => {
 test("travel preserves other state properties", () => {
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   state.player.currency.coins = 100;
   const result = travel(state, "meadow");
@@ -272,6 +284,7 @@ test("travel preserves other state properties", () => {
 test("travel does not mutate original state", () => {
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const originalLocation = state.player.currentLocationId;
   const originalEnergy = state.pet?.energyStats.energy;
@@ -286,6 +299,7 @@ test("travel energy cannot go below 0", () => {
   // Set energy to exactly the cost
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(5) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   const result = travel(state, "meadow");
 
@@ -296,10 +310,11 @@ test("travel energy cannot go below 0", () => {
 test("travel updates quest progress for Visit objectives", () => {
   const state = createTestState({
     pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
-    quests: [],
+    quests: [{ questId: "tutorial_first_steps", isCompleted: true }],
   });
   // Add an active quest with a visit objective for meadow
   state.quests = [
+    ...state.quests,
     {
       questId: "tutorial_exploration",
       state: "active",
@@ -310,5 +325,5 @@ test("travel updates quest progress for Visit objectives", () => {
   const result = travel(state, "meadow");
 
   expect(result.success).toBe(true);
-  expect(result.state.quests[0]?.objectiveProgress.visit_meadow).toBe(1);
+  expect(result.state.quests[1]?.objectiveProgress.visit_meadow).toBe(1);
 });

--- a/src/game/core/travel.test.ts
+++ b/src/game/core/travel.test.ts
@@ -246,6 +246,26 @@ test("canTravel succeeds when stage requirement met", () => {
   expect(result.success).toBe(true);
 });
 
+test("canTravel fails when quest requirement not completed", () => {
+  const state = createTestState({
+    pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
+    quests: [{ questId: "tutorial_first_steps", isCompleted: false }],
+  });
+  const result = canTravel(state, "meadow");
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("Quest required");
+});
+
+test("canTravel fails when quest requirement not started", () => {
+  const state = createTestState({
+    pet: createTestPet({ energyStats: { energy: toMicro(50) } }),
+    quests: [],
+  });
+  const result = canTravel(state, "meadow");
+  expect(result.success).toBe(false);
+  expect(result.message).toBe("Quest required");
+});
+
 // travel tests
 
 test("travel fails when canTravel fails", () => {
@@ -325,5 +345,8 @@ test("travel updates quest progress for Visit objectives", () => {
   const result = travel(state, "meadow");
 
   expect(result.success).toBe(true);
-  expect(result.state.quests[1]?.objectiveProgress.visit_meadow).toBe(1);
+  const explorationQuest = result.state.quests.find(
+    (q) => q.questId === "tutorial_exploration",
+  );
+  expect(explorationQuest?.objectiveProgress.visit_meadow).toBe(1);
 });

--- a/src/game/data/locations/towns.ts
+++ b/src/game/data/locations/towns.ts
@@ -31,6 +31,9 @@ export const willowbrookTown: Location = {
     FacilityType.Inn,
     FacilityType.QuestBoard,
   ],
+  requirements: {
+    questId: "tutorial_training",
+  },
   npcIds: ["shopkeeper_mira", "trainer_oak"],
   emoji: "🏘️",
 };
@@ -52,6 +55,7 @@ export const ironhavenTown: Location = {
   ],
   requirements: {
     stage: GrowthStage.Child,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.Shop,
@@ -84,6 +88,9 @@ export const tidecrestTown: Location = {
     FacilityType.Inn,
     FacilityType.QuestBoard,
   ],
+  requirements: {
+    questId: "tutorial_training",
+  },
   npcIds: ["fisher_marina", "captain_torrent"],
   emoji: "⚓",
 };
@@ -105,6 +112,7 @@ export const starfallSanctuary: Location = {
   ],
   requirements: {
     stage: GrowthStage.YoungAdult,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.Shop,

--- a/src/game/data/locations/wild.ts
+++ b/src/game/data/locations/wild.ts
@@ -28,6 +28,9 @@ export const sunnyMeadow: Location = {
   ],
   levelMin: 1,
   levelMax: 5,
+  requirements: {
+    questId: "tutorial_first_steps",
+  },
   facilities: [
     FacilityType.RestPoint,
     FacilityType.ForageZone,
@@ -60,6 +63,7 @@ export const mistyWoods: Location = {
   levelMax: 15,
   requirements: {
     stage: GrowthStage.Child,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -89,6 +93,9 @@ export const whisperingCoast: Location = {
   ],
   levelMin: 3,
   levelMax: 10,
+  requirements: {
+    questId: "tutorial_training",
+  },
   facilities: [
     FacilityType.RestPoint,
     FacilityType.ForageZone,
@@ -119,6 +126,7 @@ export const scorchedHighlands: Location = {
   levelMax: 25,
   requirements: {
     stage: GrowthStage.Teen,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -151,6 +159,7 @@ export const crystalCaves: Location = {
   levelMax: 20,
   requirements: {
     stage: GrowthStage.Child,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -180,6 +189,7 @@ export const shadowDepths: Location = {
   levelMax: 30,
   requirements: {
     stage: GrowthStage.YoungAdult,
+    questId: "tutorial_training",
   },
   facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
   forageTableId: "depths_forage",
@@ -204,6 +214,9 @@ export const ancientGrove: Location = {
   ],
   levelMin: 4,
   levelMax: 12,
+  requirements: {
+    questId: "tutorial_training",
+  },
   facilities: [
     FacilityType.RestPoint,
     FacilityType.ForageZone,
@@ -233,6 +246,7 @@ export const mushroomHollow: Location = {
   levelMax: 16,
   requirements: {
     stage: GrowthStage.Child,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -263,6 +277,7 @@ export const coralReef: Location = {
   levelMax: 18,
   requirements: {
     stage: GrowthStage.Child,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -293,6 +308,7 @@ export const frozenPeaks: Location = {
   levelMax: 28,
   requirements: {
     stage: GrowthStage.Teen,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -321,6 +337,7 @@ export const volcanicCaldera: Location = {
   levelMax: 32,
   requirements: {
     stage: GrowthStage.YoungAdult,
+    questId: "tutorial_training",
   },
   facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
   forageTableId: "caldera_forage",
@@ -346,6 +363,7 @@ export const sunkenTemple: Location = {
   levelMax: 26,
   requirements: {
     stage: GrowthStage.Teen,
+    questId: "tutorial_training",
   },
   facilities: [
     FacilityType.RestPoint,
@@ -375,6 +393,7 @@ export const glacialCavern: Location = {
   levelMax: 34,
   requirements: {
     stage: GrowthStage.YoungAdult,
+    questId: "tutorial_training",
   },
   facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
   forageTableId: "glacial_forage",
@@ -400,6 +419,7 @@ export const celestialSpire: Location = {
   levelMax: 40,
   requirements: {
     stage: GrowthStage.Adult,
+    questId: "tutorial_training",
   },
   facilities: [FacilityType.ForageZone, FacilityType.BattleArea],
   forageTableId: "spire_forage",


### PR DESCRIPTION
## Summary
- Sunny Meadow requires 'First Steps' tutorial quest to be completed before travel
- All other locations except Home require 'Growing Stronger' (final tutorial) quest to be completed

## Changes
- Updated `src/game/data/locations/wild.ts` - Added quest requirements to all wild/dungeon locations
- Updated `src/game/data/locations/towns.ts` - Added quest requirements to all town locations  
- Updated `src/game/core/travel.test.ts` - Updated tests to include completed quests in test states



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tutorial gates to travel to ensure players finish onboarding before exploring. Sunny Meadow now requires “First Steps”; all other locations (except Home) require “Growing Stronger”.

- **New Features**
  - Added quest-based travel requirements to all wild and town locations.
  - Stage requirements still apply alongside the new quest gates.
  - Updated travel tests to include completed tutorial quests, verify visit objective progress, and cover quest requirement failures.

<sup>Written for commit 41f9e6077e369c132fb118e51be5bae6d629016c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quest-based access requirements to multiple towns and wild locations — certain tutorial quests must be completed before traveling to these areas.
  * Strengthened progression gating to guide new players through areas in sequence.

* **Tests**
  * Updated and added travel tests to enforce the new quest prerequisites and verify quest-progression behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->