### PR TITLE
feat: implement conditional NPC dialogue and quest triggers

### DIFF
--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -2,17 +2,20 @@
  * Dialogue screen component for NPC conversations.
  */
 
-import { useCallback, useState } from "react";
-import { DialogueBox, DialogueChoices } from "@/components/npc";
+import { useCallback, useMemo, useState } from "react";
+import { DialogueBox } from "@/components/npc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   advanceDialogue,
+  checkCondition,
   selectChoice,
   startDialogue,
 } from "@/game/core/dialogue";
+import { startQuest } from "@/game/core/quests/quests";
 import { getNpc } from "@/game/data/npcs";
-import { DialogueNodeType } from "@/game/types/npc";
+import { useGameState } from "@/game/hooks/useGameState";
+import { DialogueActionType, DialogueNodeType } from "@/game/types/npc";
 
 interface DialogueScreenProps {
   npcId: string;
@@ -29,6 +32,7 @@ export function DialogueScreen({
   onOpenShop,
 }: DialogueScreenProps) {
   const npc = getNpc(npcId);
+  const { state: gameState, actions } = useGameState();
 
   // Initialize dialogue state with a single startDialogue call
   const [dialogue, setDialogue] = useState(() => {
@@ -58,13 +62,35 @@ export function DialogueScreen({
     (index: number) => {
       if (!dialogueState) return;
 
-      const result = selectChoice(dialogueState, index);
+      const result = selectChoice(dialogueState, index, gameState || undefined);
       if (result.success && result.state && result.node) {
         setDialogue({ state: result.state, node: result.node });
+
+        // Handle any actions associated with the choice
+        if (result.action && gameState) {
+          if (result.action.type === DialogueActionType.StartQuest) {
+            const questResult = startQuest(gameState, result.action.targetId);
+            if (questResult.success) {
+              actions.updateState(() => questResult.state);
+              // TODO: Show toast/notification for started quest
+            }
+          }
+        }
       }
     },
-    [dialogueState],
+    [dialogueState, gameState, actions],
   );
+
+  // Filter choices based on conditions
+  const availableChoices = useMemo(() => {
+    if (!currentNode?.choices) return [];
+    return currentNode.choices
+      .map((choice, index) => ({ choice, index }))
+      .filter(({ choice }) => {
+        if (!choice.conditions || !gameState) return true;
+        return choice.conditions.every((c) => checkCondition(gameState, c));
+      });
+  }, [currentNode, gameState]);
 
   // Handle shop button
   const handleOpenShop = useCallback(() => {
@@ -134,12 +160,19 @@ export function DialogueScreen({
       {currentNode.type === DialogueNodeType.Choice && (
         <>
           <DialogueBox npc={npc} text={currentNode.text} />
-          {currentNode.choices && (
-            <DialogueChoices
-              choices={currentNode.choices}
-              onSelect={handleSelectChoice}
-            />
-          )}
+          <div className="flex flex-col gap-2">
+            {availableChoices.map(({ choice, index }, i) => (
+              <Button
+                key={`choice-${index}-${choice.nextNodeId}`}
+                variant="outline"
+                className="justify-start text-left h-auto py-3 px-4"
+                onClick={() => handleSelectChoice(index)}
+              >
+                <span className="text-muted-foreground mr-2">{i + 1}.</span>
+                {choice.text}
+              </Button>
+            ))}
+          </div>
         </>
       )}
 

--- a/src/game/core/dialogueConditions.test.ts
+++ b/src/game/core/dialogueConditions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialGameState } from "@/game/types/gameState";
+import { DialogueConditionType } from "@/game/types/npc";
+import { createQuestProgress, QuestState } from "@/game/types/quest";
+import { checkCondition } from "./dialogue";
+
+describe("Dialogue Logic", () => {
+  test("checkCondition should return true for QuestState condition when met", () => {
+    const state = createInitialGameState();
+    // Mock a quest as completed
+    const questId = "test_quest";
+    state.quests.push({
+      ...createQuestProgress(questId),
+      state: QuestState.Completed,
+    });
+
+    const condition = {
+      type: DialogueConditionType.QuestState,
+      targetId: questId,
+      value: QuestState.Completed,
+      comparison: "eq" as const,
+    };
+
+    expect(checkCondition(state, condition)).toBe(true);
+  });
+
+  test("checkCondition should return false for QuestState condition when not met", () => {
+    const state = createInitialGameState();
+    const questId = "test_quest";
+    // Quest not started
+
+    const condition = {
+      type: DialogueConditionType.QuestState,
+      targetId: questId,
+      value: QuestState.Completed,
+      comparison: "eq" as const,
+    };
+
+    // Default state is Locked or Available, but definitely not Completed
+    expect(checkCondition(state, condition)).toBe(false);
+  });
+
+  test("checkCondition should work with SkillLevel", () => {
+    const state = createInitialGameState();
+    // Set skill level
+    state.player.skills.foraging.level = 5;
+
+    const condition = {
+      type: DialogueConditionType.SkillLevel,
+      targetId: "foraging",
+      value: "5",
+      comparison: "gte" as const,
+    };
+
+    expect(checkCondition(state, condition)).toBe(true);
+
+    const highCondition = {
+      type: DialogueConditionType.SkillLevel,
+      targetId: "foraging",
+      value: "10",
+      comparison: "gte" as const,
+    };
+
+    expect(checkCondition(state, highCondition)).toBe(false);
+  });
+});

--- a/src/game/core/oakDialogue.test.ts
+++ b/src/game/core/oakDialogue.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { oakDialogue } from "@/game/data/dialogues";
+import {
+  tutorialExploration,
+  tutorialFirstSteps,
+} from "@/game/data/quests/tutorial";
+import { createInitialGameState } from "@/game/types/gameState";
+import { createQuestProgress, QuestState } from "@/game/types/quest";
+import { checkCondition } from "./dialogue";
+
+describe("Oak Dialogue Conditions", () => {
+  // Helper to get a specific choice from Oak's greeting node
+  function getOakChoice(textSubstr: string) {
+    const greetingNode = oakDialogue.nodes.greeting;
+    if (!greetingNode) {
+      throw new Error("Oak's greeting node not found");
+    }
+    if (greetingNode.type !== "choice" || !greetingNode.choices) {
+      throw new Error(
+        "Oak's greeting node is not a choice node or has no choices",
+      );
+    }
+    return greetingNode.choices.find((c) => c.text.includes(textSubstr));
+  }
+
+  test("First quest option should be available initially", () => {
+    const state = createInitialGameState();
+    // Ensure first quest is available (requirements met)
+    // Since tutorialFirstSteps has no requirements, it's available by default if not started
+
+    const choice = getOakChoice("start my journey");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+
+  test("Second quest option should be hidden initially", () => {
+    const state = createInitialGameState();
+    const choice = getOakChoice("next challenge");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(false);
+    }
+  });
+
+  test("Second quest option should be available after completing first quest", () => {
+    const state = createInitialGameState();
+
+    // Mock completing the first quest
+    state.quests.push({
+      ...createQuestProgress(tutorialFirstSteps.id),
+      state: QuestState.Completed,
+    });
+
+    const choice = getOakChoice("next challenge");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+
+  test("Third quest option should be available after completing second quest", () => {
+    const state = createInitialGameState();
+
+    // Mock completing the first and second quests
+    state.quests.push({
+      ...createQuestProgress(tutorialFirstSteps.id),
+      state: QuestState.Completed,
+    });
+    state.quests.push({
+      ...createQuestProgress(tutorialExploration.id),
+      state: QuestState.Completed,
+    });
+
+    const choice = getOakChoice("make my pet stronger");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+});

--- a/src/game/core/quests/quests.test.ts
+++ b/src/game/core/quests/quests.test.ts
@@ -81,13 +81,38 @@ test("getQuestState returns Completed for finished quest", () => {
 });
 
 test("getAvailableQuests returns quests that can be started", () => {
+  // Create a side quest for testing
+  const sideQuest: Quest = {
+    ...tutorialFirstSteps,
+    id: "side_quest_test",
+    type: QuestType.Side,
+    chainPrevious: undefined,
+    requirements: [],
+  };
+
+  // Mock the quest in the registry
+  const { quests } = require("@/game/data/quests");
+  try {
+    quests.side_quest_test = sideQuest;
+
+    const state = createTestState();
+    const available = getAvailableQuests(state, [
+      sideQuest,
+      tutorialExploration, // Locked
+    ]);
+    expect(available.length).toBe(1);
+    expect(available[0]?.id).toBe(sideQuest.id);
+  } finally {
+    delete quests.side_quest_test;
+  }
+});
+
+test("getAvailableQuests filters out tutorial quests", () => {
   const state = createTestState();
   const available = getAvailableQuests(state, [
-    tutorialFirstSteps,
-    tutorialExploration,
+    tutorialFirstSteps, // Available but is Tutorial type
   ]);
-  expect(available.length).toBe(1);
-  expect(available[0]?.id).toBe(tutorialFirstSteps.id);
+  expect(available.length).toBe(0);
 });
 
 test("getActiveQuests returns quests in progress", () => {

--- a/src/game/core/quests/quests.ts
+++ b/src/game/core/quests/quests.ts
@@ -115,6 +115,10 @@ export function getAvailableQuests(
   allQuests: Quest[],
 ): Quest[] {
   return allQuests.filter((quest) => {
+    // Tutorial quests are hidden from the available list as they are started via NPC dialogue
+    if (quest.type === QuestType.Tutorial) {
+      return false;
+    }
     const questState = getQuestState(state, quest.id);
     return questState === QuestState.Available;
   });

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -142,6 +142,46 @@ export const oakDialogue: DialogueTree = {
             targetId: "tutorial_first_steps",
           },
         },
+        {
+          text: "I'm ready for my next challenge!",
+          nextNodeId: "next_quest",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_first_steps",
+              value: QuestState.Completed,
+            },
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_exploration",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_exploration",
+          },
+        },
+        {
+          text: "How can I make my pet stronger?",
+          nextNodeId: "training_quest",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_exploration",
+              value: QuestState.Completed,
+            },
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_training",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_training",
+          },
+        },
         { text: "Any tips for training?", nextNodeId: "training_tips" },
         {
           text: "What should new trainers know?",
@@ -153,6 +193,16 @@ export const oakDialogue: DialogueTree = {
     start_adventure: messageNode(
       "start_adventure",
       "That's the spirit! I've prepared a few tasks to help you get started. Open your Quest Log to see what needs to be done.",
+      "greeting",
+    ),
+    next_quest: messageNode(
+      "next_quest",
+      "Excellent work! You're learning fast. Now, go out and explore the world. There's much to discover!",
+      "greeting",
+    ),
+    training_quest: messageNode(
+      "training_quest",
+      "Training is essential for any pet. Visit the training grounds and help your pet reach its full potential!",
       "greeting",
     ),
     training_tips: messageNode(

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -3,10 +3,15 @@
  */
 
 import {
+  type DialogueAction,
+  DialogueActionType,
+  type DialogueCondition,
+  DialogueConditionType,
   type DialogueNode,
   DialogueNodeType,
   type DialogueTree,
 } from "@/game/types/npc";
+import { QuestState } from "@/game/types/quest";
 
 /**
  * Helper to create a message node.
@@ -30,7 +35,12 @@ function messageNode(
 function choiceNode(
   id: string,
   text: string,
-  choices: { text: string; nextNodeId: string }[],
+  choices: {
+    text: string;
+    nextNodeId: string;
+    conditions?: DialogueCondition[];
+    action?: DialogueAction;
+  }[],
 ): DialogueNode {
   return {
     id,
@@ -117,6 +127,21 @@ export const oakDialogue: DialogueTree = {
       "greeting",
       "Ah, a fellow pet trainer! I've dedicated my life to understanding these wonderful creatures. How can I assist you?",
       [
+        {
+          text: "I'm ready to start my journey!",
+          nextNodeId: "start_adventure",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_first_steps",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_first_steps",
+          },
+        },
         { text: "Any tips for training?", nextNodeId: "training_tips" },
         {
           text: "What should new trainers know?",
@@ -124,6 +149,11 @@ export const oakDialogue: DialogueTree = {
         },
         { text: "I should get going.", nextNodeId: "farewell" },
       ],
+    ),
+    start_adventure: messageNode(
+      "start_adventure",
+      "That's the spirit! I've prepared a few tasks to help you get started. Open your Quest Log to see what needs to be done.",
+      "greeting",
     ),
     training_tips: messageNode(
       "training_tips",

--- a/src/game/data/npcs.ts
+++ b/src/game/data/npcs.ts
@@ -39,7 +39,7 @@ export const trainerOak: NPC = {
   description:
     "A seasoned trainer with years of experience. He can help your pet reach its full potential.",
   roles: [NpcRole.Trainer, NpcRole.Guide, NpcRole.QuestGiver],
-  locationId: "willowbrook",
+  locationId: "home",
   dialogueId: "oak_dialogue",
   questIds: [
     "main_new_journey",

--- a/src/game/types/npc.ts
+++ b/src/game/types/npc.ts
@@ -33,6 +33,52 @@ export type DialogueNodeType =
   (typeof DialogueNodeType)[keyof typeof DialogueNodeType];
 
 /**
+ * Dialogue condition types.
+ */
+export const DialogueConditionType = {
+  QuestState: "questState",
+  HasItem: "hasItem",
+  SkillLevel: "skillLevel",
+} as const;
+
+export type DialogueConditionType =
+  (typeof DialogueConditionType)[keyof typeof DialogueConditionType];
+
+/**
+ * A condition that must be met for a dialogue choice to be available.
+ */
+export interface DialogueCondition {
+  /** Type of condition */
+  type: DialogueConditionType;
+  /** Target ID (quest ID, item ID, skill ID) */
+  targetId: string;
+  /** Value to compare against (quest state, item quantity, skill level) */
+  value?: string | number;
+  /** Comparison operator (default: 'eq') */
+  comparison?: "eq" | "neq" | "gt" | "gte" | "lt" | "lte";
+}
+
+/**
+ * Dialogue action types.
+ */
+export const DialogueActionType = {
+  StartQuest: "startQuest",
+} as const;
+
+export type DialogueActionType =
+  (typeof DialogueActionType)[keyof typeof DialogueActionType];
+
+/**
+ * An action to perform when a dialogue choice is selected.
+ */
+export interface DialogueAction {
+  /** Type of action */
+  type: DialogueActionType;
+  /** Target ID (quest ID) */
+  targetId: string;
+}
+
+/**
  * A dialogue choice option.
  */
 export interface DialogueChoice {
@@ -40,6 +86,10 @@ export interface DialogueChoice {
   text: string;
   /** Node ID to navigate to when selected */
   nextNodeId: string;
+  /** Conditions required to see this choice */
+  conditions?: DialogueCondition[];
+  /** Action to perform when selected */
+  action?: DialogueAction;
 }
 
 /**


### PR DESCRIPTION
This PR implements conditional NPC dialogue choices and the ability to trigger actions (like starting a quest) from dialogue choices.

Changes:
- Added `DialogueCondition` and `DialogueAction` types to `src/game/types/npc.ts`.
- Implemented `checkCondition` in `src/game/core/dialogue.ts` to evaluate choice availability.
- Updated `selectChoice` to return triggered actions.
- Updated `DialogueScreen.tsx` to filter choices and execute actions.
- Updated Trainer Oak's dialogue to trigger the tutorial quest.
- Added unit tests for dialogue conditions.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented conditional NPC dialogue and choice-triggered actions, allowing quests to start directly from conversations. Updated the UI to only show available choices and start the tutorial quest from Trainer Oak.

- **New Features**
  - Added DialogueCondition and DialogueAction types, plus checkCondition to evaluate choice availability.
  - selectChoice now validates conditions and returns an optional action; DialogueScreen executes StartQuest and updates game state.
  - DialogueScreen filters choices based on game state and renders only available options.
  - Updated Oak’s dialogue to gate the tutorial quest chain and trigger quests from dialogue.
  - Tutorial quests are hidden from the available quests list, since they start via NPC dialogue.
  - Added unit tests for dialogue conditions and Oak’s dialogue gating.

- **Refactors**
  - Moved Trainer Oak to the home location.

<sup>Written for commit 0d91a9b782dd9d68229c34196f70e6e76ce8130e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogue choices now show/hide based on player state (quests, skills) and can trigger quest starts and other in-dialogue actions.
  * Dialogue flow supports richer branching tied to global game progress.

* **Changes**
  * Tutorial-type quests are excluded from general available-quests lists.
  * An NPC's default location has been updated.

* **Tests**
  * Added tests for dialogue condition evaluation, quest availability, and gated NPC dialogue scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR successfully implements conditional dialogue choices and quest triggering actions for NPC conversations. The implementation allows dialogue choices to appear/disappear based on game state (quest completion, skill levels) and enables quests to start directly from dialogue selections.

**Key Changes:**
- Added `DialogueCondition` and `DialogueAction` types to support conditional logic and action triggering
- Implemented `checkCondition` function that evaluates quest state and skill level requirements
- Updated `selectChoice` to validate conditions and return triggered actions
- Modified `DialogueScreen` to filter choices based on conditions and execute `StartQuest` actions
- Updated Oak's dialogue tree with progressive tutorial quest triggers gated by completion state
- Moved Oak to home location and filtered tutorial quests from the general available quests list

**Implementation Quality:**
- The choice index handling in `DialogueScreen.tsx` correctly preserves original indices from the unfiltered array, which is required by `selectChoice`
- Comprehensive test coverage for both condition checking and Oak's dialogue flows
- Clean separation of concerns between UI filtering and business logic validation

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no blocking issues
- The implementation is well-architected with proper type safety, comprehensive test coverage, and correct index handling. The previous thread's concern about choice index mismatches appears to be a misunderstanding - the code correctly preserves and uses original indices from the unfiltered array.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/types/npc.ts | 5/5 | added `DialogueCondition`, `DialogueAction`, and related types to support conditional dialogue choices and quest triggers |
| src/game/core/dialogue.ts | 5/5 | implemented `checkCondition` to evaluate dialogue conditions and updated `selectChoice` to validate conditions and return actions |
| src/components/npc/DialogueScreen.tsx | 5/5 | integrated condition checking to filter available choices and action execution for quest triggers; choice index handling correctly preserves original indices |
| src/game/data/dialogues.ts | 5/5 | updated Oak's dialogue with conditional choices that trigger tutorial quests based on quest completion state |
| src/game/core/quests/quests.ts | 5/5 | filtered tutorial quests from available quests list since they start via NPC dialogue |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DialogueScreen
    participant dialogue.ts
    participant GameState
    participant quests.ts

    User->>DialogueScreen: Click NPC to talk
    DialogueScreen->>dialogue.ts: startDialogue(npcId)
    dialogue.ts-->>DialogueScreen: DialogueNode with choices
    
    DialogueScreen->>dialogue.ts: checkCondition(gameState, condition)
    dialogue.ts->>GameState: getQuestState(questId)
    GameState-->>dialogue.ts: QuestState
    dialogue.ts-->>DialogueScreen: boolean (condition met)
    
    DialogueScreen->>DialogueScreen: Filter available choices
    DialogueScreen->>User: Display filtered choices
    
    User->>DialogueScreen: Select choice
    DialogueScreen->>dialogue.ts: selectChoice(index, gameState)
    dialogue.ts->>dialogue.ts: Validate conditions
    dialogue.ts-->>DialogueScreen: AdvanceDialogueResult + action
    
    alt Action is StartQuest
        DialogueScreen->>quests.ts: startQuest(gameState, questId)
        quests.ts->>GameState: Update quest state
        quests.ts-->>DialogueScreen: QuestResult
        DialogueScreen->>GameState: Update game state
    end
    
    DialogueScreen->>User: Show next dialogue node
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->