### PR TITLE
fix: make time-dependent tests deterministic with setSystemTime

### DIFF
--- a/src/game/core/tickProcessor.test.ts
+++ b/src/game/core/tickProcessor.test.ts
@@ -12,11 +12,13 @@ import {
 } from "bun:test";
 import { createTestPet } from "@/game/testing/createTestPet";
 import { createInitialGameState, type GameState } from "@/game/types/gameState";
+import { QuestState } from "@/game/types/quest";
 import {
   processGameTick,
   processMultipleTicks,
   processOfflineCatchup,
 } from "./tickProcessor";
+import { getMidnightTimestamp } from "./time";
 
 // Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
 const FROZEN_TIME = 1_733_400_000_000;
@@ -301,7 +303,6 @@ describe("daily reset tests", () => {
   });
 
   test("processGameTick does not reset when already reset today", () => {
-    const { getMidnightTimestamp } = require("./time");
     const todayMidnight = getMidnightTimestamp(FROZEN_TIME);
 
     const pet = createTestPet({
@@ -401,13 +402,10 @@ describe("daily reset tests", () => {
     // Should update lastDailyReset without error
     expect(newState.pet).toBeNull();
     // lastDailyReset should be updated to today's midnight
-    const { getMidnightTimestamp } = require("./time");
     expect(newState.lastDailyReset).toBe(getMidnightTimestamp(FROZEN_TIME));
   });
 
   test("processGameTick refreshes daily quests on daily reset", () => {
-    const { QuestState } = require("@/game/types/quest");
-
     const yesterday = new Date(FROZEN_TIME);
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(12, 0, 0, 0);

--- a/src/game/core/time.test.ts
+++ b/src/game/core/time.test.ts
@@ -14,6 +14,8 @@ import { formatTicksAsTime } from "@/game/types/common";
 import {
   calculateCappedOfflineTicks,
   calculateElapsedTicks,
+  countDailyResets,
+  getMidnightTimestamp,
   getNextDailyReset,
   getNextWeeklyReset,
   getWeekStartTimestamp,
@@ -21,6 +23,7 @@ import {
   MS_PER_DAY,
   MS_PER_WEEK,
   msUntilNextTick,
+  shouldDailyReset,
   shouldWeeklyReset,
 } from "./time";
 
@@ -130,7 +133,6 @@ describe("shouldDailyReset tests", () => {
   afterEach(() => setSystemTime());
 
   test("shouldDailyReset returns true when last reset was before today midnight", () => {
-    const { shouldDailyReset } = require("./time");
     // Last reset was yesterday
     const now = new Date(FROZEN_TIME);
     const yesterday = new Date(FROZEN_TIME);
@@ -141,7 +143,6 @@ describe("shouldDailyReset tests", () => {
   });
 
   test("shouldDailyReset returns false when last reset was today", () => {
-    const { shouldDailyReset, getMidnightTimestamp } = require("./time");
     const now = new Date(FROZEN_TIME);
     now.setHours(14, 0, 0, 0); // 2 PM today
     const todayMidnight = getMidnightTimestamp(now.getTime());
@@ -150,7 +151,6 @@ describe("shouldDailyReset tests", () => {
   });
 
   test("shouldDailyReset returns true across midnight boundary", () => {
-    const { shouldDailyReset } = require("./time");
     // Last reset was 11:59 PM yesterday
     const now = new Date(FROZEN_TIME);
     const lastReset = new Date(FROZEN_TIME);
@@ -169,7 +169,6 @@ describe("countDailyResets tests", () => {
   afterEach(() => setSystemTime());
 
   test("countDailyResets returns 0 for same day", () => {
-    const { countDailyResets } = require("./time");
     const date = new Date(FROZEN_TIME);
     date.setHours(10, 0, 0, 0); // 10 AM
     const fromTime = date.getTime();
@@ -180,7 +179,6 @@ describe("countDailyResets tests", () => {
   });
 
   test("countDailyResets returns 1 for consecutive days", () => {
-    const { countDailyResets } = require("./time");
     const from = new Date(FROZEN_TIME);
     from.setHours(23, 0, 0, 0); // 11 PM Day 1
     const to = new Date(from);
@@ -191,7 +189,6 @@ describe("countDailyResets tests", () => {
   });
 
   test("countDailyResets returns 2 for 3 days apart", () => {
-    const { countDailyResets } = require("./time");
     const from = new Date(FROZEN_TIME);
     from.setHours(11, 0, 0, 0); // 11 AM Day 1
     const to = new Date(from);
@@ -203,7 +200,6 @@ describe("countDailyResets tests", () => {
   });
 
   test("countDailyResets handles different times of day", () => {
-    const { countDailyResets } = require("./time");
     // Late night to early morning next day
     const from = new Date(FROZEN_TIME);
     from.setHours(23, 59, 0, 0); // 11:59 PM
@@ -215,7 +211,6 @@ describe("countDailyResets tests", () => {
   });
 
   test("countDailyResets returns correct count for 7 days offline", () => {
-    const { countDailyResets } = require("./time");
     const from = new Date(FROZEN_TIME);
     from.setHours(12, 0, 0, 0); // Noon Day 1
     const to = new Date(from);

--- a/src/game/core/time.test.ts
+++ b/src/game/core/time.test.ts
@@ -2,7 +2,14 @@
  * Tests for time utilities.
  */
 
-import { expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { formatTicksAsTime } from "@/game/types/common";
 import {
   calculateCappedOfflineTicks,
@@ -16,6 +23,9 @@ import {
   msUntilNextTick,
   shouldWeeklyReset,
 } from "./time";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z (Thursday)
+const FROZEN_TIME = 1_733_400_000_000;
 
 test("calculateElapsedTicks returns 0 for same timestamp", () => {
   const time = Date.now();
@@ -115,96 +125,105 @@ test("getMidnightTimestamp returns start of day", () => {
   expect(midnightDate.getMilliseconds()).toBe(0);
 });
 
-test("shouldDailyReset returns true when last reset was before today midnight", () => {
-  const { shouldDailyReset } = require("./time");
-  // Last reset was yesterday
-  const now = new Date();
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  yesterday.setHours(12, 0, 0, 0);
+describe("shouldDailyReset tests", () => {
+  beforeEach(() => setSystemTime(FROZEN_TIME));
+  afterEach(() => setSystemTime());
 
-  expect(shouldDailyReset(yesterday.getTime(), now.getTime())).toBe(true);
+  test("shouldDailyReset returns true when last reset was before today midnight", () => {
+    const { shouldDailyReset } = require("./time");
+    // Last reset was yesterday
+    const now = new Date(FROZEN_TIME);
+    const yesterday = new Date(FROZEN_TIME);
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(12, 0, 0, 0);
+
+    expect(shouldDailyReset(yesterday.getTime(), now.getTime())).toBe(true);
+  });
+
+  test("shouldDailyReset returns false when last reset was today", () => {
+    const { shouldDailyReset, getMidnightTimestamp } = require("./time");
+    const now = new Date(FROZEN_TIME);
+    now.setHours(14, 0, 0, 0); // 2 PM today
+    const todayMidnight = getMidnightTimestamp(now.getTime());
+
+    expect(shouldDailyReset(todayMidnight, now.getTime())).toBe(false);
+  });
+
+  test("shouldDailyReset returns true across midnight boundary", () => {
+    const { shouldDailyReset } = require("./time");
+    // Last reset was 11:59 PM yesterday
+    const now = new Date(FROZEN_TIME);
+    const lastReset = new Date(FROZEN_TIME);
+    lastReset.setDate(lastReset.getDate() - 1);
+    lastReset.setHours(23, 59, 0, 0);
+
+    // Current time is 12:01 AM today
+    now.setHours(0, 1, 0, 0);
+
+    expect(shouldDailyReset(lastReset.getTime(), now.getTime())).toBe(true);
+  });
 });
 
-test("shouldDailyReset returns false when last reset was today", () => {
-  const { shouldDailyReset, getMidnightTimestamp } = require("./time");
-  const now = new Date();
-  now.setHours(14, 0, 0, 0); // 2 PM today
-  const todayMidnight = getMidnightTimestamp(now.getTime());
+describe("countDailyResets tests", () => {
+  beforeEach(() => setSystemTime(FROZEN_TIME));
+  afterEach(() => setSystemTime());
 
-  expect(shouldDailyReset(todayMidnight, now.getTime())).toBe(false);
-});
+  test("countDailyResets returns 0 for same day", () => {
+    const { countDailyResets } = require("./time");
+    const date = new Date(FROZEN_TIME);
+    date.setHours(10, 0, 0, 0); // 10 AM
+    const fromTime = date.getTime();
+    date.setHours(14, 0, 0, 0); // 2 PM same day
+    const toTime = date.getTime();
 
-test("shouldDailyReset returns true across midnight boundary", () => {
-  const { shouldDailyReset } = require("./time");
-  // Last reset was 11:59 PM yesterday
-  const now = new Date();
-  const lastReset = new Date(now);
-  lastReset.setDate(lastReset.getDate() - 1);
-  lastReset.setHours(23, 59, 0, 0);
+    expect(countDailyResets(fromTime, toTime)).toBe(0);
+  });
 
-  // Current time is 12:01 AM today
-  now.setHours(0, 1, 0, 0);
+  test("countDailyResets returns 1 for consecutive days", () => {
+    const { countDailyResets } = require("./time");
+    const from = new Date(FROZEN_TIME);
+    from.setHours(23, 0, 0, 0); // 11 PM Day 1
+    const to = new Date(from);
+    to.setDate(to.getDate() + 1);
+    to.setHours(1, 0, 0, 0); // 1 AM Day 2
 
-  expect(shouldDailyReset(lastReset.getTime(), now.getTime())).toBe(true);
-});
+    expect(countDailyResets(from.getTime(), to.getTime())).toBe(1);
+  });
 
-// countDailyResets tests
-test("countDailyResets returns 0 for same day", () => {
-  const { countDailyResets } = require("./time");
-  const date = new Date();
-  date.setHours(10, 0, 0, 0); // 10 AM
-  const fromTime = date.getTime();
-  date.setHours(14, 0, 0, 0); // 2 PM same day
-  const toTime = date.getTime();
+  test("countDailyResets returns 2 for 3 days apart", () => {
+    const { countDailyResets } = require("./time");
+    const from = new Date(FROZEN_TIME);
+    from.setHours(11, 0, 0, 0); // 11 AM Day 1
+    const to = new Date(from);
+    to.setDate(to.getDate() + 2);
+    to.setHours(13, 0, 0, 0); // 1 PM Day 3
 
-  expect(countDailyResets(fromTime, toTime)).toBe(0);
-});
+    // Resets at Day 2 midnight and Day 3 midnight
+    expect(countDailyResets(from.getTime(), to.getTime())).toBe(2);
+  });
 
-test("countDailyResets returns 1 for consecutive days", () => {
-  const { countDailyResets } = require("./time");
-  const from = new Date();
-  from.setHours(23, 0, 0, 0); // 11 PM Day 1
-  const to = new Date(from);
-  to.setDate(to.getDate() + 1);
-  to.setHours(1, 0, 0, 0); // 1 AM Day 2
+  test("countDailyResets handles different times of day", () => {
+    const { countDailyResets } = require("./time");
+    // Late night to early morning next day
+    const from = new Date(FROZEN_TIME);
+    from.setHours(23, 59, 0, 0); // 11:59 PM
+    const to = new Date(from);
+    to.setDate(to.getDate() + 1);
+    to.setHours(0, 1, 0, 0); // 12:01 AM next day
 
-  expect(countDailyResets(from.getTime(), to.getTime())).toBe(1);
-});
+    expect(countDailyResets(from.getTime(), to.getTime())).toBe(1);
+  });
 
-test("countDailyResets returns 2 for 3 days apart", () => {
-  const { countDailyResets } = require("./time");
-  const from = new Date();
-  from.setHours(11, 0, 0, 0); // 11 AM Day 1
-  const to = new Date(from);
-  to.setDate(to.getDate() + 2);
-  to.setHours(13, 0, 0, 0); // 1 PM Day 3
+  test("countDailyResets returns correct count for 7 days offline", () => {
+    const { countDailyResets } = require("./time");
+    const from = new Date(FROZEN_TIME);
+    from.setHours(12, 0, 0, 0); // Noon Day 1
+    const to = new Date(from);
+    to.setDate(to.getDate() + 7);
+    to.setHours(12, 0, 0, 0); // Noon Day 8
 
-  // Resets at Day 2 midnight and Day 3 midnight
-  expect(countDailyResets(from.getTime(), to.getTime())).toBe(2);
-});
-
-test("countDailyResets handles different times of day", () => {
-  const { countDailyResets } = require("./time");
-  // Late night to early morning next day
-  const from = new Date();
-  from.setHours(23, 59, 0, 0); // 11:59 PM
-  const to = new Date(from);
-  to.setDate(to.getDate() + 1);
-  to.setHours(0, 1, 0, 0); // 12:01 AM next day
-
-  expect(countDailyResets(from.getTime(), to.getTime())).toBe(1);
-});
-
-test("countDailyResets returns correct count for 7 days offline", () => {
-  const { countDailyResets } = require("./time");
-  const from = new Date();
-  from.setHours(12, 0, 0, 0); // Noon Day 1
-  const to = new Date(from);
-  to.setDate(to.getDate() + 7);
-  to.setHours(12, 0, 0, 0); // Noon Day 8
-
-  expect(countDailyResets(from.getTime(), to.getTime())).toBe(7);
+    expect(countDailyResets(from.getTime(), to.getTime())).toBe(7);
+  });
 });
 
 // Weekly reset tests
@@ -242,37 +261,38 @@ test("getWeekStartTimestamp handles Monday correctly", () => {
   expect(weekStartDate.getHours()).toBe(0);
 });
 
-test("shouldWeeklyReset returns true when last reset was before this week", () => {
-  // Last reset was last week
-  const lastWeek = new Date();
-  lastWeek.setDate(lastWeek.getDate() - 8); // 8 days ago
-  const now = Date.now();
+describe("weekly reset tests", () => {
+  beforeEach(() => setSystemTime(FROZEN_TIME));
+  afterEach(() => setSystemTime());
 
-  expect(shouldWeeklyReset(lastWeek.getTime(), now)).toBe(true);
-});
+  test("shouldWeeklyReset returns true when last reset was before this week", () => {
+    // Last reset was last week
+    const lastWeek = new Date(FROZEN_TIME);
+    lastWeek.setDate(lastWeek.getDate() - 8); // 8 days ago
 
-test("shouldWeeklyReset returns false when last reset was this week", () => {
-  const now = Date.now();
-  const thisWeekStart = getWeekStartTimestamp(now);
+    expect(shouldWeeklyReset(lastWeek.getTime(), FROZEN_TIME)).toBe(true);
+  });
 
-  expect(shouldWeeklyReset(thisWeekStart, now)).toBe(false);
-});
+  test("shouldWeeklyReset returns false when last reset was this week", () => {
+    const thisWeekStart = getWeekStartTimestamp(FROZEN_TIME);
 
-test("getNextDailyReset returns next midnight", () => {
-  const now = Date.now();
-  const nextReset = getNextDailyReset(now);
+    expect(shouldWeeklyReset(thisWeekStart, FROZEN_TIME)).toBe(false);
+  });
 
-  expect(nextReset).toBeGreaterThan(now);
-  expect(nextReset - now).toBeLessThanOrEqual(MS_PER_DAY);
-});
+  test("getNextDailyReset returns next midnight", () => {
+    const nextReset = getNextDailyReset(FROZEN_TIME);
 
-test("getNextWeeklyReset returns next Monday midnight", () => {
-  const now = Date.now();
-  const nextReset = getNextWeeklyReset(now);
+    expect(nextReset).toBeGreaterThan(FROZEN_TIME);
+    expect(nextReset - FROZEN_TIME).toBeLessThanOrEqual(MS_PER_DAY);
+  });
 
-  expect(nextReset).toBeGreaterThan(now);
-  expect(nextReset - now).toBeLessThanOrEqual(MS_PER_WEEK);
+  test("getNextWeeklyReset returns next Monday midnight", () => {
+    const nextReset = getNextWeeklyReset(FROZEN_TIME);
 
-  const nextResetDate = new Date(nextReset);
-  expect(nextResetDate.getDay()).toBe(1); // Monday
+    expect(nextReset).toBeGreaterThan(FROZEN_TIME);
+    expect(nextReset - FROZEN_TIME).toBeLessThanOrEqual(MS_PER_WEEK);
+
+    const nextResetDate = new Date(nextReset);
+    expect(nextResetDate.getDay()).toBe(1); // Monday
+  });
 });


### PR DESCRIPTION
## Summary

Use `setSystemTime` from `bun:test` to freeze time during tests that rely on `Date.now()` or relative date calculations. This prevents flaky tests at midnight boundaries or when test timing varies.

## Changes

### High Priority Files Fixed

- **tickProcessor.test.ts**: Daily reset tests now use frozen time (`FROZEN_TIME = 1_733_400_000_000`)
- **time.test.ts**: shouldDailyReset, countDailyResets, and weekly reset tests
- **quests.test.ts**: Quest timing and expiration tests

### Pattern Used

Following the reference implementation in `GameManager.test.ts`:

```typescript
describe("time-dependent tests", () => {
  const FROZEN_TIME = 1_733_400_000_000; // 2024-12-05T12:00:00.000Z

  beforeEach(() => setSystemTime(FROZEN_TIME));
  afterEach(() => setSystemTime()); // Reset to real time

  test("example", () => {
    // Date.now() will return FROZEN_TIME
  });
});
```

## Testing

All 743 tests pass.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze system time in time-dependent tests using bun:test setSystemTime to eliminate midnight-boundary flakiness. Quests, tick processing, and time utility tests are now deterministic with exact time assertions.

- **Bug Fixes**
  - Wrapped time-based suites with setSystemTime(FROZEN_TIME = 1_733_400_000_000) and reset in afterEach.
  - Stabilized daily/weekly reset logic in tickProcessor.test.ts and time.test.ts.
  - Made quest expiration and timed quest tests use fixed timestamps in quests.test.ts.

<sup>Written for commit 1c10536ec23e5029e9e44d68de16a33279d2f0a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability by introducing deterministic time control, lifecycle hooks, and grouped suites.
  * Expanded and reorganized timing-related tests for quests, daily/weekly resets, and tick processing to cover edge cases and ensure isolation and cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Eliminates test flakiness by freezing time using `setSystemTime` from `bun:test` in time-dependent test suites. The implementation correctly wraps timing-sensitive tests in `describe` blocks with `beforeEach`/`afterEach` hooks that freeze time to a constant (`FROZEN_TIME = 1_733_400_000_000`), following the pattern established in `GameManager.test.ts`.

**Key improvements:**
- Quest expiration tests now use exact time calculations instead of `Date.now()` with tolerance ranges
- Daily/weekly reset logic tests are deterministic and won't fail at midnight boundaries
- Refactored `require()` calls to static imports for better type safety (`getMidnightTimestamp`, `QuestState`, `shouldDailyReset`, `countDailyResets`)

All changes preserve existing test logic while making assertions more precise (e.g., `expect(remaining).toBe(3600000)` instead of `expect(remaining).toBeGreaterThan(0)`)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks identified
- The changes are well-contained to test files only, follow an established pattern from GameManager.test.ts, and improve test reliability without changing any production code. The refactoring from require() to static imports improves type safety. All 743 tests pass according to the PR author.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/core/quests/quests.test.ts | 5/5 | Wrapped time-dependent quest tests in describe blocks with setSystemTime for deterministic timing, using FROZEN_TIME constant for all date calculations |
| src/game/core/tickProcessor.test.ts | 5/5 | Added setSystemTime to daily reset tests, replaced Date.now() calls with FROZEN_TIME, moved getMidnightTimestamp and QuestState imports to file scope |
| src/game/core/time.test.ts | 5/5 | Wrapped daily reset tests with frozen time, moved shouldDailyReset and countDailyResets imports to top-level, removed inline require() calls |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Bun as Bun Test Runner
    participant Time as System Time
    participant Code as Test Code
    
    Note over Test,Code: Test Execution Flow with setSystemTime
    
    Test->>Bun: describe("time-dependent tests")
    Test->>Bun: beforeEach()
    Bun->>Time: setSystemTime(FROZEN_TIME)
    Note over Time: Time frozen at<br/>1_733_400_000_000<br/>(2024-12-05T12:00:00.000Z)
    
    Test->>Code: Execute test
    Code->>Time: Date.now()
    Time-->>Code: FROZEN_TIME
    Code->>Code: Calculate with FROZEN_TIME
    Note over Code: e.g., expiredTime = FROZEN_TIME - 1000<br/>futureExpiry = FROZEN_TIME + 3600000
    Code->>Code: Assert exact values
    Note over Code: expect(remaining).toBe(3600000)<br/>No tolerance needed!
    
    Test->>Bun: afterEach()
    Bun->>Time: setSystemTime()
    Note over Time: Time restored to<br/>real system time
    
    Note over Test,Code: Pattern Applied to:<br/>- quests.test.ts: Quest timing & expiration<br/>- tickProcessor.test.ts: Daily resets<br/>- time.test.ts: shouldDailyReset, countDailyResets
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->