### PR TITLE
fix: replace Date.now() with FROZEN_TIME in all test fixtures

### DIFF
--- a/src/game/core/care/careStats.test.ts
+++ b/src/game/core/care/careStats.test.ts
@@ -7,6 +7,9 @@ import { createTestPet } from "@/game/testing/createTestPet";
 import { applyCareDecay, getPoopHappinessMultiplier } from "./careStats";
 import { CARE_DECAY_AWAKE, CARE_DECAY_SLEEPING } from "./constants";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 test("getPoopHappinessMultiplier returns 1.0 for 0-2 poop", () => {
   expect(getPoopHappinessMultiplier(0)).toBe(1.0);
   expect(getPoopHappinessMultiplier(1)).toBe(1.0);
@@ -41,7 +44,7 @@ test("applyCareDecay reduces stats by sleeping decay rate when sleeping", () => 
   const pet = createTestPet({
     sleep: {
       isSleeping: true,
-      sleepStartTime: Date.now(),
+      sleepStartTime: FROZEN_TIME,
       sleepTicksToday: 0,
     },
   });

--- a/src/game/core/care/poop.test.ts
+++ b/src/game/core/care/poop.test.ts
@@ -19,6 +19,9 @@ import {
 } from "./constants";
 import { getInitialPoopTimer, processPoopTick, removePoop } from "./poop";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 test("getInitialPoopTimer returns micro threshold", () => {
   expect(getInitialPoopTimer()).toBe(POOP_MICRO_THRESHOLD);
 });
@@ -38,7 +41,11 @@ test("processPoopTick decrements timer by awake decay rate when awake", () => {
 test("processPoopTick decrements timer by sleeping decay rate when asleep", () => {
   const pet = createTestPet({
     poop: { count: 0, ticksUntilNext: 100 },
-    sleep: { isSleeping: true, sleepStartTime: Date.now(), sleepTicksToday: 0 },
+    sleep: {
+      isSleeping: true,
+      sleepStartTime: FROZEN_TIME,
+      sleepTicksToday: 0,
+    },
   });
 
   const result = processPoopTick(pet);
@@ -62,7 +69,11 @@ test("processPoopTick generates poop when timer reaches 0 while awake", () => {
 test("processPoopTick generates poop when timer reaches 0 while sleeping", () => {
   const pet = createTestPet({
     poop: { count: 0, ticksUntilNext: POOP_DECAY_SLEEPING },
-    sleep: { isSleeping: true, sleepStartTime: Date.now(), sleepTicksToday: 0 },
+    sleep: {
+      isSleeping: true,
+      sleepStartTime: FROZEN_TIME,
+      sleepTicksToday: 0,
+    },
   });
 
   const result = processPoopTick(pet);
@@ -118,7 +129,11 @@ test("mid-cycle sleep extends remaining time proportionally", () => {
 
   const petSleeping = createTestPet({
     poop: { count: 0, ticksUntilNext: timerMidway },
-    sleep: { isSleeping: true, sleepStartTime: Date.now(), sleepTicksToday: 0 },
+    sleep: {
+      isSleeping: true,
+      sleepStartTime: FROZEN_TIME,
+      sleepTicksToday: 0,
+    },
   });
 
   // After one tick awake: 480 - 2 = 478

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -12,6 +12,9 @@ import { createTestPet } from "@/game/testing/createTestPet";
 import type { GrowthStage } from "@/game/types/constants";
 import { getNextStage, processGrowthTick } from "./growth";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 // Helper to get the min age ticks for a given stage from species data
 function getStageMinAgeTicks(speciesId: string, stage: GrowthStage): number {
   const species = getSpeciesById(speciesId);
@@ -35,7 +38,7 @@ test("processGrowthTick does not transition when within same stage", () => {
     growth: {
       stage: "baby",
       substage: 1,
-      birthTime: Date.now(),
+      birthTime: FROZEN_TIME,
       ageTicks: 100,
     },
   });
@@ -51,7 +54,7 @@ test("processGrowthTick transitions stage when reaching threshold", () => {
     growth: {
       stage: "baby",
       substage: 3,
-      birthTime: Date.now(),
+      birthTime: FROZEN_TIME,
       ageTicks: childMinAge - 1,
     },
     battleStats: {
@@ -90,7 +93,7 @@ for (const { from, to } of stageTransitions) {
       growth: {
         stage: from,
         substage: 3,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: toMinAge - 1,
       },
       battleStats: {
@@ -122,7 +125,7 @@ test("processGrowthTick handles substage transitions", () => {
     growth: {
       stage: "baby",
       substage: 1,
-      birthTime: Date.now(),
+      birthTime: FROZEN_TIME,
       ageTicks: babySubstage2.minAgeTicks - 1,
     },
   });
@@ -146,7 +149,7 @@ test("processGrowthTick recalculates battle stats on substage transition", () =>
     growth: {
       stage: "baby",
       substage: 1,
-      birthTime: Date.now(),
+      birthTime: FROZEN_TIME,
       ageTicks: babySubstage2.minAgeTicks - 1,
     },
     battleStats: {

--- a/src/game/core/integration.test.ts
+++ b/src/game/core/integration.test.ts
@@ -22,6 +22,9 @@ import { createInitialGameState, type GameState } from "@/game/types/gameState";
 import type { Move } from "@/game/types/move";
 import { createDefaultResistances } from "@/game/types/stats";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 // Helper to create test game state
 function createTestGameState(overrides: Partial<GameState> = {}): GameState {
   return {
@@ -85,7 +88,7 @@ describe("Care system integration", () => {
         growth: {
           stage: GrowthStage.Baby,
           substage: 1,
-          birthTime: Date.now(),
+          birthTime: FROZEN_TIME,
           ageTicks: 0,
         },
       }),
@@ -262,7 +265,7 @@ describe("Tick processor integration", () => {
       growth: {
         stage: GrowthStage.Baby,
         substage: 1,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: 0,
       },
       poop: { count: 0, ticksUntilNext: 960 }, // POOP_MICRO_THRESHOLD
@@ -284,7 +287,7 @@ describe("Tick processor integration", () => {
       growth: {
         stage: GrowthStage.Adult,
         substage: 1,
-        birthTime: Date.now() - 1000000,
+        birthTime: FROZEN_TIME - 1_000_000,
         ageTicks: 0,
       },
     });
@@ -337,7 +340,7 @@ describe("Growth system integration", () => {
       growth: {
         stage: GrowthStage.Baby,
         substage: 1,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: 0,
       },
     });

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -23,6 +23,9 @@ import {
   useToyItem,
 } from "./items";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 function createTestState(): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);
   // Reduce stats to test restoration
@@ -33,9 +36,9 @@ function createTestState(): GameState {
 
   return {
     version: CURRENT_SAVE_VERSION,
-    lastSaveTime: Date.now(),
-    lastDailyReset: Date.now(),
-    lastWeeklyReset: Date.now(),
+    lastSaveTime: FROZEN_TIME,
+    lastDailyReset: FROZEN_TIME,
+    lastWeeklyReset: FROZEN_TIME,
     totalTicks: 0,
     pet,
     player: {

--- a/src/game/core/petStats.test.ts
+++ b/src/game/core/petStats.test.ts
@@ -15,9 +15,17 @@ import {
   createDefaultBonusMaxStats,
 } from "./petStats";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 test("calculatePetMaxStats returns correct values for baby florabit at age 0", () => {
   const pet = createTestPet({
-    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: FROZEN_TIME,
+      ageTicks: 0,
+    },
   });
   const maxStats = calculatePetMaxStats(pet);
 
@@ -46,7 +54,12 @@ test("calculatePetMaxStats includes bonus max stats", () => {
   bonusMaxStats.careLife = 500;
 
   const pet = createTestPet({
-    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: FROZEN_TIME,
+      ageTicks: 0,
+    },
     bonusMaxStats,
   });
   const maxStats = calculatePetMaxStats(pet);
@@ -80,7 +93,12 @@ test("calculatePetMaxStats returns null for invalid species", () => {
 
 test("calculatePetMaxStats values differ between growth stages", () => {
   const babyPet = createTestPet({
-    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 0 },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: FROZEN_TIME,
+      ageTicks: 0,
+    },
   });
 
   // Get the age ticks for an adult stage
@@ -96,7 +114,7 @@ test("calculatePetMaxStats values differ between growth stages", () => {
     growth: {
       stage: "adult",
       substage: 1,
-      birthTime: Date.now(),
+      birthTime: FROZEN_TIME,
       ageTicks: adultStage?.minAgeTicks ?? 0,
     },
   });

--- a/src/game/core/sleep.test.ts
+++ b/src/game/core/sleep.test.ts
@@ -18,6 +18,9 @@ import {
   wakeUp,
 } from "./sleep";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 test("putToSleep succeeds when pet is awake", () => {
   const pet = createTestPet();
   const result = putToSleep(pet);
@@ -81,7 +84,7 @@ test("wakeUp fails when pet is already awake", () => {
 test("processSleepTick accumulates sleep time when sleeping", () => {
   const sleep = {
     isSleeping: true,
-    sleepStartTime: Date.now(),
+    sleepStartTime: FROZEN_TIME,
     sleepTicksToday: 10,
   };
   const result = processSleepTick(sleep);
@@ -152,7 +155,7 @@ test("hasMetSleepRequirement returns true when exceeded requirement", () => {
 test("resetDailySleep resets sleepTicksToday to 0", () => {
   const sleep = {
     isSleeping: true,
-    sleepStartTime: Date.now(),
+    sleepStartTime: FROZEN_TIME,
     sleepTicksToday: 1500,
   };
   const result = resetDailySleep(sleep);

--- a/src/game/core/tick.test.ts
+++ b/src/game/core/tick.test.ts
@@ -10,9 +10,17 @@ import {
 import { createTestPet } from "@/game/testing/createTestPet";
 import { processPetTick } from "./tick";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 test("processPetTick increments ageTicks by 1", () => {
   const pet = createTestPet({
-    growth: { stage: "baby", substage: 1, birthTime: Date.now(), ageTicks: 5 },
+    growth: {
+      stage: "baby",
+      substage: 1,
+      birthTime: FROZEN_TIME,
+      ageTicks: 5,
+    },
   });
   const updatedPet = processPetTick(pet);
 
@@ -34,7 +42,7 @@ test("processPetTick applies care stat decay when sleeping (slower rate)", () =>
   const sleepingPet = createTestPet({
     sleep: {
       isSleeping: true,
-      sleepStartTime: Date.now(),
+      sleepStartTime: FROZEN_TIME,
       sleepTicksToday: 0,
     },
   });
@@ -66,7 +74,7 @@ test("processPetTick regenerates energy faster when sleeping", () => {
     energyStats: { energy: 10_000 },
     sleep: {
       isSleeping: true,
-      sleepStartTime: Date.now(),
+      sleepStartTime: FROZEN_TIME,
       sleepTicksToday: 0,
     },
   });

--- a/src/game/core/training.test.ts
+++ b/src/game/core/training.test.ts
@@ -19,6 +19,9 @@ import { TrainingSessionType } from "@/game/types/activity";
 import { TICKS_PER_HOUR, toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 // canStartTraining tests
 test("canStartTraining returns true when pet is idle with enough energy", () => {
   const pet = createTestPet();
@@ -33,7 +36,11 @@ test("canStartTraining returns true when pet is idle with enough energy", () => 
 test("canStartTraining fails when pet is sleeping", () => {
   const pet = createTestPet({
     activityState: ActivityState.Sleeping,
-    sleep: { isSleeping: true, sleepStartTime: Date.now(), sleepTicksToday: 0 },
+    sleep: {
+      isSleeping: true,
+      sleepStartTime: FROZEN_TIME,
+      sleepTicksToday: 0,
+    },
   });
   const result = canStartTraining(
     pet,

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -6,6 +6,9 @@ import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { useGameNotifications } from "./useGameNotifications";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 describe("useGameNotifications", () => {
   const mockSetNotification = mock((_n: GameNotification | null) => {});
 
@@ -15,7 +18,7 @@ describe("useGameNotifications", () => {
       growth: {
         stage: GrowthStage.Baby,
         substage: 0,
-        birthTime: 0,
+        birthTime: FROZEN_TIME,
         ageTicks: 0,
       },
       activeTraining: undefined,
@@ -80,9 +83,9 @@ describe("useGameNotifications", () => {
       quests: [],
       pet: defaultPet,
       isInitialized: true,
-      lastSaveTime: Date.now(),
-      lastDailyReset: Date.now(),
-      lastWeeklyReset: Date.now(),
+      lastSaveTime: FROZEN_TIME,
+      lastDailyReset: FROZEN_TIME,
+      lastWeeklyReset: FROZEN_TIME,
       player: {
         inventory: { items: [] },
         currency: { coins: 0 },

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -21,6 +21,9 @@ import { QuestState } from "@/game/types/quest";
 import { createInitialSkills } from "@/game/types/skill";
 import { cleanPet, feedPet, playWithPet, waterPet } from "./care";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 function createTestState(quests: QuestProgress[] = []): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);
   // Reduce stats to test restoration
@@ -33,9 +36,9 @@ function createTestState(quests: QuestProgress[] = []): GameState {
 
   return {
     version: CURRENT_SAVE_VERSION,
-    lastSaveTime: Date.now(),
-    lastDailyReset: Date.now(),
-    lastWeeklyReset: Date.now(),
+    lastSaveTime: FROZEN_TIME,
+    lastDailyReset: FROZEN_TIME,
+    lastWeeklyReset: FROZEN_TIME,
     totalTicks: 0,
     pet,
     player: {

--- a/src/game/state/actions/sleep.test.ts
+++ b/src/game/state/actions/sleep.test.ts
@@ -11,12 +11,15 @@ import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { sleepPet, wakePet } from "./sleep";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 function createTestGameState(isSleeping: boolean): GameState {
   return {
     version: 1,
-    lastSaveTime: Date.now(),
-    lastDailyReset: Date.now(),
-    lastWeeklyReset: Date.now(),
+    lastSaveTime: FROZEN_TIME,
+    lastDailyReset: FROZEN_TIME,
+    lastWeeklyReset: FROZEN_TIME,
     totalTicks: 0,
     pet: {
       identity: {
@@ -27,7 +30,7 @@ function createTestGameState(isSleeping: boolean): GameState {
       growth: {
         stage: GrowthStage.Baby,
         substage: 1,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: 0,
       },
       careStats: {
@@ -51,7 +54,7 @@ function createTestGameState(isSleeping: boolean): GameState {
       },
       sleep: {
         isSleeping,
-        sleepStartTime: isSleeping ? Date.now() : null,
+        sleepStartTime: isSleeping ? FROZEN_TIME : null,
         sleepTicksToday: 0,
       },
       activityState: isSleeping ? ActivityState.Sleeping : ActivityState.Idle,
@@ -72,9 +75,9 @@ function createTestGameState(isSleeping: boolean): GameState {
 function createEmptyGameState(): GameState {
   return {
     version: 1,
-    lastSaveTime: Date.now(),
-    lastDailyReset: Date.now(),
-    lastWeeklyReset: Date.now(),
+    lastSaveTime: FROZEN_TIME,
+    lastDailyReset: FROZEN_TIME,
+    lastWeeklyReset: FROZEN_TIME,
     totalTicks: 0,
     pet: null,
     player: {

--- a/src/game/state/actions/training.test.ts
+++ b/src/game/state/actions/training.test.ts
@@ -13,6 +13,9 @@ import { toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 import { cancelTraining, startTraining } from "./training";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 describe("startTraining", () => {
   test("returns failure when no pet", () => {
     const state = createTestGameState(null);
@@ -125,7 +128,7 @@ describe("startTraining", () => {
       growth: {
         stage: GrowthStage.Baby,
         substage: 1,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: 0,
       },
     });
@@ -149,7 +152,7 @@ describe("startTraining", () => {
       growth: {
         stage: GrowthStage.Child,
         substage: 1,
-        birthTime: Date.now(),
+        birthTime: FROZEN_TIME,
         ageTicks: 1000,
       },
     });

--- a/src/game/state/persistence.test.ts
+++ b/src/game/state/persistence.test.ts
@@ -14,6 +14,9 @@ import {
   validateGameState,
 } from "./persistence";
 
+// Fixed timestamp for deterministic test fixtures
+const FROZEN_TIME = 1_733_400_000_000;
+
 // Mock localStorage for testing
 const localStorageData: Record<string, string> = {};
 
@@ -203,7 +206,7 @@ describe("saveGame and loadGame", () => {
     state.pendingEvents = [
       {
         type: "stageTransition",
-        timestamp: Date.now(),
+        timestamp: FROZEN_TIME,
         previousStage: "baby",
         newStage: "child",
         petName: "Test",

--- a/src/game/testing/constants.ts
+++ b/src/game/testing/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared test constants for deterministic testing.
+ */
+
+/**
+ * Frozen timestamp for deterministic test fixtures.
+ * 2024-12-05T12:00:00.000Z (Thursday)
+ */
+export const FROZEN_TIME = 1_733_400_000_000;

--- a/src/game/testing/createTestPet.ts
+++ b/src/game/testing/createTestPet.ts
@@ -10,6 +10,7 @@ import type { Pet } from "@/game/types/pet";
 import { createInitialSkills } from "@/game/types/skill";
 import type { BattleStats } from "@/game/types/stats";
 import { createDefaultResistances } from "@/game/types/stats";
+import { FROZEN_TIME } from "./constants";
 
 /**
  * Create default (zero) battle stats for testing.
@@ -27,7 +28,7 @@ export function createDefaultBattleStats(): BattleStats {
 
 /**
  * Factory function to create default test pet values.
- * Using a factory ensures fresh timestamps for each call.
+ * Uses FROZEN_TIME for deterministic test fixtures.
  */
 const createDefaultTestPet = (): Pet => ({
   identity: {
@@ -38,7 +39,7 @@ const createDefaultTestPet = (): Pet => ({
   growth: {
     stage: GrowthStage.Baby,
     substage: 1,
-    birthTime: Date.now(),
+    birthTime: FROZEN_TIME,
     ageTicks: 0,
   },
   careStats: {
@@ -140,7 +141,7 @@ export function createSleepingTestPet(overrides: DeepPartial<Pet> = {}): Pet {
     sleep: {
       ...sleepOverrides,
       isSleeping: true,
-      sleepStartTime: sleepOverrides?.sleepStartTime ?? Date.now(),
+      sleepStartTime: sleepOverrides?.sleepStartTime ?? FROZEN_TIME,
     },
     activityState: ActivityState.Sleeping,
   });
@@ -157,12 +158,11 @@ export function createTestGameState(
     }
   > = {},
 ): GameState {
-  const now = Date.now();
   const { player: playerOverrides, ...stateOverrides } = overrides;
 
   return {
     version: 1,
-    lastSaveTime: now,
+    lastSaveTime: FROZEN_TIME,
     totalTicks: 0,
     pet,
     player: {
@@ -174,8 +174,8 @@ export function createTestGameState(
     },
     quests: [],
     isInitialized: true,
-    lastDailyReset: now,
-    lastWeeklyReset: now,
+    lastDailyReset: FROZEN_TIME,
+    lastWeeklyReset: FROZEN_TIME,
     pendingEvents: [],
     pendingNotifications: [],
     ...stateOverrides,


### PR DESCRIPTION
## Summary

Replace all dynamic `Date.now()` calls with a fixed `FROZEN_TIME` constant for deterministic test fixtures. This completes the remaining medium and low priority items from the time determinism investigation.

## Changes

### Files Updated (14 files)

**Medium Priority:**
- `state/actions/sleep.test.ts` - lastSaveTime, lastDailyReset, lastWeeklyReset, sleepStartTime
- `state/actions/care.test.ts` - lastSaveTime, lastDailyReset, lastWeeklyReset
- `core/sleep.test.ts` - sleepStartTime fixtures
- `core/items.test.ts` - lastSaveTime, lastDailyReset, lastWeeklyReset
- `hooks/useGameNotifications.test.ts` - lastSaveTime, lastDailyReset, lastWeeklyReset, birthTime

**Low Priority:**
- `core/tick.test.ts` - birthTime, sleepStartTime
- `core/growth.test.ts` - birthTime fixtures
- `core/petStats.test.ts` - birthTime fixtures
- `core/training.test.ts` - sleepStartTime fixtures
- `core/care/poop.test.ts` - sleepStartTime fixtures
- `core/care/careStats.test.ts` - sleepStartTime fixtures
- `state/actions/training.test.ts` - birthTime fixtures
- `state/persistence.test.ts` - event timestamp fixture
- `core/integration.test.ts` - birthTime fixtures

### Pattern Used

```typescript
// Fixed timestamp for deterministic test fixtures
const FROZEN_TIME = 1_733_400_000_000; // 2024-12-05T12:00:00.000Z
```

### Investigation File Updated

Updated `investigate/bug_time.ts` to mark all 18 files as completed.

## Testing

All 743 tests pass.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all Date.now() calls in test fixtures with a fixed FROZEN_TIME (1_733_400_000_000) to make time-dependent tests deterministic and remove flakiness. Completes the remaining items from the time determinism investigation.

- **Refactors**
  - Standardized timestamps for birthTime, sleepStartTime, lastSaveTime/daily/weekly resets, and event timestamps across 14 test files.
  - Centralized FROZEN_TIME in src/game/testing/constants.ts and updated createTestPet.ts and related test utilities to use it.
  - Updated investigate/bug_time.ts to mark all 18 files complete.

<sup>Written for commit 67cbd09cb05df93e816396b6720e3e3e355e2f98. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and consistency across the suite by standardizing timestamp handling in test fixtures.

---

**Note:** This release contains internal testing improvements with no end-user visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Systematically replaces all `Date.now()` calls with a fixed `FROZEN_TIME` constant (1_733_400_000_000) across 14 test files to eliminate time-dependent test flakiness and ensure deterministic test execution.

**Changes Made:**
- Added consistent `FROZEN_TIME` constant declaration to each test file
- Replaced dynamic timestamps in fixtures for: `birthTime`, `sleepStartTime`, `lastSaveTime`, `lastDailyReset`, `lastWeeklyReset`, and event timestamps
- Covers medium and low priority items from time determinism investigation
- All 743 tests pass with deterministic fixtures

**Quality Notes:**
- Changes are strictly mechanical and consistent across all files
- Pattern follows established approach from previous time determinism work
- No logic changes, only test fixture improvements
- Remaining `Date.now()` calls in other test files are legitimate (used for relative time calculations, not fixture data)

<h3>Confidence Score: 5/5</h3>


- Safe to merge - mechanical refactoring of test fixtures with no logic changes
- Perfect score reflects: (1) purely mechanical changes to test fixtures with zero production code impact, (2) consistent pattern applied uniformly across all 14 files, (3) all 743 tests passing, (4) addresses legitimate test determinism concerns, (5) follows established codebase patterns from prior work
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/testing/constants.ts | 5/5 | Added centralized FROZEN_TIME constant (1_733_400_000_000) for deterministic test fixtures |
| src/game/testing/createTestPet.ts | 5/5 | Imported and used FROZEN_TIME constant for birthTime, sleepStartTime, and state timestamps in test utilities |
| src/game/core/items.test.ts | 5/5 | Added FROZEN_TIME constant and replaced Date.now() in lastSaveTime, lastDailyReset, lastWeeklyReset fixtures |
| src/game/core/sleep.test.ts | 5/5 | Added FROZEN_TIME constant and replaced Date.now() in sleepStartTime and state time tracking fixtures |
| src/game/hooks/useGameNotifications.test.ts | 5/5 | Added FROZEN_TIME constant and replaced Date.now() in birthTime, lastSaveTime, lastDailyReset, lastWeeklyReset fixtures |
| src/game/state/actions/care.test.ts | 5/5 | Added FROZEN_TIME constant and replaced Date.now() in lastSaveTime, lastDailyReset, lastWeeklyReset fixtures |
| src/game/state/actions/sleep.test.ts | 5/5 | Added FROZEN_TIME constant and replaced Date.now() in birthTime, sleepStartTime, and state time tracking fixtures |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as Pull Request #130
    participant Tests as Test Suite
    participant Fixtures as Test Fixtures
    
    Note over Dev,Fixtures: Before: Non-deterministic Tests
    Dev->>Tests: Run test suite
    Tests->>Fixtures: Create fixture with Date.now()
    Fixtures-->>Tests: Returns current timestamp
    Note over Tests: Different timestamp each run
    Tests-->>Dev: Test results may vary
    
    Note over Dev,Fixtures: After: Deterministic Tests
    Dev->>PR: Apply FROZEN_TIME changes
    PR->>Fixtures: Replace Date.now() with FROZEN_TIME
    Note over Fixtures: const FROZEN_TIME = 1_733_400_000_000
    Dev->>Tests: Run test suite
    Tests->>Fixtures: Create fixture with FROZEN_TIME
    Fixtures-->>Tests: Returns fixed timestamp
    Note over Tests: Same timestamp every run
    Tests-->>Dev: Consistent, reproducible results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->