### PR TITLE
fix: clear battle events on battle end/start to prevent animation loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,10 @@ import type { BattleActionEvent, GameEvent } from "@/game/types/event";
 import { ObjectiveType } from "@/game/types/quest";
 import "./index.css";
 
+/** Filter out battle events from pending events to prevent animation replay */
+const clearBattleEvents = (events: GameEvent[]) =>
+  events.filter((e) => e.type !== "battleAction");
+
 /**
  * Main game content that renders based on active tab.
  */
@@ -92,10 +96,6 @@ function GameContent({
   if (!state?.isInitialized) {
     return <NewGameScreen onStartGame={actions.startNewGame} />;
   }
-
-  // Helper to filter out battle events from pending events
-  const clearBattleEvents = (events: GameEvent[]) =>
-    events.filter((e) => e.type !== "battleAction");
 
   // Handle starting a battle
   const handleStartBattle = (enemySpeciesId: string, enemyLevel: number) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ import "./index.css";
 
 /** Filter out battle events from pending events to prevent animation replay */
 const clearBattleEvents = (events: GameEvent[]) =>
-  events.filter((e) => e.type !== "battleAction");
+  events.filter((e) => e.type !== "battleAction" && e.type !== "battleEnd");
 
 /**
  * Main game content that renders based on active tab.


### PR DESCRIPTION
## Problem
When a user finished a battle and started a new one within 30 seconds (before the next game tick cleared `pendingEvents`), stale `BattleActionEvent`s from the previous battle would cause the new `BattleScreen` to replay all those animations, locking the UI with `isAnimating=true`.

## Root Cause
- Battle events are emitted into `state.pendingEvents` during combat
- `pendingEvents` are only cleared by `processGameTick` which runs every 30 seconds
- `BattleScreen` tracks processed events via `processedEventsRef`, which resets on component remount
- When a new battle starts, stale events are interpreted as new unprocessed events

## Solution
Clear battle events from `pendingEvents` in all battle exit paths:
- `handleStartBattle`: ensures clean slate for new battle
- `handleBattleEnd`: clears events when battle ends normally
- `handleFlee`: clears events when fleeing from battle

## Testing
Pre-commit hooks passed (biome check, typecheck, tests).





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale battle events when a battle starts or ends to stop the BattleScreen from replaying old animations and locking the UI. Prevents the animation loop that occurred when starting a new battle within the 30s game tick window.

- **Bug Fixes**
  - Added a helper to filter out "battleAction" and "battleEnd" events from pendingEvents.
  - Clear battle events in handleStartBattle, handleBattleEnd, and handleFlee.
  - Stops animation replay and isAnimating lock in new battles.

<sup>Written for commit 25a1110860c58da16ffe340c7ee216632468691f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale battle events could persist and trigger repeated animations or actions when starting, ending, or fleeing battles. The app now clears those leftover events during battle start, end, and flee flows to ensure a clean battle state, prevent duplicate behaviors, and provide smoother, more predictable battle transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed animation loop bug by clearing stale battle events (`battleAction` and `battleEnd`) from `pendingEvents` at all battle lifecycle points.

- Added `clearBattleEvents` helper function that filters out battle-related events
- Clears events in `handleStartBattle` to ensure clean slate for new battles
- Clears events in `handleBattleEnd` after battle completion
- Clears events in `handleFlee` when player flees

The fix prevents the race condition where starting a new battle within 30 seconds (before `processGameTick` clears `pendingEvents`) would cause `BattleScreen` to replay all animations from the previous battle, since `processedEventsRef` resets on component remount but stale events remain in state.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns - it's a focused bug fix with proper coverage of all battle exit paths
- The fix correctly addresses the root cause by clearing stale events at all battle entry/exit points. The implementation is clean, well-commented, and handles all code paths (`handleStartBattle`, `handleBattleEnd`, `handleFlee`). The helper function correctly filters both `battleAction` and `battleEnd` events. Pre-commit hooks passed, and the fix is minimal with no side effects on other game systems.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/App.tsx | 5/5 | Added `clearBattleEvents` helper to filter out stale battle events in `handleStartBattle`, `handleBattleEnd`, and `handleFlee` to prevent animation loop bug |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BattleScreen
    participant App
    participant GameState
    
    Note over User,GameState: Battle 1 - Normal Flow
    User->>App: Start Battle (handleStartBattle)
    App->>GameState: Clear battle events from pendingEvents
    App->>GameState: Set activeBattle state
    App->>BattleScreen: Navigate to battle
    Note over BattleScreen: processedEventsRef = new Set()
    
    loop Battle Actions
        User->>BattleScreen: Select move
        BattleScreen->>GameState: Dispatch BATTLE_PLAYER_ATTACK
        GameState->>GameState: Process action, emit battleAction events
        GameState-->>BattleScreen: battleEvents updated
        BattleScreen->>BattleScreen: Process unprocessed events (via timestamp)
        BattleScreen->>BattleScreen: Play animations, add timestamp to processedEventsRef
    end
    
    User->>BattleScreen: Battle ends
    BattleScreen->>App: onBattleEnd callback
    App->>GameState: Clear battle events from pendingEvents
    App->>GameState: Clear activeBattle, set pet to idle
    App->>App: Navigate to exploration
    
    Note over User,GameState: Battle 2 - Within 30s (Before Tick)
    User->>App: Start Battle 2 (handleStartBattle)
    App->>GameState: Clear battle events from pendingEvents ✓
    App->>GameState: Set new activeBattle state
    App->>BattleScreen: Navigate to battle
    Note over BattleScreen: processedEventsRef = new Set() (reset on remount)
    Note over BattleScreen: No stale events to process ✓
    BattleScreen->>BattleScreen: No animation loop bug ✓
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->