### PR TITLE
feat: use offline catchup for large tick accumulations

### DIFF
--- a/src/game/GameManager.ts
+++ b/src/game/GameManager.ts
@@ -29,10 +29,11 @@ import type { GameState } from "@/game/types/gameState";
 const CHECK_INTERVAL_MS = 1000;
 
 /**
- * Maximum ticks to process in a single update cycle.
- * Prevents the game from freezing if too much time has passed.
+ * Threshold for switching to offline catchup mode (30 ticks = 15 minutes).
+ * If more ticks than this have accumulated, we use the offline catchup
+ * processor instead of processing ticks individually.
  */
-const MAX_CATCHUP_TICKS = 10;
+const OFFLINE_CATCHUP_THRESHOLD_TICKS = 30;
 
 /**
  * Battle tick interval within the main loop (1 second).
@@ -53,7 +54,8 @@ export type StateUpdateCallback = (
  * Uses delta-time accumulator pattern:
  * - Tracks the timestamp of the last processed tick
  * - On each check interval, calculates how many ticks should have occurred
- * - Processes multiple ticks if needed to catch up (capped to prevent freezing)
+ * - Processes multiple ticks if needed to catch up
+ * - If too many ticks accumulated (>15 min), uses offline catchup instead
  */
 export class GameManager {
   private intervalId: ReturnType<typeof setInterval> | null = null;
@@ -98,7 +100,11 @@ export class GameManager {
   /**
    * Update the game state using delta-time accumulator pattern.
    * Calculates elapsed time since last update and processes
-   * as many ticks as needed to catch up (capped to prevent freezing).
+   * as many ticks as needed to catch up.
+   *
+   * If too many ticks have accumulated (e.g., browser tab was inactive for
+   * more than 15 minutes), we switch to offline catchup mode which processes
+   * all ticks efficiently as if the user had closed and reopened the tab.
    *
    * Battle tick processing is unified into this loop using its own accumulator
    * to prevent synchronization issues between game ticks and battle processing.
@@ -110,43 +116,39 @@ export class GameManager {
     this.battleAccumulator += deltaTime;
     this.lastTickTime = currentTime;
 
-    // Process as many ticks as have accumulated (with cap)
-    let ticksProcessed = 0;
-    while (
-      this.accumulator >= TICK_DURATION_MS &&
-      ticksProcessed < MAX_CATCHUP_TICKS
-    ) {
-      this.tick();
-      this.accumulator -= TICK_DURATION_MS;
-      ticksProcessed++;
+    // Calculate how many ticks need to be processed
+    const ticksToProcess = Math.floor(this.accumulator / TICK_DURATION_MS);
+
+    if (ticksToProcess >= OFFLINE_CATCHUP_THRESHOLD_TICKS) {
+      // Too many ticks accumulated - use offline catchup for efficiency
+      // This handles cases like browser tab being inactive for a long time
+      this.updateState((state) => {
+        const { state: newState } = processOfflineCatchup(
+          state,
+          ticksToProcess,
+          MAX_OFFLINE_TICKS,
+        );
+        return newState;
+      });
+      this.accumulator -= ticksToProcess * TICK_DURATION_MS;
+      // Reset battle accumulator since battles shouldn't continue during offline time
+      this.battleAccumulator = 0;
+    } else {
+      // Process ticks individually for normal gameplay
+      while (this.accumulator >= TICK_DURATION_MS) {
+        this.tick();
+        this.accumulator -= TICK_DURATION_MS;
+      }
     }
 
-    // If we hit the cap, reset accumulator to prevent runaway catch-up
-    if (ticksProcessed >= MAX_CATCHUP_TICKS && this.accumulator > 0) {
-      this.accumulator = 0;
-    }
-
-    // Process battle tick at BATTLE_TICK_INTERVAL_MS for responsive combat
+    // Process battle ticks at BATTLE_TICK_INTERVAL_MS for responsive combat
     // Unified into main loop to prevent synchronization issues
-    // Using while loop for consistent catch-up behavior after background throttling
-    let battleTicksProcessed = 0;
-    while (
-      this.battleAccumulator >= BATTLE_TICK_INTERVAL_MS &&
-      battleTicksProcessed < MAX_CATCHUP_TICKS
-    ) {
+    // Battle accumulator is reset when offline catchup is used (above)
+    while (this.battleAccumulator >= BATTLE_TICK_INTERVAL_MS) {
       // Using Date.now() to get a new timestamp for each tick to help avoid
       // event timestamp collisions, which would cause UI animations to be skipped.
       this.updateState((state) => processBattleTick(state, Date.now()));
       this.battleAccumulator -= BATTLE_TICK_INTERVAL_MS;
-      battleTicksProcessed++;
-    }
-
-    // If we hit the cap, reset accumulator to prevent runaway catch-up
-    if (
-      battleTicksProcessed >= MAX_CATCHUP_TICKS &&
-      this.battleAccumulator > 0
-    ) {
-      this.battleAccumulator = 0;
     }
   }
 

--- a/src/game/GameManager.ts
+++ b/src/game/GameManager.ts
@@ -33,7 +33,7 @@ const CHECK_INTERVAL_MS = 1000;
  * If more ticks than this have accumulated, we use the offline catchup
  * processor instead of processing ticks individually.
  */
-const OFFLINE_CATCHUP_THRESHOLD_TICKS = 30;
+export const OFFLINE_CATCHUP_THRESHOLD_TICKS = 30;
 
 /**
  * Battle tick interval within the main loop (1 second).
@@ -122,15 +122,18 @@ export class GameManager {
     if (ticksToProcess >= OFFLINE_CATCHUP_THRESHOLD_TICKS) {
       // Too many ticks accumulated - use offline catchup for efficiency
       // This handles cases like browser tab being inactive for a long time
+      let ticksProcessed = 0;
       this.updateState((state) => {
-        const { state: newState } = processOfflineCatchup(
+        const result = processOfflineCatchup(
           state,
           ticksToProcess,
           MAX_OFFLINE_TICKS,
         );
-        return newState;
+        ticksProcessed = result.ticksProcessed;
+        return result.state;
       });
-      this.accumulator -= ticksToProcess * TICK_DURATION_MS;
+      // Use ticksProcessed (not ticksToProcess) since offline catchup may cap at MAX_OFFLINE_TICKS
+      this.accumulator -= ticksProcessed * TICK_DURATION_MS;
       // Reset battle accumulator since battles shouldn't continue during offline time
       this.battleAccumulator = 0;
     } else {
@@ -191,6 +194,54 @@ export class GameManager {
    */
   get running(): boolean {
     return this.isRunning;
+  }
+
+  /**
+   * Expose update method for testing.
+   * @internal Only for use in tests
+   */
+  _testUpdate(): void {
+    this.update();
+  }
+
+  /**
+   * Manually set the accumulator for testing.
+   * @internal Only for use in tests
+   */
+  _testSetAccumulator(value: number): void {
+    this.accumulator = value;
+  }
+
+  /**
+   * Get current accumulator value for testing.
+   * @internal Only for use in tests
+   */
+  _testGetAccumulator(): number {
+    return this.accumulator;
+  }
+
+  /**
+   * Manually set the battle accumulator for testing.
+   * @internal Only for use in tests
+   */
+  _testSetBattleAccumulator(value: number): void {
+    this.battleAccumulator = value;
+  }
+
+  /**
+   * Get current battle accumulator value for testing.
+   * @internal Only for use in tests
+   */
+  _testGetBattleAccumulator(): number {
+    return this.battleAccumulator;
+  }
+
+  /**
+   * Set the last tick time for testing.
+   * @internal Only for use in tests
+   */
+  _testSetLastTickTime(value: number): void {
+    this.lastTickTime = value;
   }
 }
 


### PR DESCRIPTION
Instead of capping at 10 ticks and discarding remaining time when browser tab is inactive, switch to offline catchup mode when more than 30 ticks (15 minutes) have accumulated. This processes all accumulated ticks efficiently as if the user closed and reopened the tab, preventing lost game time.

- Replace MAX_CATCHUP_TICKS with OFFLINE_CATCHUP_THRESHOLD_TICKS
- Use processOfflineCatchup when threshold exceeded
- Reset battle accumulator during offline catchup (battles don't continue while offline)
- Simplify battle tick processing loop



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to offline catchup when more than 30 ticks (15 minutes) accumulate so inactive tabs process all queued time without losing progress. Battles pause during offline catchup and tick handling is simplified.

- **New Features**
  - Added OFFLINE_CATCHUP_THRESHOLD_TICKS (30) and trigger processOfflineCatchup when exceeded.
  - Reset battle accumulator during offline catchup; process all accumulated ticks.

- **Refactors**
  - Removed MAX_CATCHUP_TICKS cap and related counters.
  - Simplified battle tick loop for consistent, cap-free processing.
  - Use ticksProcessed from offline catchup when decrementing the accumulator to prevent negative values and preserve partial tick remainder.

<sup>Written for commit 5a50fa31f7bd43708188cce91923bc4c74955ee6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved offline catch-up behavior: long inactivity now triggers a bulk catch-up path that advances game state efficiently, adjusts accumulators correctly, and resets battle tick tracking to maintain consistency when players return.
* **Tests**
  * Added automated tests covering both bulk offline catch-up and normal tick processing, including accumulator and remainder handling to prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Switches from capping accumulated ticks at 10 (5 minutes) to using offline catchup mode when 30+ ticks (15 minutes) accumulate. This ensures inactive tabs process all queued time without loss.

Key changes:
- Replaced `MAX_CATCHUP_TICKS` (hard cap) with `OFFLINE_CATCHUP_THRESHOLD_TICKS` (mode switch threshold)
- When threshold exceeded, delegates to `processOfflineCatchup` for batch processing (respects `MAX_OFFLINE_TICKS` cap of 30 days)
- Resets `battleAccumulator` during offline catchup since battles pause when offline
- Simplified battle tick loop by removing now-unnecessary cap logic
- Added test helper methods (`_testSetAccumulator`, etc.) to enable comprehensive unit tests
- Comprehensive test coverage verifies threshold behavior, accumulator handling, and battle reset logic

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is clean and well-tested. Logic correctly handles the threshold check, properly delegates to offline catchup, and maintains accumulator state. Battle accumulator reset is appropriate since battles shouldn't continue offline. Tests thoroughly cover edge cases including exact threshold boundary, accumulator remainder preservation, and battle reset behavior. The change improves user experience by preventing time loss without introducing complexity or bugs.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/GameManager.ts | 5/5 | Replaced `MAX_CATCHUP_TICKS` cap with `OFFLINE_CATCHUP_THRESHOLD_TICKS` threshold logic. When 30+ ticks accumulate, uses `processOfflineCatchup` instead of processing individually. Adds test helper methods and resets battle accumulator during offline catchup. |
| src/game/GameManager.test.ts | 5/5 | Added comprehensive tests for offline catchup threshold behavior: verifies correct mode switching at 30 ticks, battle accumulator reset, and accumulator remainder preservation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser Tab
    participant GM as GameManager
    participant TP as TickProcessor
    participant State as GameState

    Browser->>GM: update() called after 15+ min inactive
    GM->>GM: Calculate deltaTime
    GM->>GM: accumulator += deltaTime
    GM->>GM: ticksToProcess = accumulator / TICK_DURATION_MS
    
    alt ticksToProcess >= 30 (OFFLINE_CATCHUP_THRESHOLD_TICKS)
        GM->>GM: Enter offline catchup mode
        GM->>TP: processOfflineCatchup(state, ticksToProcess, MAX_OFFLINE_TICKS)
        TP->>TP: cappedTicks = min(ticksToProcess, MAX_OFFLINE_TICKS)
        loop For each tick (up to MAX_OFFLINE_TICKS)
            TP->>TP: processGameTick(state, simulatedTime)
            TP->>State: Update pet, growth, activities
            State-->>TP: Updated state
        end
        TP-->>GM: {state, ticksProcessed}
        GM->>GM: accumulator -= ticksProcessed * TICK_DURATION_MS
        GM->>GM: battleAccumulator = 0 (reset)
    else ticksToProcess < 30
        GM->>GM: Normal tick processing
        loop While accumulator >= TICK_DURATION_MS
            GM->>TP: tick() → processGameTick()
            TP->>State: Update game state
            State-->>TP: Updated state
            GM->>GM: accumulator -= TICK_DURATION_MS
        end
    end
    
    GM->>GM: Process battle ticks
    loop While battleAccumulator >= BATTLE_TICK_INTERVAL_MS
        GM->>State: processBattleTick(state, timestamp)
        State-->>GM: Updated state
        GM->>GM: battleAccumulator -= BATTLE_TICK_INTERVAL_MS
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->