### PR TITLE
Fix: tutorial quest 'Into the Wild' not tracking foraging completion

### DIFF
--- a/src/game/core/tickProcessor.ts
+++ b/src/game/core/tickProcessor.ts
@@ -218,7 +218,7 @@ export function processGameTick(
         updatedState = updateQuestProgress(
           updatedState,
           ObjectiveType.Explore,
-          "forage",
+          "foraging",
         );
 
         // Update quest progress for Collect objectives for each item found

--- a/src/game/data/quests/daily.ts
+++ b/src/game/data/quests/daily.ts
@@ -62,7 +62,7 @@ export const dailyForager: Quest = {
       id: "forage_once",
       type: ObjectiveType.Explore,
       description: "Complete foraging sessions",
-      target: "forage",
+      target: "foraging",
       quantity: 3,
     },
   ],

--- a/src/game/data/quests/tutorial.ts
+++ b/src/game/data/quests/tutorial.ts
@@ -76,7 +76,7 @@ export const tutorialExploration: Quest = {
       id: "forage_once",
       type: ObjectiveType.Explore,
       description: "Complete a foraging session",
-      target: "forage",
+      target: "foraging",
       quantity: 1,
     },
   ],

--- a/src/game/data/quests/weekly.ts
+++ b/src/game/data/quests/weekly.ts
@@ -69,7 +69,7 @@ export const weeklyExplorer: Quest = {
       id: "forage_weekly",
       type: ObjectiveType.Explore,
       description: "Complete foraging sessions",
-      target: "forage",
+      target: "foraging",
       quantity: 15,
     },
   ],


### PR DESCRIPTION
## Problem

Foraging completion was not progressing any quests that track foraging activity, including:
- Tutorial quest 'Into the Wild' (tutorial_exploration)
- Daily quest 'Daily Forager' (daily_forager)  
- Weekly quest 'Weekly Explorer' (weekly_explorer)

## Root Cause

There was a mismatch between the activity ID (`'foraging'`) and the quest objective targets (`'forage'`):

1. **tickProcessor.ts** - Hardcoded `'forage'` when calling `updateQuestProgress` on exploration completion
2. **Quest definitions** - All foraging quest objectives had `target: 'forage'` instead of `target: 'foraging'`

The `findMatchingObjectives` function does an exact string match, so `'forage' !== 'foraging'` caused no quest progress to be recorded.

## Fix

Updated all occurrences:
- `src/game/core/tickProcessor.ts` - Changed hardcoded `'forage'` to `'foraging'`
- `src/game/data/quests/tutorial.ts` - Fixed `forage_once` objective target
- `src/game/data/quests/daily.ts` - Fixed `forage_once` objective target
- `src/game/data/quests/weekly.ts` - Fixed `forage_weekly` objective target

## Testing

All 534 tests pass, including the test that verifies quest progress is updated when exploration completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized quest objective wording for consistency across tutorial, daily, and weekly quests to ensure objectives display and track uniformly.
  * Minor non-functional updates to internal quest references; no changes to rewards, progression, or player-facing quest structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->