### PR TITLE
feat: NPC driven tutorial quests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,6 @@ Follow this workflow when implementing new features:
 6. **Evaluate each review comment** and determine if it's valid
 7. **Address valid issues** with code changes
 8. **Commit and push** to the current branch
-9. **Request re-review** from Copilot using the `gh pr edit` with the `--add-reviewer` flag
+9. **Request re-review** from Copilot using the `github` MCP server.
 10. **Wait ~10 minutes** again for PR feedback comments by using `sleep`
 11. **Repeat from step 5** until the PR is approved

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -2,17 +2,20 @@
  * Dialogue screen component for NPC conversations.
  */
 
-import { useCallback, useState } from "react";
-import { DialogueBox, DialogueChoices } from "@/components/npc";
+import { useCallback, useMemo, useState } from "react";
+import { DialogueBox } from "@/components/npc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   advanceDialogue,
+  checkCondition,
   selectChoice,
   startDialogue,
 } from "@/game/core/dialogue";
+import { startQuest } from "@/game/core/quests/quests";
 import { getNpc } from "@/game/data/npcs";
-import { DialogueNodeType } from "@/game/types/npc";
+import { useGameState } from "@/game/hooks/useGameState";
+import { DialogueActionType, DialogueNodeType } from "@/game/types/npc";
 
 interface DialogueScreenProps {
   npcId: string;
@@ -29,6 +32,7 @@ export function DialogueScreen({
   onOpenShop,
 }: DialogueScreenProps) {
   const npc = getNpc(npcId);
+  const { state: gameState, actions } = useGameState();
 
   // Initialize dialogue state with a single startDialogue call
   const [dialogue, setDialogue] = useState(() => {
@@ -58,13 +62,35 @@ export function DialogueScreen({
     (index: number) => {
       if (!dialogueState) return;
 
-      const result = selectChoice(dialogueState, index);
+      const result = selectChoice(dialogueState, index, gameState || undefined);
       if (result.success && result.state && result.node) {
         setDialogue({ state: result.state, node: result.node });
+
+        // Handle any actions associated with the choice
+        if (result.action && gameState) {
+          if (result.action.type === DialogueActionType.StartQuest) {
+            const questResult = startQuest(gameState, result.action.targetId);
+            if (questResult.success) {
+              actions.updateState(() => questResult.state);
+              // TODO: Show toast/notification for started quest
+            }
+          }
+        }
       }
     },
-    [dialogueState],
+    [dialogueState, gameState, actions],
   );
+
+  // Filter choices based on conditions
+  const availableChoices = useMemo(() => {
+    if (!currentNode?.choices) return [];
+    return currentNode.choices
+      .map((choice, index) => ({ choice, index }))
+      .filter(({ choice }) => {
+        if (!choice.conditions || !gameState) return true;
+        return choice.conditions.every((c) => checkCondition(gameState, c));
+      });
+  }, [currentNode, gameState]);
 
   // Handle shop button
   const handleOpenShop = useCallback(() => {
@@ -134,12 +160,19 @@ export function DialogueScreen({
       {currentNode.type === DialogueNodeType.Choice && (
         <>
           <DialogueBox npc={npc} text={currentNode.text} />
-          {currentNode.choices && (
-            <DialogueChoices
-              choices={currentNode.choices}
-              onSelect={handleSelectChoice}
-            />
-          )}
+          <div className="flex flex-col gap-2">
+            {availableChoices.map(({ choice, index }, i) => (
+              <Button
+                key={`choice-${index}-${choice.nextNodeId}`}
+                variant="outline"
+                className="justify-start text-left h-auto py-3 px-4"
+                onClick={() => handleSelectChoice(index)}
+              >
+                <span className="text-muted-foreground mr-2">{i + 1}.</span>
+                {choice.text}
+              </Button>
+            ))}
+          </div>
         </>
       )}
 

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -23,6 +23,9 @@ interface DialogueScreenProps {
   onOpenShop?: (npcId: string) => void;
 }
 
+/** Duration in ms to show error messages */
+const ERROR_DISPLAY_DURATION = 3000;
+
 /**
  * Full-screen dialogue interface for NPC conversations.
  */
@@ -33,6 +36,7 @@ export function DialogueScreen({
 }: DialogueScreenProps) {
   const npc = getNpc(npcId);
   const { state: gameState, actions } = useGameState();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Initialize dialogue state with a single startDialogue call
   const [dialogue, setDialogue] = useState(() => {
@@ -78,7 +82,9 @@ export function DialogueScreen({
           if (actionFn) {
             const questResult = actionFn(gameState, result.action.targetId);
             if (!questResult.success) {
-              // Don't advance dialogue if quest action failed
+              // Show error message to user
+              setErrorMessage(questResult.message);
+              setTimeout(() => setErrorMessage(null), ERROR_DISPLAY_DURATION);
               return;
             }
             actions.updateState(() => questResult.state);
@@ -157,6 +163,15 @@ export function DialogueScreen({
           </div>
         </CardHeader>
       </Card>
+
+      {/* Error message */}
+      {errorMessage && (
+        <Card className="border-destructive bg-destructive/10">
+          <CardContent className="py-2 text-sm text-destructive">
+            {errorMessage}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Dialogue content */}
       {currentNode.type === DialogueNodeType.Message && (

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -12,7 +12,7 @@ import {
   selectChoice,
   startDialogue,
 } from "@/game/core/dialogue";
-import { startQuest } from "@/game/core/quests/quests";
+import { completeQuest, startQuest } from "@/game/core/quests/quests";
 import { getNpc } from "@/game/data/npcs";
 import { useGameState } from "@/game/hooks/useGameState";
 import { DialogueActionType, DialogueNodeType } from "@/game/types/npc";
@@ -73,6 +73,15 @@ export function DialogueScreen({
             if (questResult.success) {
               actions.updateState(() => questResult.state);
               // TODO: Show toast/notification for started quest
+            }
+          } else if (result.action.type === DialogueActionType.CompleteQuest) {
+            const questResult = completeQuest(
+              gameState,
+              result.action.targetId,
+            );
+            if (questResult.success) {
+              actions.updateState(() => questResult.state);
+              // TODO: Show toast/notification for completed quest
             }
           }
         }

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -64,9 +64,7 @@ export function DialogueScreen({
 
       const result = selectChoice(dialogueState, index, gameState || undefined);
       if (result.success && result.state && result.node) {
-        setDialogue({ state: result.state, node: result.node });
-
-        // Handle any actions associated with the choice
+        // Handle quest actions BEFORE advancing dialogue
         if (result.action && gameState) {
           const questActionMap: Record<
             string,
@@ -79,11 +77,16 @@ export function DialogueScreen({
           const actionFn = questActionMap[result.action.type];
           if (actionFn) {
             const questResult = actionFn(gameState, result.action.targetId);
-            if (questResult.success) {
-              actions.updateState(() => questResult.state);
+            if (!questResult.success) {
+              // Don't advance dialogue if quest action failed
+              return;
             }
+            actions.updateState(() => questResult.state);
           }
         }
+
+        // Only advance dialogue after successful quest action (or no action)
+        setDialogue({ state: result.state, node: result.node });
       }
     },
     [dialogueState, gameState, actions],

--- a/src/components/npc/DialogueScreen.tsx
+++ b/src/components/npc/DialogueScreen.tsx
@@ -68,20 +68,19 @@ export function DialogueScreen({
 
         // Handle any actions associated with the choice
         if (result.action && gameState) {
-          if (result.action.type === DialogueActionType.StartQuest) {
-            const questResult = startQuest(gameState, result.action.targetId);
+          const questActionMap: Record<
+            string,
+            typeof startQuest | typeof completeQuest
+          > = {
+            [DialogueActionType.StartQuest]: startQuest,
+            [DialogueActionType.CompleteQuest]: completeQuest,
+          };
+
+          const actionFn = questActionMap[result.action.type];
+          if (actionFn) {
+            const questResult = actionFn(gameState, result.action.targetId);
             if (questResult.success) {
               actions.updateState(() => questResult.state);
-              // TODO: Show toast/notification for started quest
-            }
-          } else if (result.action.type === DialogueActionType.CompleteQuest) {
-            const questResult = completeQuest(
-              gameState,
-              result.action.targetId,
-            );
-            if (questResult.success) {
-              actions.updateState(() => questResult.state);
-              // TODO: Show toast/notification for completed quest
             }
           }
         }

--- a/src/components/quests/QuestDetail.tsx
+++ b/src/components/quests/QuestDetail.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { areAllRequiredObjectivesComplete } from "@/game/core/quests";
 import { getItemById } from "@/game/data/items";
 import type { Quest, QuestProgress, QuestReward } from "@/game/types/quest";
+import { QuestType } from "@/game/types/quest";
 import { formatTimeRemaining } from "./formatTimeRemaining";
 import { ObjectiveList } from "./ObjectiveList";
 import { hasExpiration } from "./questUtils";
@@ -129,19 +130,17 @@ export function QuestDetail({
               Accept Quest
             </Button>
           )}
-          {canComplete && onComplete && (
-            <>
-              {quest.type === "tutorial" ? (
-                <Button disabled className="w-full" variant="outline">
-                  Return to Oak to complete
-                </Button>
-              ) : (
-                <Button onClick={onComplete} className="w-full">
-                  Complete Quest
-                </Button>
-              )}
-            </>
-          )}
+          {canComplete &&
+            onComplete &&
+            (quest.type === QuestType.Tutorial ? (
+              <Button disabled className="w-full" variant="outline">
+                Return to Oak to complete
+              </Button>
+            ) : (
+              <Button onClick={onComplete} className="w-full">
+                Complete Quest
+              </Button>
+            ))}
           {isCompleted && (
             <div className="text-center text-green-600 font-semibold">
               ✅ Quest Completed

--- a/src/components/quests/QuestDetail.tsx
+++ b/src/components/quests/QuestDetail.tsx
@@ -130,9 +130,17 @@ export function QuestDetail({
             </Button>
           )}
           {canComplete && onComplete && (
-            <Button onClick={onComplete} className="w-full">
-              Complete Quest
-            </Button>
+            <>
+              {quest.type === "tutorial" ? (
+                <Button disabled className="w-full" variant="outline">
+                  Return to Oak to complete
+                </Button>
+              ) : (
+                <Button onClick={onComplete} className="w-full">
+                  Complete Quest
+                </Button>
+              )}
+            </>
           )}
           {isCompleted && (
             <div className="text-center text-green-600 font-semibold">

--- a/src/game/core/dialogue.ts
+++ b/src/game/core/dialogue.ts
@@ -40,6 +40,30 @@ export interface AdvanceDialogueResult {
 }
 
 /**
+ * Compare two numbers using the specified comparison operator.
+ */
+function compareNumbers(
+  actual: number,
+  target: number,
+  comparison: DialogueCondition["comparison"],
+): boolean {
+  switch (comparison) {
+    case "eq":
+      return actual === target;
+    case "neq":
+      return actual !== target;
+    case "gt":
+      return actual > target;
+    case "lte":
+      return actual <= target;
+    case "lt":
+      return actual < target;
+    default:
+      return actual >= target;
+  }
+}
+
+/**
  * Check if a condition is met.
  */
 export function checkCondition(
@@ -70,22 +94,7 @@ export function checkCondition(
       if (Number.isNaN(targetLevel)) {
         return false;
       }
-      const comparison = condition.comparison || "gte";
-
-      switch (comparison) {
-        case "eq":
-          return level === targetLevel;
-        case "neq":
-          return level !== targetLevel;
-        case "gt":
-          return level > targetLevel;
-        case "lte":
-          return level <= targetLevel;
-        case "lt":
-          return level < targetLevel;
-        default:
-          return level >= targetLevel;
-      }
+      return compareNumbers(level, targetLevel, condition.comparison || "gte");
     }
     case DialogueConditionType.HasItem: {
       const itemId = condition.targetId;
@@ -94,22 +103,11 @@ export function checkCondition(
         return false;
       }
       const currentQuantity = getItemQuantity(state.player.inventory, itemId);
-      const comparison = condition.comparison || "gte";
-
-      switch (comparison) {
-        case "eq":
-          return currentQuantity === quantity;
-        case "neq":
-          return currentQuantity !== quantity;
-        case "gt":
-          return currentQuantity > quantity;
-        case "lte":
-          return currentQuantity <= quantity;
-        case "lt":
-          return currentQuantity < quantity;
-        default:
-          return currentQuantity >= quantity;
-      }
+      return compareNumbers(
+        currentQuantity,
+        quantity,
+        condition.comparison || "gte",
+      );
     }
     case DialogueConditionType.QuestObjectivesComplete: {
       const questId = condition.targetId;

--- a/src/game/core/dialogue.ts
+++ b/src/game/core/dialogue.ts
@@ -2,9 +2,11 @@
  * Dialogue navigation logic.
  */
 
+import { areAllRequiredObjectivesComplete } from "@/game/core/quests/objectives";
 import { getQuestState } from "@/game/core/quests/quests";
 import { getDialogue } from "@/game/data/dialogues";
 import { getNpc } from "@/game/data/npcs";
+import { getQuest } from "@/game/data/quests";
 import type { GameState } from "@/game/types/gameState";
 import {
   type DialogueAction,
@@ -70,6 +72,23 @@ export function checkCondition(
       if (comparison === "lte") return level <= targetLevel;
       if (comparison === "lt") return level < targetLevel;
       return level >= targetLevel;
+    }
+    case DialogueConditionType.QuestObjectivesComplete: {
+      const questId = condition.targetId;
+      const quest = getQuest(questId);
+      if (!quest) return false;
+
+      const progress = state.quests.find((q) => q.questId === questId);
+      if (!progress) return false;
+
+      const areComplete = areAllRequiredObjectivesComplete(
+        quest.objectives,
+        progress,
+      );
+      const targetValue =
+        condition.value === undefined ? true : !!condition.value;
+
+      return areComplete === targetValue;
     }
     // Add other condition types here as needed
     default:

--- a/src/game/core/dialogue.ts
+++ b/src/game/core/dialogue.ts
@@ -89,7 +89,7 @@ export function checkCondition(
     }
     case DialogueConditionType.HasItem: {
       const itemId = condition.targetId;
-      const quantity = Number(condition.value) || 1;
+      const quantity = Number(condition.value ?? 1);
       if (Number.isNaN(quantity)) {
         return false;
       }

--- a/src/game/core/dialogueConditions.test.ts
+++ b/src/game/core/dialogueConditions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialGameState } from "@/game/types/gameState";
+import { DialogueConditionType } from "@/game/types/npc";
+import { createQuestProgress, QuestState } from "@/game/types/quest";
+import { checkCondition } from "./dialogue";
+
+describe("Dialogue Logic", () => {
+  test("checkCondition should return true for QuestState condition when met", () => {
+    const state = createInitialGameState();
+    // Mock a quest as completed
+    const questId = "test_quest";
+    state.quests.push({
+      ...createQuestProgress(questId),
+      state: QuestState.Completed,
+    });
+
+    const condition = {
+      type: DialogueConditionType.QuestState,
+      targetId: questId,
+      value: QuestState.Completed,
+      comparison: "eq" as const,
+    };
+
+    expect(checkCondition(state, condition)).toBe(true);
+  });
+
+  test("checkCondition should return false for QuestState condition when not met", () => {
+    const state = createInitialGameState();
+    const questId = "test_quest";
+    // Quest not started
+
+    const condition = {
+      type: DialogueConditionType.QuestState,
+      targetId: questId,
+      value: QuestState.Completed,
+      comparison: "eq" as const,
+    };
+
+    // Default state is Locked or Available, but definitely not Completed
+    expect(checkCondition(state, condition)).toBe(false);
+  });
+
+  test("checkCondition should work with SkillLevel", () => {
+    const state = createInitialGameState();
+    // Set skill level
+    state.player.skills.foraging.level = 5;
+
+    const condition = {
+      type: DialogueConditionType.SkillLevel,
+      targetId: "foraging",
+      value: "5",
+      comparison: "gte" as const,
+    };
+
+    expect(checkCondition(state, condition)).toBe(true);
+
+    const highCondition = {
+      type: DialogueConditionType.SkillLevel,
+      targetId: "foraging",
+      value: "10",
+      comparison: "gte" as const,
+    };
+
+    expect(checkCondition(state, highCondition)).toBe(false);
+  });
+});

--- a/src/game/core/dialogueConditions.test.ts
+++ b/src/game/core/dialogueConditions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { addItem } from "@/game/core/inventory";
 import { FOOD_ITEMS } from "@/game/data/items";
+import { tutorialFirstSteps } from "@/game/data/quests/tutorial";
 import { createInitialGameState } from "@/game/types/gameState";
 import { DialogueConditionType } from "@/game/types/npc";
 import { createQuestProgress, QuestState } from "@/game/types/quest";
@@ -169,6 +170,78 @@ describe("Dialogue Logic", () => {
       type: "unknownType" as DialogueConditionType,
       targetId: "test",
       value: "test",
+    };
+
+    expect(checkCondition(state, condition)).toBe(false);
+  });
+
+  test("checkCondition should work with QuestObjectivesComplete when all objectives are complete", () => {
+    const state = createInitialGameState();
+    const questId = tutorialFirstSteps.id;
+
+    // Start the quest and complete all objectives
+    state.quests.push({
+      ...createQuestProgress(questId),
+      state: QuestState.Active,
+      objectiveProgress: {
+        feed_pet: 1,
+        give_water: 1,
+      },
+    });
+
+    const condition = {
+      type: DialogueConditionType.QuestObjectivesComplete,
+      targetId: questId,
+      value: true,
+    };
+
+    expect(checkCondition(state, condition)).toBe(true);
+  });
+
+  test("checkCondition should return false for QuestObjectivesComplete when objectives are incomplete", () => {
+    const state = createInitialGameState();
+    const questId = tutorialFirstSteps.id;
+
+    // Start the quest but only complete one objective
+    state.quests.push({
+      ...createQuestProgress(questId),
+      state: QuestState.Active,
+      objectiveProgress: {
+        feed_pet: 1,
+        give_water: 0,
+      },
+    });
+
+    const condition = {
+      type: DialogueConditionType.QuestObjectivesComplete,
+      targetId: questId,
+      value: true,
+    };
+
+    expect(checkCondition(state, condition)).toBe(false);
+  });
+
+  test("checkCondition should return false for QuestObjectivesComplete when quest not in progress", () => {
+    const state = createInitialGameState();
+    const questId = tutorialFirstSteps.id;
+    // Quest not started
+
+    const condition = {
+      type: DialogueConditionType.QuestObjectivesComplete,
+      targetId: questId,
+      value: true,
+    };
+
+    expect(checkCondition(state, condition)).toBe(false);
+  });
+
+  test("checkCondition should return false for QuestObjectivesComplete when quest does not exist", () => {
+    const state = createInitialGameState();
+
+    const condition = {
+      type: DialogueConditionType.QuestObjectivesComplete,
+      targetId: "nonexistent_quest",
+      value: true,
     };
 
     expect(checkCondition(state, condition)).toBe(false);

--- a/src/game/core/oakDialogue.test.ts
+++ b/src/game/core/oakDialogue.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { oakDialogue } from "@/game/data/dialogues";
+import {
+  tutorialExploration,
+  tutorialFirstSteps,
+} from "@/game/data/quests/tutorial";
+import { createInitialGameState } from "@/game/types/gameState";
+import { createQuestProgress, QuestState } from "@/game/types/quest";
+import { checkCondition } from "./dialogue";
+
+describe("Oak Dialogue Conditions", () => {
+  // Helper to get a specific choice from Oak's greeting node
+  function getOakChoice(textSubstr: string) {
+    const greetingNode = oakDialogue.nodes.greeting;
+    if (!greetingNode) {
+      throw new Error("Oak's greeting node not found");
+    }
+    if (greetingNode.type !== "choice" || !greetingNode.choices) {
+      throw new Error(
+        "Oak's greeting node is not a choice node or has no choices",
+      );
+    }
+    return greetingNode.choices.find((c) => c.text.includes(textSubstr));
+  }
+
+  test("First quest option should be available initially", () => {
+    const state = createInitialGameState();
+    // Ensure first quest is available (requirements met)
+    // Since tutorialFirstSteps has no requirements, it's available by default if not started
+
+    const choice = getOakChoice("start my journey");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+
+  test("Second quest option should be hidden initially", () => {
+    const state = createInitialGameState();
+    const choice = getOakChoice("next challenge");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(false);
+    }
+  });
+
+  test("Second quest option should be available after completing first quest", () => {
+    const state = createInitialGameState();
+
+    // Mock completing the first quest
+    state.quests.push({
+      ...createQuestProgress(tutorialFirstSteps.id),
+      state: QuestState.Completed,
+    });
+
+    const choice = getOakChoice("next challenge");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+
+  test("Third quest option should be available after completing second quest", () => {
+    const state = createInitialGameState();
+
+    // Mock completing the first and second quests
+    state.quests.push({
+      ...createQuestProgress(tutorialFirstSteps.id),
+      state: QuestState.Completed,
+    });
+    state.quests.push({
+      ...createQuestProgress(tutorialExploration.id),
+      state: QuestState.Completed,
+    });
+
+    const choice = getOakChoice("make my pet stronger");
+    expect(choice).toBeDefined();
+
+    if (choice?.conditions) {
+      const met = choice.conditions.every((c) => checkCondition(state, c));
+      expect(met).toBe(true);
+    }
+  });
+});

--- a/src/game/core/oakDialogue.test.ts
+++ b/src/game/core/oakDialogue.test.ts
@@ -30,22 +30,20 @@ describe("Oak Dialogue Conditions", () => {
 
     const choice = getOakChoice("start my journey");
     expect(choice).toBeDefined();
+    expect(choice?.conditions).toBeDefined();
 
-    if (choice?.conditions) {
-      const met = choice.conditions.every((c) => checkCondition(state, c));
-      expect(met).toBe(true);
-    }
+    const met = choice?.conditions?.every((c) => checkCondition(state, c));
+    expect(met).toBe(true);
   });
 
   test("Second quest option should be hidden initially", () => {
     const state = createInitialGameState();
     const choice = getOakChoice("next challenge");
     expect(choice).toBeDefined();
+    expect(choice?.conditions).toBeDefined();
 
-    if (choice?.conditions) {
-      const met = choice.conditions.every((c) => checkCondition(state, c));
-      expect(met).toBe(false);
-    }
+    const met = choice?.conditions?.every((c) => checkCondition(state, c));
+    expect(met).toBe(false);
   });
 
   test("Second quest option should be available after completing first quest", () => {
@@ -59,11 +57,10 @@ describe("Oak Dialogue Conditions", () => {
 
     const choice = getOakChoice("next challenge");
     expect(choice).toBeDefined();
+    expect(choice?.conditions).toBeDefined();
 
-    if (choice?.conditions) {
-      const met = choice.conditions.every((c) => checkCondition(state, c));
-      expect(met).toBe(true);
-    }
+    const met = choice?.conditions?.every((c) => checkCondition(state, c));
+    expect(met).toBe(true);
   });
 
   test("Third quest option should be available after completing second quest", () => {
@@ -81,10 +78,9 @@ describe("Oak Dialogue Conditions", () => {
 
     const choice = getOakChoice("make my pet stronger");
     expect(choice).toBeDefined();
+    expect(choice?.conditions).toBeDefined();
 
-    if (choice?.conditions) {
-      const met = choice.conditions.every((c) => checkCondition(state, c));
-      expect(met).toBe(true);
-    }
+    const met = choice?.conditions?.every((c) => checkCondition(state, c));
+    expect(met).toBe(true);
   });
 });

--- a/src/game/core/quests/quests.test.ts
+++ b/src/game/core/quests/quests.test.ts
@@ -81,13 +81,38 @@ test("getQuestState returns Completed for finished quest", () => {
 });
 
 test("getAvailableQuests returns quests that can be started", () => {
+  // Create a side quest for testing
+  const sideQuest: Quest = {
+    ...tutorialFirstSteps,
+    id: "side_quest_test",
+    type: QuestType.Side,
+    chainPrevious: undefined,
+    requirements: [],
+  };
+
+  // Mock the quest in the registry
+  const { quests } = require("@/game/data/quests");
+  try {
+    quests.side_quest_test = sideQuest;
+
+    const state = createTestState();
+    const available = getAvailableQuests(state, [
+      sideQuest,
+      tutorialExploration, // Locked
+    ]);
+    expect(available.length).toBe(1);
+    expect(available[0]?.id).toBe(sideQuest.id);
+  } finally {
+    delete quests.side_quest_test;
+  }
+});
+
+test("getAvailableQuests filters out tutorial quests", () => {
   const state = createTestState();
   const available = getAvailableQuests(state, [
-    tutorialFirstSteps,
-    tutorialExploration,
+    tutorialFirstSteps, // Available but is Tutorial type
   ]);
-  expect(available.length).toBe(1);
-  expect(available[0]?.id).toBe(tutorialFirstSteps.id);
+  expect(available.length).toBe(0);
 });
 
 test("getActiveQuests returns quests in progress", () => {

--- a/src/game/core/quests/quests.ts
+++ b/src/game/core/quests/quests.ts
@@ -115,6 +115,10 @@ export function getAvailableQuests(
   allQuests: Quest[],
 ): Quest[] {
   return allQuests.filter((quest) => {
+    // Tutorial quests are hidden from the available list as they are started via NPC dialogue
+    if (quest.type === QuestType.Tutorial) {
+      return false;
+    }
     const questState = getQuestState(state, quest.id);
     return questState === QuestState.Available;
   });

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -142,6 +142,46 @@ export const oakDialogue: DialogueTree = {
             targetId: "tutorial_first_steps",
           },
         },
+        {
+          text: "I'm ready for my next challenge!",
+          nextNodeId: "next_quest",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_first_steps",
+              value: QuestState.Completed,
+            },
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_exploration",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_exploration",
+          },
+        },
+        {
+          text: "How can I make my pet stronger?",
+          nextNodeId: "training_quest",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_exploration",
+              value: QuestState.Completed,
+            },
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_training",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_training",
+          },
+        },
         { text: "Any tips for training?", nextNodeId: "training_tips" },
         {
           text: "What should new trainers know?",
@@ -153,6 +193,16 @@ export const oakDialogue: DialogueTree = {
     start_adventure: messageNode(
       "start_adventure",
       "That's the spirit! I've prepared a few tasks to help you get started. Open your Quest Log to see what needs to be done.",
+      "greeting",
+    ),
+    next_quest: messageNode(
+      "next_quest",
+      "Excellent work! You're learning fast. Now, go out and explore the world. There's much to discover!",
+      "greeting",
+    ),
+    training_quest: messageNode(
+      "training_quest",
+      "Training is essential for any pet. Visit the training grounds and help your pet reach its full potential!",
       "greeting",
     ),
     training_tips: messageNode(

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -3,10 +3,15 @@
  */
 
 import {
+  type DialogueAction,
+  DialogueActionType,
+  type DialogueCondition,
+  DialogueConditionType,
   type DialogueNode,
   DialogueNodeType,
   type DialogueTree,
 } from "@/game/types/npc";
+import { QuestState } from "@/game/types/quest";
 
 /**
  * Helper to create a message node.
@@ -30,7 +35,12 @@ function messageNode(
 function choiceNode(
   id: string,
   text: string,
-  choices: { text: string; nextNodeId: string }[],
+  choices: {
+    text: string;
+    nextNodeId: string;
+    conditions?: DialogueCondition[];
+    action?: DialogueAction;
+  }[],
 ): DialogueNode {
   return {
     id,
@@ -117,6 +127,21 @@ export const oakDialogue: DialogueTree = {
       "greeting",
       "Ah, a fellow pet trainer! I've dedicated my life to understanding these wonderful creatures. How can I assist you?",
       [
+        {
+          text: "I'm ready to start my journey!",
+          nextNodeId: "start_adventure",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_first_steps",
+              value: QuestState.Available,
+            },
+          ],
+          action: {
+            type: DialogueActionType.StartQuest,
+            targetId: "tutorial_first_steps",
+          },
+        },
         { text: "Any tips for training?", nextNodeId: "training_tips" },
         {
           text: "What should new trainers know?",
@@ -124,6 +149,11 @@ export const oakDialogue: DialogueTree = {
         },
         { text: "I should get going.", nextNodeId: "farewell" },
       ],
+    ),
+    start_adventure: messageNode(
+      "start_adventure",
+      "That's the spirit! I've prepared a few tasks to help you get started. Open your Quest Log to see what needs to be done.",
+      "greeting",
     ),
     training_tips: messageNode(
       "training_tips",

--- a/src/game/data/dialogues.ts
+++ b/src/game/data/dialogues.ts
@@ -127,6 +127,28 @@ export const oakDialogue: DialogueTree = {
       "greeting",
       "Ah, a fellow pet trainer! I've dedicated my life to understanding these wonderful creatures. How can I assist you?",
       [
+        // Complete First Steps
+        {
+          text: "I've completed the basic care tasks.",
+          nextNodeId: "complete_first_steps",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_first_steps",
+              value: QuestState.Active,
+            },
+            {
+              type: DialogueConditionType.QuestObjectivesComplete,
+              targetId: "tutorial_first_steps",
+              value: true,
+            },
+          ],
+          action: {
+            type: DialogueActionType.CompleteQuest,
+            targetId: "tutorial_first_steps",
+          },
+        },
+        // Start First Steps
         {
           text: "I'm ready to start my journey!",
           nextNodeId: "start_adventure",
@@ -142,6 +164,28 @@ export const oakDialogue: DialogueTree = {
             targetId: "tutorial_first_steps",
           },
         },
+        // Complete Exploration
+        {
+          text: "I've explored the area and found some things.",
+          nextNodeId: "complete_exploration",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_exploration",
+              value: QuestState.Active,
+            },
+            {
+              type: DialogueConditionType.QuestObjectivesComplete,
+              targetId: "tutorial_exploration",
+              value: true,
+            },
+          ],
+          action: {
+            type: DialogueActionType.CompleteQuest,
+            targetId: "tutorial_exploration",
+          },
+        },
+        // Start Exploration
         {
           text: "I'm ready for my next challenge!",
           nextNodeId: "next_quest",
@@ -162,6 +206,28 @@ export const oakDialogue: DialogueTree = {
             targetId: "tutorial_exploration",
           },
         },
+        // Complete Training
+        {
+          text: "I've finished my pet's training session.",
+          nextNodeId: "complete_training",
+          conditions: [
+            {
+              type: DialogueConditionType.QuestState,
+              targetId: "tutorial_training",
+              value: QuestState.Active,
+            },
+            {
+              type: DialogueConditionType.QuestObjectivesComplete,
+              targetId: "tutorial_training",
+              value: true,
+            },
+          ],
+          action: {
+            type: DialogueActionType.CompleteQuest,
+            targetId: "tutorial_training",
+          },
+        },
+        // Start Training
         {
           text: "How can I make my pet stronger?",
           nextNodeId: "training_quest",
@@ -195,14 +261,29 @@ export const oakDialogue: DialogueTree = {
       "That's the spirit! I've prepared a few tasks to help you get started. Open your Quest Log to see what needs to be done.",
       "greeting",
     ),
+    complete_first_steps: messageNode(
+      "complete_first_steps",
+      "Wonderful! You're taking good care of your pet. Here's a small reward for your efforts.",
+      "greeting",
+    ),
     next_quest: messageNode(
       "next_quest",
       "Excellent work! You're learning fast. Now, go out and explore the world. There's much to discover!",
       "greeting",
     ),
+    complete_exploration: messageNode(
+      "complete_exploration",
+      "You found some interesting items! Exploration is key to survival. Keep up the good work.",
+      "greeting",
+    ),
     training_quest: messageNode(
       "training_quest",
       "Training is essential for any pet. Visit the training grounds and help your pet reach its full potential!",
+      "greeting",
+    ),
+    complete_training: messageNode(
+      "complete_training",
+      "Impressive! Your pet is growing stronger every day. I think you're ready for even greater challenges now.",
       "greeting",
     ),
     training_tips: messageNode(

--- a/src/game/data/locations/home.ts
+++ b/src/game/data/locations/home.ts
@@ -29,5 +29,6 @@ export const homeLocation: Location = {
     FacilityType.PlayArea,
     FacilityType.Storage,
   ],
+  npcIds: ["trainer_oak"],
   emoji: "🏠",
 };

--- a/src/game/data/locations/towns.ts
+++ b/src/game/data/locations/towns.ts
@@ -34,7 +34,7 @@ export const willowbrookTown: Location = {
   requirements: {
     questId: "tutorial_training",
   },
-  npcIds: ["shopkeeper_mira", "trainer_oak"],
+  npcIds: ["shopkeeper_mira"],
   emoji: "🏘️",
 };
 

--- a/src/game/data/npcs.ts
+++ b/src/game/data/npcs.ts
@@ -39,7 +39,7 @@ export const trainerOak: NPC = {
   description:
     "A seasoned trainer with years of experience. He can help your pet reach its full potential.",
   roles: [NpcRole.Trainer, NpcRole.Guide, NpcRole.QuestGiver],
-  locationId: "willowbrook",
+  locationId: "home",
   dialogueId: "oak_dialogue",
   questIds: [
     "main_new_journey",

--- a/src/game/types/npc.ts
+++ b/src/game/types/npc.ts
@@ -39,6 +39,7 @@ export const DialogueConditionType = {
   QuestState: "questState",
   HasItem: "hasItem",
   SkillLevel: "skillLevel",
+  QuestObjectivesComplete: "questObjectivesComplete",
 } as const;
 
 export type DialogueConditionType =
@@ -53,7 +54,7 @@ export interface DialogueCondition {
   /** Target ID (quest ID, item ID, skill ID) */
   targetId: string;
   /** Value to compare against (quest state, item quantity, skill level) */
-  value?: string | number;
+  value?: string | number | boolean;
   /** Comparison operator (default: 'eq') */
   comparison?: "eq" | "neq" | "gt" | "gte" | "lt" | "lte";
 }
@@ -63,6 +64,7 @@ export interface DialogueCondition {
  */
 export const DialogueActionType = {
   StartQuest: "startQuest",
+  CompleteQuest: "completeQuest",
 } as const;
 
 export type DialogueActionType =

--- a/src/game/types/npc.ts
+++ b/src/game/types/npc.ts
@@ -33,6 +33,52 @@ export type DialogueNodeType =
   (typeof DialogueNodeType)[keyof typeof DialogueNodeType];
 
 /**
+ * Dialogue condition types.
+ */
+export const DialogueConditionType = {
+  QuestState: "questState",
+  HasItem: "hasItem",
+  SkillLevel: "skillLevel",
+} as const;
+
+export type DialogueConditionType =
+  (typeof DialogueConditionType)[keyof typeof DialogueConditionType];
+
+/**
+ * A condition that must be met for a dialogue choice to be available.
+ */
+export interface DialogueCondition {
+  /** Type of condition */
+  type: DialogueConditionType;
+  /** Target ID (quest ID, item ID, skill ID) */
+  targetId: string;
+  /** Value to compare against (quest state, item quantity, skill level) */
+  value?: string | number;
+  /** Comparison operator (default: 'eq') */
+  comparison?: "eq" | "neq" | "gt" | "gte" | "lt" | "lte";
+}
+
+/**
+ * Dialogue action types.
+ */
+export const DialogueActionType = {
+  StartQuest: "startQuest",
+} as const;
+
+export type DialogueActionType =
+  (typeof DialogueActionType)[keyof typeof DialogueActionType];
+
+/**
+ * An action to perform when a dialogue choice is selected.
+ */
+export interface DialogueAction {
+  /** Type of action */
+  type: DialogueActionType;
+  /** Target ID (quest ID) */
+  targetId: string;
+}
+
+/**
  * A dialogue choice option.
  */
 export interface DialogueChoice {
@@ -40,6 +86,10 @@ export interface DialogueChoice {
   text: string;
   /** Node ID to navigate to when selected */
   nextNodeId: string;
+  /** Conditions required to see this choice */
+  conditions?: DialogueCondition[];
+  /** Action to perform when selected */
+  action?: DialogueAction;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a robust system for conditional dialogue choices and quest integration within NPC conversations. The main improvements include supporting dialogue choices that depend on game state (such as quest progress or skill levels), handling quest actions directly from dialogue, and ensuring tutorial quests are only started via NPCs. Comprehensive tests and data updates ensure correctness and a smooth player experience.

**Dialogue System Enhancements**

* Added support for conditional dialogue choices, allowing choices to appear or be selectable only if certain game state conditions (like quest state or skill level) are met. Introduced the `checkCondition` function and updated the dialogue engine to use it. [[1]](diffhunk://#diff-c4e46904276cf715e624cb7ebd957116e6b1e3c1018fa18ef36d1073e470a269R41-R98) [[2]](diffhunk://#diff-c4e46904276cf715e624cb7ebd957116e6b1e3c1018fa18ef36d1073e470a269L174-R240) [[3]](diffhunk://#diff-c4e46904276cf715e624cb7ebd957116e6b1e3c1018fa18ef36d1073e470a269R286-R301) [[4]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L61-R103) [[5]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L137-R184) [[6]](diffhunk://#diff-e53dc0a9824d043473e6cac8037454535f8329eabd633f2c2050cd17538a866cL33-R43)
* Dialogue choices can now trigger quest actions (start or complete quests) directly from the conversation UI, updating the game state accordingly. [[1]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L61-R103) [[2]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L137-R184) [[3]](diffhunk://#diff-e53dc0a9824d043473e6cac8037454535f8329eabd633f2c2050cd17538a866cR130-R250)

**Quest System Adjustments**

* Tutorial quests are now hidden from the general available quest list and can only be started via NPC dialogue, preventing confusion and guiding players through the intended flow. [[1]](diffhunk://#diff-6ca5003a11b26c78b815026e2c6b476efa9f92ff18809fcdd3c1fc56486055e4R118-R121) [[2]](diffhunk://#diff-b097dcb822033d093e324a83782c0fddfc8e532c11a357d555ccf4b287f00d51R84-R115)
* Updated the Oak NPC's dialogue tree to use the new conditional/actionable choices for starting and completing tutorial quests, with precise conditions for when each option appears.

**Testing and Reliability**

* Added comprehensive tests for the new dialogue condition logic, including quest state and skill level checks, and for Oak's dialogue flow to ensure correct visibility of choices as quests progress. [[1]](diffhunk://#diff-ed87e6e1e096a421aba8253028e6a469c0a8144ad5f9d2ba4f0dd88ddd4ee309R1-R66) [[2]](diffhunk://#diff-1e878289ceb6dd52762e3a1e4a65ed7666fbfb7068a31d5262829e48dde4bd38R1-R90)

**User Interface Improvements**

* Updated the dialogue UI to only display choices that are currently available based on the player's state, and to handle quest-related actions seamlessly within the dialogue. [[1]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L137-R184) [[2]](diffhunk://#diff-12f59ceb7110735449b2c1ff896dedc406dc4f4832d95740300ecdab6a29b238L61-R103)

These changes collectively make the dialogue and quest systems more dynamic, interactive, and aligned with player progression.









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conditional NPC dialogue with quest triggers and moves tutorial quests to be started and completed through Oak. The quest list hides tutorials, and dialogue only shows choices that match the player’s state.

- **New Features**
  - Conditional dialogue choices based on quest state, objectives, skill levels, and inventory items.
  - Choices can start or complete quests directly; Oak’s dialogue drives the tutorial quest chain.
  - Tutorial quests are hidden from Available Quests and must be turned in via NPC dialogue.
  - Dialogue UI filters choices by conditions; QuestDetail disables direct completion for tutorial quests with guidance.
  - Added tests for condition logic and Oak’s dialogue flow; moved Oak to home for easier access.

<sup>Written for commit e75b214c6c9da2241afa8e829eaced8c5ebcca76. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogue choices now show/hide based on game state and can trigger quest start/complete actions; new Oak dialogue options and nodes added.
* **Refactor**
  * Dialogue UI now filters choices by condition, executes quest outcomes before advancing, and surfaces transient error messages.
* **UX**
  * Quest detail button behavior/text changes for tutorial quests.
* **Tests**
  * Added comprehensive tests for dialogue conditions and quest-driven dialogue flows.
* **Chores**
  * Updated NPC location mappings and added Home NPC association.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds a well-designed conditional dialogue system that dynamically shows/hides choices based on quest progress, and allows quest actions to be triggered directly from NPC conversations. Tutorial quests are now hidden from the general quest list and must be started/completed via Oak's dialogue.

**Key Changes:**
- Implemented `checkCondition` function supporting quest state, skill level, inventory, and objective completion checks
- Modified `DialogueScreen` to filter choices by conditions and execute quest actions before advancing dialogue
- Tutorial quests filtered from available quest list in `getAvailableQuests`
- Oak moved to Home location and dialogue tree updated with conditional quest start/complete options
- `QuestDetail` shows disabled button with guidance for tutorial quest completion
- Comprehensive test coverage for condition logic and Oak's dialogue flow

**Concerns:**
- All implementations are clean and well-tested with proper error handling

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is thorough with comprehensive test coverage, proper error handling, and clean separation of concerns. All edge cases are handled correctly in the condition checking logic, and the quest action flow properly validates before updating state.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/core/dialogue.ts | 5/5 | Added `checkCondition` function and quest action handling to `selectChoice`, enabling conditional dialogue choices based on game state |
| src/components/npc/DialogueScreen.tsx | 5/5 | Updated to filter choices by conditions, execute quest actions before advancing dialogue, and display error messages |
| src/components/quests/QuestDetail.tsx | 5/5 | Modified complete button for tutorial quests to show disabled state with guidance to return to Oak |
| src/game/core/quests/quests.ts | 5/5 | Added filter to hide tutorial quests from available quest list |
| src/game/data/dialogues.ts | 5/5 | Expanded Oak's dialogue tree with conditional choices for starting and completing tutorial quests |
| src/game/types/npc.ts | 5/5 | Added types for dialogue conditions and actions with comprehensive comparison operators |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Player
    participant DialogueScreen
    participant dialogue.ts
    participant GameState
    participant quests.ts
    
    Player->>DialogueScreen: Select dialogue choice
    DialogueScreen->>dialogue.ts: selectChoice(state, index, gameState)
    dialogue.ts->>dialogue.ts: checkCondition(gameState, conditions)
    
    alt Conditions not met
        dialogue.ts-->>DialogueScreen: {success: false, message: "Conditions not met"}
        DialogueScreen-->>Player: Show error message
    else Conditions met
        dialogue.ts->>dialogue.ts: Get next node
        dialogue.ts-->>DialogueScreen: {success: true, action, nextNode}
        
        alt Has quest action
            DialogueScreen->>quests.ts: startQuest() or completeQuest()
            
            alt Quest action fails
                quests.ts-->>DialogueScreen: {success: false, message}
                DialogueScreen-->>Player: Show error message (3s timeout)
            else Quest action succeeds
                quests.ts->>GameState: Update quest state
                quests.ts-->>DialogueScreen: {success: true, newState}
                DialogueScreen->>GameState: updateState()
                DialogueScreen->>DialogueScreen: Advance to next node
                DialogueScreen-->>Player: Show next dialogue
            end
        else No action
            DialogueScreen->>DialogueScreen: Advance to next node
            DialogueScreen-->>Player: Show next dialogue
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=572ffb98-977a-4f2c-833b-573c17e24ccc))

<!-- /greptile_comment -->