### PR TITLE
refactor: apply QuestMessages and ExplorationMessages constants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -129,11 +129,11 @@ The codebase already has good constant extraction in several areas:
 
 ### Quest Messages (`src/game/core/quests/quests.ts`)
 
-- [ ] **Lines 41, 145-196, 204-278**: Quest action messages - `QuestMessages` defined in messages.ts but not yet applied to quests.ts
+- [x] **Lines 41, 145-196, 204-278**: Quest action messages - `QuestMessages` defined in messages.ts and applied to quests.ts
 
 ### Exploration Messages (`src/game/core/exploration/exploration.ts`)
 
-- [ ] **Lines 159, 169, 265, 438-440, 477**: Exploration messages - `ExplorationMessages` defined in messages.ts but not yet applied to exploration.ts
+- [x] **Lines 159, 169, 265, 438-440, 477**: Exploration messages - `ExplorationMessages` defined in messages.ts and applied to exploration.ts
 
 ### Location IDs
 

--- a/src/game/core/exploration/exploration.ts
+++ b/src/game/core/exploration/exploration.ts
@@ -14,6 +14,7 @@ import { addXpToPlayerSkill } from "@/game/core/skills";
 import { getActivityById } from "@/game/data/exploration/activities";
 import { getDropTableById } from "@/game/data/exploration/dropTables";
 import { getLocation } from "@/game/data/locations";
+import { ExplorationMessages } from "@/game/data/messages";
 import type {
   ActiveExploration,
   ExplorationDrop,
@@ -152,7 +153,7 @@ export function canStartExplorationActivity(
   if (pet.activityState !== ActivityState.Idle) {
     return {
       canStart: false,
-      reason: `Pet is currently ${pet.activityState}`,
+      reason: ExplorationMessages.petBusy(pet.activityState),
     };
   }
 
@@ -161,7 +162,7 @@ export function canStartExplorationActivity(
   if (!activity) {
     return {
       canStart: false,
-      reason: `Unknown activity: ${activityId}`,
+      reason: ExplorationMessages.unknownActivityId(activityId),
     };
   }
 
@@ -170,7 +171,7 @@ export function canStartExplorationActivity(
   if (!location) {
     return {
       canStart: false,
-      reason: `Unknown location: ${locationId}`,
+      reason: ExplorationMessages.unknownLocation(locationId),
     };
   }
 
@@ -179,7 +180,7 @@ export function canStartExplorationActivity(
   if (!locationDropTables || locationDropTables.length === 0) {
     return {
       canStart: false,
-      reason: `${activity.name} is not available at this location`,
+      reason: ExplorationMessages.activityNotAvailable(activity.name),
     };
   }
 
@@ -203,7 +204,7 @@ export function canStartExplorationActivity(
   if (energyMicro < requiredEnergyMicro) {
     return {
       canStart: false,
-      reason: `Not enough energy (need ${activity.energyCost})`,
+      reason: ExplorationMessages.notEnoughEnergy(activity.energyCost),
     };
   }
 
@@ -217,7 +218,7 @@ export function canStartExplorationActivity(
   if (cooldownRemaining > 0) {
     return {
       canStart: false,
-      reason: `Activity on cooldown (${cooldownRemaining} ticks remaining)`,
+      reason: ExplorationMessages.onCooldown(cooldownRemaining),
     };
   }
 
@@ -258,7 +259,7 @@ export function startExplorationActivity(
     return {
       success: false,
       pet,
-      message: `Unknown activity: ${activityId}`,
+      message: ExplorationMessages.unknownActivityId(activityId),
     };
   }
 
@@ -369,7 +370,7 @@ export function completeExplorationActivity(
       pet,
       itemsFound: [],
       skillXpGains: {},
-      message: "No active exploration to complete",
+      message: ExplorationMessages.noActiveExploration,
     };
   }
 
@@ -384,7 +385,7 @@ export function completeExplorationActivity(
       },
       itemsFound: [],
       skillXpGains: {},
-      message: "Unknown activity",
+      message: ExplorationMessages.unknownActivity,
     };
   }
 
@@ -430,10 +431,10 @@ export function completeExplorationActivity(
   };
 
   const itemCount = itemsFound.reduce((sum, drop) => sum + drop.quantity, 0);
-  const message =
-    itemCount > 0
-      ? `Found ${itemCount} item${itemCount !== 1 ? "s" : ""} at ${locationName}!`
-      : `Exploration complete at ${locationName}, but nothing was found this time.`;
+  const message = ExplorationMessages.explorationComplete(
+    itemCount,
+    locationName,
+  );
 
   return {
     success: true,
@@ -454,7 +455,7 @@ export function cancelExploration(pet: Pet): {
   if (!pet.activeExploration) {
     return {
       pet,
-      message: "No active exploration to cancel",
+      message: ExplorationMessages.noExplorationToCancel,
     };
   }
 
@@ -470,7 +471,7 @@ export function cancelExploration(pet: Pet): {
         energy: pet.energyStats.energy + energyRefund,
       },
     },
-    message: "Exploration cancelled. Energy has been refunded.",
+    message: ExplorationMessages.explorationCancelled,
   };
 }
 

--- a/src/game/core/quests/quests.test.ts
+++ b/src/game/core/quests/quests.test.ts
@@ -527,7 +527,7 @@ test("startTimedQuest successfully starts a timed quest with expiration", () => 
     const result = startTimedQuest(state, "timed_available_quest", currentTime);
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe("Started quest: Test Timed Quest");
+    expect(result.message).toBe("Started quest: Test Timed Quest.");
 
     const progress = result.state.quests.find(
       (q) => q.questId === "timed_available_quest",
@@ -733,7 +733,7 @@ test("startQuest fails when not at required start location", () => {
     const result = startQuest(state, "location_start_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe("Go to start location");
+    expect(result.message).toBe("Go to start location.");
   } finally {
     delete quests.location_start_quest;
   }
@@ -754,7 +754,7 @@ test("startQuest succeeds when at required start location", () => {
     const result = startQuest(state, "location_start_quest");
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe("Started quest: Location Start Quest");
+    expect(result.message).toBe("Started quest: Location Start Quest.");
   } finally {
     delete quests.location_start_quest;
   }
@@ -789,7 +789,7 @@ test("completeQuest fails when not at required complete location", () => {
     const result = completeQuest(state, "location_complete_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe("Go to turn-in location");
+    expect(result.message).toBe("Go to turn-in location.");
   } finally {
     delete quests.location_complete_quest;
   }
@@ -818,7 +818,7 @@ test("completeQuest succeeds when at required complete location", () => {
     const result = completeQuest(state, "location_complete_quest");
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe("Completed quest: Location Complete Quest");
+    expect(result.message).toBe("Completed quest: Location Complete Quest.");
   } finally {
     delete quests.location_complete_quest;
   }
@@ -847,7 +847,7 @@ test("quest with different start and complete locations works correctly", () => 
       "different_locations_quest",
     );
     expect(failCompleteResult.success).toBe(false);
-    expect(failCompleteResult.message).toBe("Go to turn-in location");
+    expect(failCompleteResult.message).toBe("Go to turn-in location.");
 
     // Move to guild_hall and complete
     const movedState = {
@@ -879,7 +879,7 @@ test("startTimedQuest fails when not at required start location", () => {
     const result = startTimedQuest(state, "timed_location_quest");
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe("Go to start location");
+    expect(result.message).toBe("Go to start location.");
   } finally {
     delete quests.timed_location_quest;
   }
@@ -900,7 +900,7 @@ test("startTimedQuest succeeds when at required start location", () => {
     const result = startTimedQuest(state, "timed_location_quest");
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe("Started quest: Timed Location Quest");
+    expect(result.message).toBe("Started quest: Timed Location Quest.");
   } finally {
     delete quests.timed_location_quest;
   }

--- a/src/game/core/quests/quests.ts
+++ b/src/game/core/quests/quests.ts
@@ -3,6 +3,7 @@
  */
 
 import { getNextDailyReset, getNextWeeklyReset } from "@/game/core/time";
+import { QuestMessages } from "@/game/data/messages";
 import { getDailyQuests, getQuest, getWeeklyQuests } from "@/game/data/quests";
 import type { GameState } from "@/game/types/gameState";
 import {
@@ -38,7 +39,7 @@ function validateStartLocation(
   if (quest.startLocationId && currentLocationId !== quest.startLocationId) {
     return {
       valid: false,
-      message: "Go to start location",
+      message: QuestMessages.goToStartLocation,
     };
   }
   return { valid: true };
@@ -57,7 +58,7 @@ function validateCompleteLocation(
   ) {
     return {
       valid: false,
-      message: "Go to turn-in location",
+      message: QuestMessages.goToTurnInLocation,
     };
   }
   return { valid: true };
@@ -145,7 +146,7 @@ export function startQuest(
     return {
       success: false,
       state,
-      message: "Quest not found.",
+      message: QuestMessages.questNotFound,
     };
   }
 
@@ -153,7 +154,7 @@ export function startQuest(
     return {
       success: false,
       state,
-      message: "Use startTimedQuest for timed quests.",
+      message: QuestMessages.useStartTimedQuest,
     };
   }
 
@@ -164,8 +165,8 @@ export function startQuest(
       state,
       message:
         currentState === QuestState.Locked
-          ? "Quest requirements not met."
-          : "Quest is already in progress or completed.",
+          ? QuestMessages.questLocked
+          : QuestMessages.questAlreadyStarted,
     };
   }
 
@@ -191,7 +192,7 @@ export function startQuest(
       ...state,
       quests: newQuests,
     },
-    message: `Started quest: ${quest.name}`,
+    message: QuestMessages.startedQuest(quest.name),
   };
 }
 
@@ -207,7 +208,7 @@ export function completeQuest(
     return {
       success: false,
       state,
-      message: "Quest not found.",
+      message: QuestMessages.questNotFound,
     };
   }
 
@@ -216,7 +217,7 @@ export function completeQuest(
     return {
       success: false,
       state,
-      message: "Quest not started.",
+      message: QuestMessages.questNotStarted,
     };
   }
 
@@ -225,7 +226,7 @@ export function completeQuest(
     return {
       success: false,
       state,
-      message: "Quest is not active.",
+      message: QuestMessages.questNotActive,
     };
   }
 
@@ -233,7 +234,7 @@ export function completeQuest(
     return {
       success: false,
       state,
-      message: "Not all objectives are complete.",
+      message: QuestMessages.objectivesIncomplete,
     };
   }
 
@@ -272,7 +273,7 @@ export function completeQuest(
       ...rewardResult.state,
       quests: newQuests,
     },
-    message: `Completed quest: ${quest.name}`,
+    message: QuestMessages.completedQuest(quest.name),
     rewardsSummary: rewardResult.rewardsSummary,
   };
 }
@@ -495,7 +496,7 @@ export function startTimedQuest(
     return {
       success: false,
       state,
-      message: "Quest not found.",
+      message: QuestMessages.questNotFound,
     };
   }
 
@@ -503,7 +504,7 @@ export function startTimedQuest(
     return {
       success: false,
       state,
-      message: "Quest is not a timed quest.",
+      message: QuestMessages.notTimedQuest,
     };
   }
 
@@ -511,7 +512,7 @@ export function startTimedQuest(
     return {
       success: false,
       state,
-      message: "Timed quest has no duration configured.",
+      message: QuestMessages.noDurationConfigured,
     };
   }
 
@@ -522,8 +523,8 @@ export function startTimedQuest(
       state,
       message:
         currentState === QuestState.Locked
-          ? "Quest requirements not met."
-          : "Quest is already in progress, completed, or expired.",
+          ? QuestMessages.questLocked
+          : QuestMessages.questExpired,
     };
   }
 
@@ -550,6 +551,6 @@ export function startTimedQuest(
       ...state,
       quests: newQuests,
     },
-    message: `Started quest: ${quest.name}`,
+    message: QuestMessages.startedQuest(quest.name),
   };
 }

--- a/src/game/core/quests/quests.ts
+++ b/src/game/core/quests/quests.ts
@@ -524,7 +524,7 @@ export function startTimedQuest(
       message:
         currentState === QuestState.Locked
           ? QuestMessages.questLocked
-          : QuestMessages.questExpired,
+          : QuestMessages.timedQuestNotAvailable,
     };
   }
 

--- a/src/game/data/messages.ts
+++ b/src/game/data/messages.ts
@@ -222,8 +222,9 @@ export const QuestMessages = {
   notTimedQuest: "Quest is not a timed quest.",
   /** When timed quest has no duration configured */
   noDurationConfigured: "Timed quest has no duration configured.",
-  /** When timed quest is expired */
-  questExpired: "Quest is already in progress, completed, or expired.",
+  /** When timed quest is not available (in progress, completed, or expired) */
+  timedQuestNotAvailable:
+    "Quest is already in progress, completed, or expired.",
   /** When should use startTimedQuest instead */
   useStartTimedQuest: "Use startTimedQuest for timed quests.",
   /**
@@ -262,31 +263,31 @@ export const ExplorationMessages = {
    * @param activityId - The unknown activity ID
    */
   unknownActivityId: (activityId: string): string =>
-    `Unknown activity: ${activityId}`,
+    `Unknown activity: ${activityId}.`,
   /**
    * Generate a message for unknown location.
    * @param locationId - The unknown location ID
    */
   unknownLocation: (locationId: string): string =>
-    `Unknown location: ${locationId}`,
+    `Unknown location: ${locationId}.`,
   /**
    * Generate a message for activity not available at location.
    * @param activityName - The activity name
    */
   activityNotAvailable: (activityName: string): string =>
-    `${activityName} is not available at this location`,
+    `${activityName} is not available at this location.`,
   /**
    * Generate a message for insufficient energy.
    * @param energyCost - Required energy cost
    */
   notEnoughEnergy: (energyCost: number): string =>
-    `Not enough energy (need ${energyCost})`,
+    `Not enough energy (need ${energyCost}).`,
   /**
    * Generate a message for activity on cooldown.
    * @param ticksRemaining - Ticks remaining on cooldown
    */
   onCooldown: (ticksRemaining: number): string =>
-    `Activity on cooldown (${ticksRemaining} ticks remaining)`,
+    `Activity on cooldown (${ticksRemaining} ticks remaining).`,
   /**
    * Generate a message for exploration completion with items found.
    * @param itemCount - Number of items found


### PR DESCRIPTION
## Summary
This PR applies the centralized message constants to the quest and exploration systems, completing two TODO items.

## Changes
- Apply `QuestMessages` to `quests.ts` for all quest action messages
- Apply `ExplorationMessages` to `exploration.ts` for all exploration messages  
- Update `quests.test.ts` to match new message format with periods
- Update `TODO.md` to mark these tasks as complete

## Testing
All existing tests pass after updating expected message values to include trailing periods.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches quest and exploration to shared message constants for consistent outputs. Updates tests to match the new message format with trailing periods.

- **Refactors**
  - Use QuestMessages in quests.ts for start/complete flows, validation, and errors.
  - Use ExplorationMessages in exploration.ts for availability, energy, cooldown, completion, and cancel messages.
  - Update quests.test.ts expectations to include periods.
  - Mark related TODO items as done.

<sup>Written for commit 1dda8d85793e6ee512b273fbe3493f556ce7f810. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized quest and exploration activity messages for improved consistency throughout the game.
  * Enhanced message formatting for better presentation to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR completes the migration to centralized message constants by applying `QuestMessages` and `ExplorationMessages` throughout the quest and exploration systems. All user-facing messages now flow through the constants defined in `messages.ts`, improving consistency and enabling future localization.

- Applied `QuestMessages` constants to all 14 message sites in `quests.ts` for validation, start/complete flows, and error handling
- Applied `ExplorationMessages` constants to all 10 message sites in `exploration.ts` for availability checks, energy validation, cooldown handling, and completion messages
- Updated all affected test expectations in `quests.test.ts` to match the new message format with trailing periods
- Fixed a minor naming improvement in `messages.ts`: renamed `questExpired` to `timedQuestNotAvailable` for better clarity
- Marked corresponding TODO items as complete

The refactoring is thorough and maintains backward compatibility in behavior while standardizing all message formatting with consistent trailing periods.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a pure refactoring PR that replaces hardcoded message strings with centralized constants. All tests have been updated and pass. The changes are mechanical, well-tested, and improve code maintainability without altering any business logic or behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/core/quests/quests.ts | 5/5 | Replaced hardcoded strings with QuestMessages constants for consistent messaging |
| src/game/core/exploration/exploration.ts | 5/5 | Replaced hardcoded strings with ExplorationMessages constants for consistent messaging |
| src/game/core/quests/quests.test.ts | 5/5 | Updated test expectations to match new message format with trailing periods |
| src/game/data/messages.ts | 5/5 | Fixed typo in comment and renamed questExpired to timedQuestNotAvailable for clarity |
| TODO.md | 5/5 | Marked quest and exploration message refactoring tasks as complete |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Code as Quest/Exploration Code
    participant Messages as messages.ts
    participant User as User Interface
    
    Note over Code,Messages: Before PR: Hardcoded strings
    Code->>User: "Quest not found"
    Code->>User: "Unknown activity: activityId"
    
    Note over Code,Messages: After PR: Centralized constants
    Code->>Messages: QuestMessages.questNotFound
    Messages-->>Code: "Quest not found."
    Code->>User: "Quest not found."
    
    Code->>Messages: ExplorationMessages.unknownActivityId(id)
    Messages-->>Code: "Unknown activity: {id}."
    Code->>User: "Unknown activity: {id}."
    
    Note over Code,User: All messages now consistent with periods
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->