### PR TITLE
fix: prevent race condition in offline catchup accumulator handling

### DIFF
--- a/src/game/GameManager.ts
+++ b/src/game/GameManager.ts
@@ -122,18 +122,18 @@ export class GameManager {
     if (ticksToProcess >= OFFLINE_CATCHUP_THRESHOLD_TICKS) {
       // Too many ticks accumulated - use offline catchup for efficiency
       // This handles cases like browser tab being inactive for a long time
-      let ticksProcessed = 0;
       this.updateState((state) => {
         const result = processOfflineCatchup(
           state,
           ticksToProcess,
           MAX_OFFLINE_TICKS,
         );
-        ticksProcessed = result.ticksProcessed;
         return result.state;
       });
-      // Use ticksProcessed (not ticksToProcess) since offline catchup may cap at MAX_OFFLINE_TICKS
-      this.accumulator -= ticksProcessed * TICK_DURATION_MS;
+      // We assume all ticks are handled (processed or capped/discarded)
+      // so we remove them from the accumulator immediately.
+      // Do NOT rely on a variable updated in the async updateState callback.
+      this.accumulator -= ticksToProcess * TICK_DURATION_MS;
       // Reset battle accumulator since battles shouldn't continue during offline time
       this.battleAccumulator = 0;
     } else {


### PR DESCRIPTION
## Problem
Daily quests were resetting earlier than expected and displaying expiration times of "1d 2h" (26 hours), indicating quests were reset for a future date.

## Root Cause
The previous fix in commit 5a50fa3 still relied on a `ticksProcessed` variable updated inside the async `updateState` callback. Because `updateState` is asynchronous, the variable was still `0` when the accumulator was decremented immediately after the call.

This caused:
1. Accumulator was never cleared (subtracted 0)
2. Next game loop iteration saw the same huge accumulator + new delta time
3. Infinite re-processing of ticks, advancing game time into the future
4. Quests crossed midnight boundaries for future days

## Fix
Subtract `ticksToProcess` directly instead of relying on the async callback's return value. This is safe because `processOfflineCatchup` handles capping at `MAX_OFFLINE_TICKS` internally - any excess ticks are discarded, so all requested ticks are "consumed" from the accumulator's perspective.

## Testing
- All 743 tests pass
- Existing tests verify accumulator is correctly decremented after offline catchup
- Tests verify partial tick remainder is preserved

## References
- Bug analysis: `investigate/bug_daily.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in offline catchup that caused infinite tick re-processing and advanced game time. This stops early daily quest resets and the 26h expiry issue.

- **Bug Fixes**
  - Subtract ticksToProcess from the accumulator immediately instead of relying on a value set in the async updateState callback.
  - Safe due to processOfflineCatchup capping at MAX_OFFLINE_TICKS; excess ticks are discarded, so all requested ticks are consumed.

<sup>Written for commit 1548cc585bbe1686c298c260361f75fc3968a9cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized offline catch-up processing logic for improved efficiency in tick handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed a critical race condition in offline catchup accumulator handling that caused game time to advance into the future, resetting daily quests prematurely.

**Key Changes:**
- Removed reliance on `ticksProcessed` variable that was updated inside the async `updateState` callback
- Now directly subtracts `ticksToProcess` from accumulator immediately after calling `updateState`
- This is safe because `processOfflineCatchup` internally caps at `MAX_OFFLINE_TICKS`, so all requested ticks are consumed from the accumulator's perspective

**Root Cause:**
The previous fix in commit 5a50fa3 attempted to use `ticksProcessed` from the async callback result, but the accumulator subtraction happened before the callback executed, resulting in subtracting 0. This left the accumulator unchanged, causing infinite re-processing on the next game loop iteration.

**Testing:**
- All 743 tests pass
- Test coverage includes:
  - Accumulator correctly decremented after offline catchup (line 340)
  - Partial tick remainder preserved (line 364)
  - Battle accumulator reset during offline catchup (line 315)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it fixes a critical race condition with a minimal, well-tested change
- The fix correctly addresses the root cause by removing async dependency. The logic is sound: `processOfflineCatchup` caps at `MAX_OFFLINE_TICKS` internally, so subtracting all `ticksToProcess` is correct regardless of capping. Comprehensive test coverage verifies accumulator handling in multiple scenarios.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/GameManager.ts | 5/5 | Fixed race condition by subtracting `ticksToProcess` immediately instead of relying on async callback variable |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GL as Game Loop
    participant GM as GameManager
    participant ACC as Accumulator
    participant USC as updateState Callback
    participant TP as tickProcessor

    Note over GL,TP: Before Fix (Race Condition)
    GL->>GM: update() called
    GM->>ACC: accumulator += deltaTime
    GM->>GM: ticksToProcess = floor(accumulator / TICK_DURATION_MS)
    alt ticksToProcess >= OFFLINE_CATCHUP_THRESHOLD_TICKS
        GM->>GM: ticksProcessed = 0 (local var)
        GM->>USC: updateState(callback)
        Note right of USC: Async callback queued
        USC-->>TP: processOfflineCatchup()
        TP-->>USC: result.ticksProcessed
        USC->>GM: ticksProcessed = result.ticksProcessed
        Note right of GM: Variable updated AFTER subtraction
        GM->>ACC: accumulator -= ticksProcessed * TICK_DURATION_MS
        Note right of ACC: Subtracts 0! Race condition!
        GL->>GM: update() called again (next iteration)
        Note over GM,ACC: Accumulator still has huge value + new delta
        GM->>GM: Infinite re-processing loop
        Note over GM: Game time advances into future
    end

    Note over GL,TP: After Fix (Corrected)
    GL->>GM: update() called
    GM->>ACC: accumulator += deltaTime
    GM->>GM: ticksToProcess = floor(accumulator / TICK_DURATION_MS)
    alt ticksToProcess >= OFFLINE_CATCHUP_THRESHOLD_TICKS
        GM->>USC: updateState(callback)
        USC-->>TP: processOfflineCatchup()
        TP-->>USC: result.state
        GM->>ACC: accumulator -= ticksToProcess * TICK_DURATION_MS
        Note right of ACC: Immediate subtraction using ticksToProcess
        Note right of GM: All ticks consumed from accumulator
        GL->>GM: update() called again (next iteration)
        Note over GM,ACC: Accumulator correctly reset, only new delta added
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->