### PR TITLE
fix: persist notifications until user dismissal

### DIFF
--- a/src/game/GameManager.test.ts
+++ b/src/game/GameManager.test.ts
@@ -282,7 +282,7 @@ test("GameManager uses offline catchup when ticks >= threshold", () => {
   expect(regularTicksProcessed).toBe(0);
 });
 
-test("GameManager uses normal tick processing when ticks < threshold", () => {
+test("GameManager uses batch tick processing when ticks < threshold", () => {
   let updateCallCount = 0;
   let totalTicksProcessed = 0;
 
@@ -307,8 +307,8 @@ test("GameManager uses normal tick processing when ticks < threshold", () => {
   // Trigger update
   manager._testUpdate();
 
-  // Should have processed ticks individually (one call per tick)
-  expect(updateCallCount).toBe(ticksNeeded);
+  // Should have processed all ticks in a single batch call
+  expect(updateCallCount).toBe(1);
   expect(totalTicksProcessed).toBe(ticksNeeded);
 });
 

--- a/src/game/context/GameContext.tsx
+++ b/src/game/context/GameContext.tsx
@@ -129,8 +129,12 @@ export function GameProvider({ children }: GameProviderProps) {
   }, []);
 
   const dismissNotification = useCallback(() => {
-    setNotification(null);
-  }, []);
+    // Remove the first notification from pendingNotifications in state
+    updateState((state) => ({
+      ...state,
+      pendingNotifications: state.pendingNotifications.slice(1),
+    }));
+  }, [updateState]);
 
   /**
    * Process offline ticks and return the updated state plus report.

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -77,6 +77,7 @@ function createTestState(): GameState {
     quests: [],
     isInitialized: true,
     pendingEvents: [],
+    pendingNotifications: [],
   };
 }
 

--- a/src/game/hooks/useGameNotifications.ts
+++ b/src/game/hooks/useGameNotifications.ts
@@ -1,85 +1,23 @@
-import { useEffect, useRef } from "react";
-import type { GameEvent, GameNotification, GameState } from "@/game/types";
+import { useEffect } from "react";
+import type { GameNotification, GameState } from "@/game/types";
 
 /**
- * Hook to handle side effects and generate notifications based on game events.
+ * Hook to handle notifications from the persistent pendingNotifications queue.
  *
- * This hook consumes events from the event bus (state.pendingEvents) instead of
- * diffing state to detect changes. This is more robust and scales better as
- * the game grows with more event types.
+ * This hook reads from state.pendingNotifications (persisted) and provides
+ * the first notification to the UI. Unlike the old event-based approach,
+ * notifications persist across page refreshes until explicitly dismissed.
  *
  * @param state The current game state
  * @param setNotification callback to set a new notification
  */
 export function useGameNotifications(
   state: GameState | null,
-  setNotification: (notification: GameNotification) => void,
+  setNotification: (notification: GameNotification | null) => void,
 ) {
-  // Track processed events to avoid duplicate notifications
-  const lastProcessedTimestampRef = useRef<number>(0);
-
   useEffect(() => {
-    if (!state?.pendingEvents?.length) return;
-
-    // Process new events (those with timestamp > last processed)
-    const newEvents = state.pendingEvents.filter(
-      (event) => event.timestamp > lastProcessedTimestampRef.current,
-    );
-
-    if (newEvents.length === 0) return;
-
-    // Find the maximum timestamp using reduce (avoids potential stack overflow
-    // from Math.max(...array) with very large arrays)
-    const maxTimestamp = newEvents.reduce(
-      (max, e) => Math.max(max, e.timestamp),
-      0,
-    );
-    lastProcessedTimestampRef.current = maxTimestamp;
-
-    // Process each event and create notifications
-    // Note: Only one notification is shown at a time (first one wins).
-    // Additional events are marked as processed and won't trigger duplicate notifications.
-    for (const event of newEvents) {
-      const notification = eventToNotification(event);
-      if (notification) {
-        setNotification(notification);
-        break;
-      }
-    }
-    // Depends on pendingEvents reference changing (created via spread in emitEvents)
-  }, [state?.pendingEvents, setNotification]);
-}
-
-/**
- * Convert a game event to a notification for UI display.
- */
-function eventToNotification(event: GameEvent): GameNotification | null {
-  switch (event.type) {
-    case "stageTransition":
-      return {
-        type: "stageTransition",
-        previousStage: event.previousStage,
-        newStage: event.newStage,
-        petName: event.petName,
-      };
-    case "trainingComplete":
-      return {
-        type: "trainingComplete",
-        facilityName: event.facilityName,
-        statsGained: event.statsGained,
-        message: event.message,
-        petName: event.petName,
-      };
-    case "explorationComplete":
-      return {
-        type: "explorationComplete",
-        locationName: event.locationName,
-        itemsFound: event.itemsFound,
-        message: event.message,
-        petName: event.petName,
-      };
-    // Other event types don't have corresponding notifications yet
-    default:
-      return null;
-  }
+    // Show the first pending notification, or null if none
+    const firstNotification = state?.pendingNotifications?.[0] ?? null;
+    setNotification(firstNotification);
+  }, [state?.pendingNotifications, setNotification]);
 }

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -66,6 +66,7 @@ function createTestState(quests: QuestProgress[] = []): GameState {
     quests,
     isInitialized: true,
     pendingEvents: [],
+    pendingNotifications: [],
   };
 }
 

--- a/src/game/state/actions/sleep.test.ts
+++ b/src/game/state/actions/sleep.test.ts
@@ -65,6 +65,7 @@ function createTestGameState(isSleeping: boolean): GameState {
     quests: [],
     isInitialized: true,
     pendingEvents: [],
+    pendingNotifications: [],
   };
 }
 
@@ -85,6 +86,7 @@ function createEmptyGameState(): GameState {
     quests: [],
     isInitialized: true,
     pendingEvents: [],
+    pendingNotifications: [],
   };
 }
 

--- a/src/game/state/persistence.ts
+++ b/src/game/state/persistence.ts
@@ -63,6 +63,14 @@ export function validateGameState(value: unknown): value is GameState {
     return false;
   }
 
+  // pendingNotifications must be an array (or undefined, will be initialized)
+  if (
+    obj.pendingNotifications !== undefined &&
+    !Array.isArray(obj.pendingNotifications)
+  ) {
+    return false;
+  }
+
   // activeBattle is optional but must have correct structure if present
   if (obj.activeBattle !== undefined) {
     if (typeof obj.activeBattle !== "object" || obj.activeBattle === null)
@@ -136,10 +144,11 @@ export function loadGame(): LoadResult {
       );
     }
 
-    // Ensure pendingEvents is initialized (not persisted)
+    // Ensure pendingEvents is initialized (not persisted) and pendingNotifications exists
     const stateWithEvents: GameState = {
       ...parsed,
       pendingEvents: parsed.pendingEvents ?? [],
+      pendingNotifications: parsed.pendingNotifications ?? [],
     };
 
     return { success: true, state: stateWithEvents };
@@ -197,9 +206,11 @@ export function importSave(data: string): LoadResult {
     }
 
     // Create a clean state object to save, ensuring transient data is not persisted
+    // but keeping pendingNotifications (user-facing notifications)
     const cleanState: GameState = {
       ...parsed,
       pendingEvents: [],
+      pendingNotifications: parsed.pendingNotifications ?? [],
     };
 
     localStorage.setItem(STORAGE_KEY, JSON.stringify(cleanState));

--- a/src/game/state/persistence.ts
+++ b/src/game/state/persistence.ts
@@ -63,11 +63,8 @@ export function validateGameState(value: unknown): value is GameState {
     return false;
   }
 
-  // pendingNotifications must be an array (or undefined, will be initialized)
-  if (
-    obj.pendingNotifications !== undefined &&
-    !Array.isArray(obj.pendingNotifications)
-  ) {
+  // pendingNotifications must be an array
+  if (!Array.isArray(obj.pendingNotifications)) {
     return false;
   }
 
@@ -144,11 +141,10 @@ export function loadGame(): LoadResult {
       );
     }
 
-    // Ensure pendingEvents is initialized (not persisted) and pendingNotifications exists
+    // Ensure pendingEvents is initialized (not persisted)
     const stateWithEvents: GameState = {
       ...parsed,
-      pendingEvents: parsed.pendingEvents ?? [],
-      pendingNotifications: parsed.pendingNotifications ?? [],
+      pendingEvents: [],
     };
 
     return { success: true, state: stateWithEvents };
@@ -205,12 +201,11 @@ export function importSave(data: string): LoadResult {
       return { success: false, error: "Invalid save data structure" };
     }
 
-    // Create a clean state object to save, ensuring transient data is not persisted
-    // but keeping pendingNotifications (user-facing notifications)
+    // Create a clean state object to save, clearing transient pendingEvents
+    // but keeping pendingNotifications (user-facing, must persist)
     const cleanState: GameState = {
       ...parsed,
       pendingEvents: [],
-      pendingNotifications: parsed.pendingNotifications ?? [],
     };
 
     localStorage.setItem(STORAGE_KEY, JSON.stringify(cleanState));

--- a/src/game/testing/createTestPet.ts
+++ b/src/game/testing/createTestPet.ts
@@ -177,6 +177,7 @@ export function createTestGameState(
     lastDailyReset: now,
     lastWeeklyReset: now,
     pendingEvents: [],
+    pendingNotifications: [],
     ...stateOverrides,
   };
 }

--- a/src/game/types/gameState.ts
+++ b/src/game/types/gameState.ts
@@ -5,6 +5,7 @@
 import type { BattleState } from "@/game/core/battle/battle";
 import { DEFAULT_LOCATION_ID, type Tick, type Timestamp } from "./common";
 import type { GameEvent } from "./event";
+import type { GameNotification } from "./notification";
 import type { Pet } from "./pet";
 import type { QuestProgress } from "./quest";
 import { createInitialSkills, type PlayerSkills } from "./skill";
@@ -106,6 +107,12 @@ export interface GameState {
    * Not persisted to storage.
    */
   pendingEvents: GameEvent[];
+  /**
+   * Notifications requiring user acknowledgment (exploration/training results, etc.).
+   * Persisted to storage and only cleared when user explicitly dismisses them.
+   * This ensures results are shown even after page refresh.
+   */
+  pendingNotifications: GameNotification[];
 }
 
 /**
@@ -134,5 +141,6 @@ export function createInitialGameState(): GameState {
     lastDailyReset: currentTime,
     lastWeeklyReset: currentTime,
     pendingEvents: [],
+    pendingNotifications: [],
   };
 }


### PR DESCRIPTION
## Summary
Fix bug where result modals (exploration/training completion) were automatically cleared before users could review them.

## Problem
1. **Event Loss in Game Loop**: When multiple ticks were processed in a single frame, React's state batching caused intermediate events to be lost.
2. **Offline Catchup Event Loss**: The offline catchup report was discarded, losing events from offline time.
3. **Events Not Persisted**: Events were ephemeral and lost on page refresh.

## Solution
- Add `pendingNotifications: GameNotification[]` to `GameState` for persisted notifications
- Convert events to notifications in `tickProcessor` and store in state
- Update `GameManager` to use batch processing (`processMultipleTicks`) to prevent React batching from losing events
- Update `useGameNotifications` to read from persisted `pendingNotifications`
- Update `dismissNotification` to remove from state instead of local state
- Update persistence layer to handle `pendingNotifications`

## Changes
- `src/game/types/gameState.ts`: Add `pendingNotifications` field
- `src/game/core/tickProcessor.ts`: Add `eventToNotification` helper and accumulate notifications
- `src/game/GameManager.ts`: Use `processMultipleTicks` for batch processing
- `src/game/hooks/useGameNotifications.ts`: Read from `pendingNotifications`
- `src/game/context/GameContext.tsx`: Update `dismissNotification` to modify state
- `src/game/state/persistence.ts`: Handle `pendingNotifications` in validation and loading
- Test files updated to reflect new behavior

## Testing
- All 743 tests pass
- Type checking passes
- Linting passes



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist exploration and training result notifications until the user dismisses them. Batch tick processing ensures notifications aren't lost between frames or page refreshes.

- **Bug Fixes**
  - Added GameState.pendingNotifications and persisted it to storage.
  - Converted tick events to notifications in tickProcessor and enqueued them.
  - Switched GameManager to processMultipleTicks to accumulate notifications in one update.
  - useGameNotifications now reads from pendingNotifications; dismissNotification pops the first item.
  - Made pendingNotifications required in save validation and cleared transient pendingEvents on load/import.

<sup>Written for commit 1d48e02fffbc3e5f5287fa866b29f3a4b7630535. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now persist in a queue and survive page refreshes; dismissing a notification advances the queue and shows the next item.
* **Performance Improvements**
  * Tick processing now batches multiple ticks into a single state update when appropriate, reducing update churn and improving responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added persistent notification queue to fix bug where exploration and training completion modals were lost before users could review them.

- Added `pendingNotifications` array to `GameState` that persists to localStorage, ensuring notifications survive page refreshes
- Modified `tickProcessor` to convert significant events (exploration/training completion, stage transitions) into persistent notifications
- Switched `GameManager` from individual tick processing to batch processing via `processMultipleTicks`, preventing React's automatic state batching from discarding intermediate events when multiple ticks occur in a single frame
- Simplified `useGameNotifications` to read from the persistent queue instead of tracking event timestamps
- Updated `dismissNotification` to remove notifications from state using `slice(1)`, enabling queue-based notification flow
- All 743 tests pass with updated test helpers initializing the new `pendingNotifications` field

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested (743 passing tests), and solves a real bug without introducing breaking changes. The separation of transient events (`pendingEvents`) and persistent notifications (`pendingNotifications`) is architecturally sound. The batch processing approach correctly prevents React batching issues.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/types/gameState.ts | 5/5 | Added `pendingNotifications` field to GameState for persisting user-facing notifications until dismissal |
| src/game/core/tickProcessor.ts | 5/5 | Added `eventToNotification` helper and notification accumulation logic to persist exploration/training completion events |
| src/game/GameManager.ts | 5/5 | Switched from individual tick processing to batch processing via `processMultipleTicks` to prevent React batching from losing notifications |
| src/game/hooks/useGameNotifications.ts | 5/5 | Simplified to read first notification from persistent `pendingNotifications` queue instead of tracking event timestamps |
| src/game/context/GameContext.tsx | 5/5 | Updated `dismissNotification` to remove notification from state via slice(1) instead of clearing local state |
| src/game/state/persistence.ts | 5/5 | Added validation for `pendingNotifications` array and ensured it persists (unlike `pendingEvents` which are cleared) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GM as GameManager
    participant TP as tickProcessor
    participant GS as GameState
    participant Hook as useGameNotifications
    participant UI as UI Component
    participant User as User

    Note over GM,GS: Normal Gameplay (< 30 ticks)
    GM->>TP: processMultipleTicks(state, ticksToProcess)
    loop For each tick
        TP->>TP: processGameTick(state)
        TP->>TP: Check for training/exploration completion
        alt Activity Completed
            TP->>TP: Create GameEvent (transient)
            TP->>TP: eventToNotification(event)
            TP->>GS: Add to pendingNotifications[]
            TP->>GS: Add to pendingEvents[]
        end
    end
    TP-->>GM: Updated state with accumulated notifications
    GM->>GS: Single state update (prevents React batching loss)
    
    Note over GS,UI: Notification Display
    GS->>Hook: pendingNotifications[0]
    Hook->>UI: setNotification(firstNotification)
    UI->>User: Display modal/notification
    
    Note over UI,GS: User Dismissal
    User->>UI: Click dismiss
    UI->>GS: dismissNotification()
    GS->>GS: pendingNotifications.slice(1)
    GS->>Hook: pendingNotifications[0] (next notification)
    Hook->>UI: setNotification(nextNotification or null)
    
    Note over GS,User: Page Refresh
    GS->>GS: saveGame() persists pendingNotifications
    User->>User: Refresh page
    GS->>GS: loadGame() restores pendingNotifications
    GS->>Hook: pendingNotifications[0]
    Hook->>UI: setNotification(firstNotification)
    UI->>User: Display persisted notification
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->