### PR TITLE
fix: make GameManager timing tests deterministic

### DIFF
--- a/src/game/GameManager.test.ts
+++ b/src/game/GameManager.test.ts
@@ -2,7 +2,7 @@
  * Tests for GameManager class.
  */
 
-import { expect, mock, test } from "bun:test";
+import { expect, mock, setSystemTime, test } from "bun:test";
 import { BattlePhase, initializeBattle } from "@/game/core/battle/battle";
 import { basicAttack } from "@/game/data/moves";
 import { SPECIES } from "@/game/data/species";
@@ -248,6 +248,10 @@ test("GameManager.dispatchBattleAction() processes battle action correctly", () 
 // Tests for offline catchup threshold behavior
 
 test("GameManager uses offline catchup when ticks >= threshold", () => {
+  // Freeze time to ensure deterministic behavior
+  const frozenTime = 1000000;
+  setSystemTime(frozenTime);
+
   let ticksProcessedByOfflineCatchup = 0;
   let regularTicksProcessed = 0;
 
@@ -280,9 +284,16 @@ test("GameManager uses offline catchup when ticks >= threshold", () => {
   // Should have used offline catchup
   expect(ticksProcessedByOfflineCatchup).toBe(OFFLINE_CATCHUP_THRESHOLD_TICKS);
   expect(regularTicksProcessed).toBe(0);
+
+  // Reset system time
+  setSystemTime();
 });
 
 test("GameManager uses batch tick processing when ticks < threshold", () => {
+  // Freeze time to ensure deterministic behavior
+  const frozenTime = 1000000;
+  setSystemTime(frozenTime);
+
   let updateCallCount = 0;
   let totalTicksProcessed = 0;
 
@@ -310,9 +321,16 @@ test("GameManager uses batch tick processing when ticks < threshold", () => {
   // Should have processed all ticks in a single batch call
   expect(updateCallCount).toBe(1);
   expect(totalTicksProcessed).toBe(ticksNeeded);
+
+  // Reset system time
+  setSystemTime();
 });
 
 test("GameManager resets battle accumulator during offline catchup", () => {
+  // Freeze time to ensure deterministic behavior
+  const frozenTime = 1000000;
+  setSystemTime(frozenTime);
+
   const updateState: StateUpdateCallback = (updater) => {
     const initialState = {
       ...createInitialGameState(),
@@ -335,9 +353,16 @@ test("GameManager resets battle accumulator during offline catchup", () => {
 
   // Battle accumulator should be reset to 0
   expect(manager._testGetBattleAccumulator()).toBe(0);
+
+  // Reset system time
+  setSystemTime();
 });
 
 test("GameManager correctly decrements accumulator after offline catchup", () => {
+  // Freeze time to ensure deterministic behavior
+  const frozenTime = 1000000;
+  setSystemTime(frozenTime);
+
   const updateState: StateUpdateCallback = (updater) => {
     const initialState = {
       ...createInitialGameState(),
@@ -359,9 +384,16 @@ test("GameManager correctly decrements accumulator after offline catchup", () =>
 
   // Accumulator should be exactly 0 (no remainder since we set exact ticks)
   expect(manager._testGetAccumulator()).toBe(0);
+
+  // Reset system time
+  setSystemTime();
 });
 
 test("GameManager preserves accumulator remainder after offline catchup", () => {
+  // Freeze time to ensure deterministic behavior
+  const frozenTime = 1000000;
+  setSystemTime(frozenTime);
+
   const updateState: StateUpdateCallback = (updater) => {
     const initialState = {
       ...createInitialGameState(),
@@ -384,4 +416,7 @@ test("GameManager preserves accumulator remainder after offline catchup", () => 
 
   // Accumulator should have the partial tick remainder
   expect(manager._testGetAccumulator()).toBe(partialTickMs);
+
+  // Reset system time
+  setSystemTime();
 });

--- a/src/game/GameManager.test.ts
+++ b/src/game/GameManager.test.ts
@@ -2,7 +2,15 @@
  * Tests for GameManager class.
  */
 
-import { expect, mock, setSystemTime, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { BattlePhase, initializeBattle } from "@/game/core/battle/battle";
 import { basicAttack } from "@/game/data/moves";
 import { SPECIES } from "@/game/data/species";
@@ -247,176 +255,155 @@ test("GameManager.dispatchBattleAction() processes battle action correctly", () 
 
 // Tests for offline catchup threshold behavior
 
-test("GameManager uses offline catchup when ticks >= threshold", () => {
-  // Freeze time to ensure deterministic behavior
-  const frozenTime = 1000000;
-  setSystemTime(frozenTime);
+describe("GameManager offline catchup timing tests", () => {
+  const FROZEN_TIME = 1_000_000;
 
-  let ticksProcessedByOfflineCatchup = 0;
-  let regularTicksProcessed = 0;
+  beforeEach(() => {
+    setSystemTime(FROZEN_TIME);
+  });
 
-  const updateState: StateUpdateCallback = (updater) => {
-    const initialState = {
-      ...createInitialGameState(),
-      pet: createTestPet(),
-      totalTicks: 0,
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  test("uses offline catchup when ticks >= threshold", () => {
+    let ticksProcessedByOfflineCatchup = 0;
+    let regularTicksProcessed = 0;
+
+    const updateState: StateUpdateCallback = (updater) => {
+      const initialState = {
+        ...createInitialGameState(),
+        pet: createTestPet(),
+        totalTicks: 0,
+      };
+      const newState = updater(initialState);
+      // If totalTicks increased by a large amount, offline catchup was used
+      const ticksDelta = newState.totalTicks - initialState.totalTicks;
+      if (ticksDelta >= OFFLINE_CATCHUP_THRESHOLD_TICKS) {
+        ticksProcessedByOfflineCatchup = ticksDelta;
+      } else if (ticksDelta === 1) {
+        regularTicksProcessed++;
+      }
     };
-    const newState = updater(initialState);
-    // If totalTicks increased by a large amount, offline catchup was used
-    const ticksDelta = newState.totalTicks - initialState.totalTicks;
-    if (ticksDelta >= OFFLINE_CATCHUP_THRESHOLD_TICKS) {
-      ticksProcessedByOfflineCatchup = ticksDelta;
-    } else if (ticksDelta === 1) {
-      regularTicksProcessed++;
-    }
-  };
 
-  const manager = new GameManager(updateState);
+    const manager = new GameManager(updateState);
 
-  // Set up accumulator to trigger offline catchup (exactly at threshold)
-  const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
-  manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
-  manager._testSetLastTickTime(Date.now());
+    // Set up accumulator to trigger offline catchup (exactly at threshold)
+    const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
+    manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
+    manager._testSetLastTickTime(Date.now());
 
-  // Trigger update
-  manager._testUpdate();
+    // Trigger update
+    manager._testUpdate();
 
-  // Should have used offline catchup
-  expect(ticksProcessedByOfflineCatchup).toBe(OFFLINE_CATCHUP_THRESHOLD_TICKS);
-  expect(regularTicksProcessed).toBe(0);
+    // Should have used offline catchup
+    expect(ticksProcessedByOfflineCatchup).toBe(
+      OFFLINE_CATCHUP_THRESHOLD_TICKS,
+    );
+    expect(regularTicksProcessed).toBe(0);
+  });
 
-  // Reset system time
-  setSystemTime();
-});
+  test("uses batch tick processing when ticks < threshold", () => {
+    let updateCallCount = 0;
+    let totalTicksProcessed = 0;
 
-test("GameManager uses batch tick processing when ticks < threshold", () => {
-  // Freeze time to ensure deterministic behavior
-  const frozenTime = 1000000;
-  setSystemTime(frozenTime);
-
-  let updateCallCount = 0;
-  let totalTicksProcessed = 0;
-
-  const updateState: StateUpdateCallback = (updater) => {
-    updateCallCount++;
-    const initialState = {
-      ...createInitialGameState(),
-      pet: createTestPet(),
-      totalTicks: totalTicksProcessed,
+    const updateState: StateUpdateCallback = (updater) => {
+      updateCallCount++;
+      const initialState = {
+        ...createInitialGameState(),
+        pet: createTestPet(),
+        totalTicks: totalTicksProcessed,
+      };
+      const newState = updater(initialState);
+      totalTicksProcessed = newState.totalTicks;
     };
-    const newState = updater(initialState);
-    totalTicksProcessed = newState.totalTicks;
-  };
 
-  const manager = new GameManager(updateState);
+    const manager = new GameManager(updateState);
 
-  // Set up accumulator just below the threshold (29 ticks)
-  const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS - 1;
-  manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
-  manager._testSetLastTickTime(Date.now());
+    // Set up accumulator just below the threshold (29 ticks)
+    const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS - 1;
+    manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
+    manager._testSetLastTickTime(Date.now());
 
-  // Trigger update
-  manager._testUpdate();
+    // Trigger update
+    manager._testUpdate();
 
-  // Should have processed all ticks in a single batch call
-  expect(updateCallCount).toBe(1);
-  expect(totalTicksProcessed).toBe(ticksNeeded);
+    // Should have processed all ticks in a single batch call
+    expect(updateCallCount).toBe(1);
+    expect(totalTicksProcessed).toBe(ticksNeeded);
+  });
 
-  // Reset system time
-  setSystemTime();
-});
-
-test("GameManager resets battle accumulator during offline catchup", () => {
-  // Freeze time to ensure deterministic behavior
-  const frozenTime = 1000000;
-  setSystemTime(frozenTime);
-
-  const updateState: StateUpdateCallback = (updater) => {
-    const initialState = {
-      ...createInitialGameState(),
-      pet: createTestPet(),
-      totalTicks: 0,
+  test("resets battle accumulator during offline catchup", () => {
+    const updateState: StateUpdateCallback = (updater) => {
+      const initialState = {
+        ...createInitialGameState(),
+        pet: createTestPet(),
+        totalTicks: 0,
+      };
+      updater(initialState);
     };
-    updater(initialState);
-  };
 
-  const manager = new GameManager(updateState);
+    const manager = new GameManager(updateState);
 
-  // Set up accumulator to trigger offline catchup
-  const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
-  manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
-  manager._testSetBattleAccumulator(5000); // 5 seconds of battle ticks
-  manager._testSetLastTickTime(Date.now());
+    // Set up accumulator to trigger offline catchup
+    const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
+    manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
+    manager._testSetBattleAccumulator(5000); // 5 seconds of battle ticks
+    manager._testSetLastTickTime(Date.now());
 
-  // Trigger update
-  manager._testUpdate();
+    // Trigger update
+    manager._testUpdate();
 
-  // Battle accumulator should be reset to 0
-  expect(manager._testGetBattleAccumulator()).toBe(0);
+    // Battle accumulator should be reset to 0
+    expect(manager._testGetBattleAccumulator()).toBe(0);
+  });
 
-  // Reset system time
-  setSystemTime();
-});
-
-test("GameManager correctly decrements accumulator after offline catchup", () => {
-  // Freeze time to ensure deterministic behavior
-  const frozenTime = 1000000;
-  setSystemTime(frozenTime);
-
-  const updateState: StateUpdateCallback = (updater) => {
-    const initialState = {
-      ...createInitialGameState(),
-      pet: createTestPet(),
-      totalTicks: 0,
+  test("correctly decrements accumulator after offline catchup", () => {
+    const updateState: StateUpdateCallback = (updater) => {
+      const initialState = {
+        ...createInitialGameState(),
+        pet: createTestPet(),
+        totalTicks: 0,
+      };
+      updater(initialState);
     };
-    updater(initialState);
-  };
 
-  const manager = new GameManager(updateState);
+    const manager = new GameManager(updateState);
 
-  // Set up accumulator with exact tick boundary (no remainder)
-  const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
-  manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
-  manager._testSetLastTickTime(Date.now());
+    // Set up accumulator with exact tick boundary (no remainder)
+    const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
+    manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS);
+    manager._testSetLastTickTime(Date.now());
 
-  // Trigger update
-  manager._testUpdate();
+    // Trigger update
+    manager._testUpdate();
 
-  // Accumulator should be exactly 0 (no remainder since we set exact ticks)
-  expect(manager._testGetAccumulator()).toBe(0);
+    // Accumulator should be exactly 0 (no remainder since we set exact ticks)
+    expect(manager._testGetAccumulator()).toBe(0);
+  });
 
-  // Reset system time
-  setSystemTime();
-});
-
-test("GameManager preserves accumulator remainder after offline catchup", () => {
-  // Freeze time to ensure deterministic behavior
-  const frozenTime = 1000000;
-  setSystemTime(frozenTime);
-
-  const updateState: StateUpdateCallback = (updater) => {
-    const initialState = {
-      ...createInitialGameState(),
-      pet: createTestPet(),
-      totalTicks: 0,
+  test("preserves accumulator remainder after offline catchup", () => {
+    const updateState: StateUpdateCallback = (updater) => {
+      const initialState = {
+        ...createInitialGameState(),
+        pet: createTestPet(),
+        totalTicks: 0,
+      };
+      updater(initialState);
     };
-    updater(initialState);
-  };
 
-  const manager = new GameManager(updateState);
+    const manager = new GameManager(updateState);
 
-  // Set up accumulator with extra partial tick
-  const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
-  const partialTickMs = 5000; // 5 seconds extra
-  manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS + partialTickMs);
-  manager._testSetLastTickTime(Date.now());
+    // Set up accumulator with extra partial tick
+    const ticksNeeded = OFFLINE_CATCHUP_THRESHOLD_TICKS;
+    const partialTickMs = 5000; // 5 seconds extra
+    manager._testSetAccumulator(ticksNeeded * TICK_DURATION_MS + partialTickMs);
+    manager._testSetLastTickTime(Date.now());
 
-  // Trigger update
-  manager._testUpdate();
+    // Trigger update
+    manager._testUpdate();
 
-  // Accumulator should have the partial tick remainder
-  expect(manager._testGetAccumulator()).toBe(partialTickMs);
-
-  // Reset system time
-  setSystemTime();
+    // Accumulator should have the partial tick remainder
+    expect(manager._testGetAccumulator()).toBe(partialTickMs);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes flaky test failures in GameManager tests caused by timing race conditions.

## Problem

Tests that set `lastTickTime` to `Date.now()` and then call `_testUpdate()` could fail intermittently because the `update()` method calculates `deltaTime = currentTime - lastTickTime`. If even a few milliseconds pass between setting `lastTickTime` and the internal `Date.now()` call, the accumulator ends up with a small unexpected value.

## Solution

Use Bun's `setSystemTime()` to freeze time during these tests, ensuring `Date.now()` returns the same value consistently.

## Affected Tests

- GameManager uses offline catchup when ticks >= threshold
- GameManager uses batch tick processing when ticks < threshold
- GameManager resets battle accumulator during offline catchup
- GameManager correctly decrements accumulator after offline catchup
- GameManager preserves accumulator remainder after offline catchup

## Testing

All 743 tests pass.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GameManager timing tests deterministic by freezing system time with Bun’s setSystemTime. Prevents flaky failures from Date.now race conditions and ensures consistent accumulator values.

<sup>Written for commit 2878ded3cf0f24ca464555a0a3e99500d164ee5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made time-dependent offline catchup tests deterministic by freezing and controlling system time during those scenarios; refactored test structure to isolate timing, improving reliability and consistency without altering game behavior or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Wrapped five timing-sensitive GameManager tests in a `describe` block with `beforeEach/afterEach` hooks that use Bun's `setSystemTime()` to freeze time during execution. This eliminates race conditions where milliseconds could elapse between setting `lastTickTime` and calling `_testUpdate()`, causing flaky failures when `deltaTime` accumulated unexpected values.

**Changes:**
- Added `describe`, `beforeEach`, `afterEach`, and `setSystemTime` imports from `bun:test`
- Grouped tests in "GameManager offline catchup timing tests" describe block
- `beforeEach` freezes time at 1,000,000ms
- `afterEach` unfreezes time by calling `setSystemTime()` without arguments
- All five affected tests now run with deterministic `Date.now()` values

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are test-only and use Bun's built-in `setSystemTime()` API correctly to eliminate timing race conditions. The fix is minimal, well-scoped, and follows testing best practices. All 743 tests pass, confirming no regressions.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/GameManager.test.ts | 5/5 | Wrapped timing-sensitive tests in describe block with `beforeEach/afterEach` using `setSystemTime` to eliminate race conditions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Bun as Bun Test Runner
    participant GM as GameManager
    participant Time as Date.now()
    
    Note over Test,Time: Before Fix (Race Condition)
    Test->>GM: _testSetLastTickTime(Date.now())
    Note over Time: returns T1 = 1000000
    Test->>GM: _testUpdate()
    GM->>Time: Date.now()
    Note over Time: returns T2 = 1000003 (3ms later!)
    GM->>GM: deltaTime = T2 - T1 = 3ms
    GM->>GM: accumulator += 3ms (unexpected!)
    Note over GM: Test fails: accumulator not as expected
    
    Note over Test,Time: After Fix (Deterministic)
    Test->>Bun: beforeEach()
    Bun->>Time: setSystemTime(1000000)
    Note over Time: Frozen at 1000000
    Test->>GM: _testSetLastTickTime(Date.now())
    Note over Time: returns 1000000
    Test->>GM: _testUpdate()
    GM->>Time: Date.now()
    Note over Time: returns 1000000 (same!)
    GM->>GM: deltaTime = 1000000 - 1000000 = 0ms
    GM->>GM: accumulator += 0ms (as expected)
    Note over GM: Test passes consistently
    Test->>Bun: afterEach()
    Bun->>Time: setSystemTime() - unfreezes time
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->