### PR TITLE
fix: add deterministic time to test files using Date.now()

### DIFF
--- a/src/game/GameManager.test.ts
+++ b/src/game/GameManager.test.ts
@@ -31,6 +31,12 @@ import {
   type StateUpdateCallback,
 } from "./GameManager";
 
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
+
 // Tests for GameManager lifecycle
 
 test("GameManager starts not running", () => {

--- a/src/game/GameManager.test.ts
+++ b/src/game/GameManager.test.ts
@@ -18,6 +18,7 @@ import {
   createDefaultBattleStats,
   createTestPet,
 } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { TICK_DURATION_MS } from "@/game/types/common";
 import type { GameState } from "@/game/types/gameState";
 import { createInitialGameState } from "@/game/types/gameState";
@@ -31,11 +32,7 @@ import {
   type StateUpdateCallback,
 } from "./GameManager";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 // Tests for GameManager lifecycle
 

--- a/src/game/core/care/careStats.test.ts
+++ b/src/game/core/care/careStats.test.ts
@@ -2,10 +2,16 @@
  * Tests for care stat decay logic.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import { createTestPet } from "@/game/testing/createTestPet";
 import { applyCareDecay, getPoopHappinessMultiplier } from "./careStats";
 import { CARE_DECAY_AWAKE, CARE_DECAY_SLEEPING } from "./constants";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 test("getPoopHappinessMultiplier returns 1.0 for 0-2 poop", () => {
   expect(getPoopHappinessMultiplier(0)).toBe(1.0);

--- a/src/game/core/care/careStats.test.ts
+++ b/src/game/core/care/careStats.test.ts
@@ -2,16 +2,13 @@
  * Tests for care stat decay logic.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { createTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { applyCareDecay, getPoopHappinessMultiplier } from "./careStats";
 import { CARE_DECAY_AWAKE, CARE_DECAY_SLEEPING } from "./constants";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 test("getPoopHappinessMultiplier returns 1.0 for 0-2 poop", () => {
   expect(getPoopHappinessMultiplier(0)).toBe(1.0);

--- a/src/game/core/care/poop.test.ts
+++ b/src/game/core/care/poop.test.ts
@@ -9,8 +9,15 @@
  * This ensures mid-cycle state changes properly adjust timing.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import { createTestPet } from "@/game/testing/createTestPet";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
+
 import {
   MAX_POOP_COUNT,
   POOP_DECAY_AWAKE,

--- a/src/game/core/care/poop.test.ts
+++ b/src/game/core/care/poop.test.ts
@@ -9,15 +9,9 @@
  * This ensures mid-cycle state changes properly adjust timing.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { createTestPet } from "@/game/testing/createTestPet";
-
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
-
+import { setupTimeFreezing } from "@/game/testing/time";
 import {
   MAX_POOP_COUNT,
   POOP_DECAY_AWAKE,
@@ -25,6 +19,8 @@ import {
   POOP_MICRO_THRESHOLD,
 } from "./constants";
 import { getInitialPoopTimer, processPoopTick, removePoop } from "./poop";
+
+setupTimeFreezing();
 
 test("getInitialPoopTimer returns micro threshold", () => {
   expect(getInitialPoopTimer()).toBe(POOP_MICRO_THRESHOLD);

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -2,7 +2,7 @@
  * Tests for growth logic.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   getSpeciesById,
   getSpeciesGrowthStage,
@@ -11,6 +11,12 @@ import {
 import { createTestPet } from "@/game/testing/createTestPet";
 import type { GrowthStage } from "@/game/types/constants";
 import { getNextStage, processGrowthTick } from "./growth";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 // Helper to get the min age ticks for a given stage from species data
 function getStageMinAgeTicks(speciesId: string, stage: GrowthStage): number {

--- a/src/game/core/growth.test.ts
+++ b/src/game/core/growth.test.ts
@@ -2,21 +2,18 @@
  * Tests for growth logic.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   getSpeciesById,
   getSpeciesGrowthStage,
   SPECIES,
 } from "@/game/data/species";
 import { createTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import type { GrowthStage } from "@/game/types/constants";
 import { getNextStage, processGrowthTick } from "./growth";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 // Helper to get the min age ticks for a given stage from species data
 function getStageMinAgeTicks(speciesId: string, stage: GrowthStage): number {

--- a/src/game/core/integration.test.ts
+++ b/src/game/core/integration.test.ts
@@ -3,7 +3,14 @@
  * Tests the interaction between multiple game mechanics.
  */
 
-import { describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { calculateDamage } from "@/game/core/battle/damage";
 import { applyCareLifeChange } from "@/game/core/care/careLife";
 import { applyCareDecay } from "@/game/core/care/careStats";
@@ -21,6 +28,12 @@ import { DamageType, GrowthStage } from "@/game/types/constants";
 import { createInitialGameState, type GameState } from "@/game/types/gameState";
 import type { Move } from "@/game/types/move";
 import { createDefaultResistances } from "@/game/types/stats";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 // Helper to create test game state
 function createTestGameState(overrides: Partial<GameState> = {}): GameState {

--- a/src/game/core/integration.test.ts
+++ b/src/game/core/integration.test.ts
@@ -3,14 +3,7 @@
  * Tests the interaction between multiple game mechanics.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { calculateDamage } from "@/game/core/battle/damage";
 import { applyCareLifeChange } from "@/game/core/care/careLife";
 import { applyCareDecay } from "@/game/core/care/careStats";
@@ -24,16 +17,13 @@ import {
   createSleepingTestPet,
   createTestPet,
 } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { DamageType, GrowthStage } from "@/game/types/constants";
 import { createInitialGameState, type GameState } from "@/game/types/gameState";
 import type { Move } from "@/game/types/move";
 import { createDefaultResistances } from "@/game/types/stats";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 // Helper to create test game state
 function createTestGameState(overrides: Partial<GameState> = {}): GameState {

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -2,7 +2,7 @@
  * Tests for item usage functions.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   CLEANING_ITEMS,
   DRINK_ITEMS,
@@ -12,6 +12,7 @@ import {
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
 import { createSleepingTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
 import { ActivityState } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
@@ -23,11 +24,7 @@ import {
   useToyItem,
 } from "./items";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 function createTestState(): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);

--- a/src/game/core/items.test.ts
+++ b/src/game/core/items.test.ts
@@ -2,7 +2,7 @@
  * Tests for item usage functions.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   CLEANING_ITEMS,
   DRINK_ITEMS,
@@ -22,6 +22,12 @@ import {
   useFoodItem,
   useToyItem,
 } from "./items";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 function createTestState(): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);

--- a/src/game/core/petStats.test.ts
+++ b/src/game/core/petStats.test.ts
@@ -2,7 +2,7 @@
  * Tests for pet stats calculation utilities.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   getSpeciesById,
   getSpeciesGrowthStage,
@@ -14,6 +14,12 @@ import {
   calculatePetMaxStats,
   createDefaultBonusMaxStats,
 } from "./petStats";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 test("calculatePetMaxStats returns correct values for baby florabit at age 0", () => {
   const pet = createTestPet({

--- a/src/game/core/petStats.test.ts
+++ b/src/game/core/petStats.test.ts
@@ -2,24 +2,21 @@
  * Tests for pet stats calculation utilities.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   getSpeciesById,
   getSpeciesGrowthStage,
   SPECIES,
 } from "@/game/data/species";
 import { createTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import {
   calculateMaxStatsForAge,
   calculatePetMaxStats,
   createDefaultBonusMaxStats,
 } from "./petStats";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 test("calculatePetMaxStats returns correct values for baby florabit at age 0", () => {
   const pet = createTestPet({

--- a/src/game/core/sleep.test.ts
+++ b/src/game/core/sleep.test.ts
@@ -2,19 +2,13 @@
  * Tests for sleep state transitions.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   createSleepingTestPet,
   createTestPet,
 } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { ActivityState } from "@/game/types/constants";
-
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
-
 import {
   canPerformCareActions,
   getRemainingMinSleep,
@@ -24,6 +18,8 @@ import {
   resetDailySleep,
   wakeUp,
 } from "./sleep";
+
+setupTimeFreezing();
 
 test("putToSleep succeeds when pet is awake", () => {
   const pet = createTestPet();

--- a/src/game/core/sleep.test.ts
+++ b/src/game/core/sleep.test.ts
@@ -2,12 +2,19 @@
  * Tests for sleep state transitions.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   createSleepingTestPet,
   createTestPet,
 } from "@/game/testing/createTestPet";
 import { ActivityState } from "@/game/types/constants";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
+
 import {
   canPerformCareActions,
   getRemainingMinSleep,

--- a/src/game/core/tick.test.ts
+++ b/src/game/core/tick.test.ts
@@ -2,19 +2,16 @@
  * Tests for single tick processing logic.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   ENERGY_REGEN_AWAKE,
   ENERGY_REGEN_SLEEPING,
 } from "@/game/core/care/constants";
 import { createTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { processPetTick } from "./tick";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 test("processPetTick increments ageTicks by 1", () => {
   const pet = createTestPet({

--- a/src/game/core/tick.test.ts
+++ b/src/game/core/tick.test.ts
@@ -2,13 +2,19 @@
  * Tests for single tick processing logic.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   ENERGY_REGEN_AWAKE,
   ENERGY_REGEN_SLEEPING,
 } from "@/game/core/care/constants";
 import { createTestPet } from "@/game/testing/createTestPet";
 import { processPetTick } from "./tick";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 test("processPetTick increments ageTicks by 1", () => {
   const pet = createTestPet({

--- a/src/game/core/training.test.ts
+++ b/src/game/core/training.test.ts
@@ -2,7 +2,7 @@
  * Tests for training system core logic.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   applyTrainingCompletion,
   cancelTraining,
@@ -14,16 +14,13 @@ import {
   startTraining,
 } from "@/game/core/training";
 import { createTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import type { ActiveTraining } from "@/game/types/activity";
 import { TrainingSessionType } from "@/game/types/activity";
 import { TICKS_PER_HOUR, toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 // canStartTraining tests
 test("canStartTraining returns true when pet is idle with enough energy", () => {

--- a/src/game/core/training.test.ts
+++ b/src/game/core/training.test.ts
@@ -2,7 +2,7 @@
  * Tests for training system core logic.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   applyTrainingCompletion,
   cancelTraining,
@@ -18,6 +18,12 @@ import type { ActiveTraining } from "@/game/types/activity";
 import { TrainingSessionType } from "@/game/types/activity";
 import { TICKS_PER_HOUR, toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 // canStartTraining tests
 test("canStartTraining returns true when pet is idle with enough energy", () => {

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -1,26 +1,15 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
+import { setupTimeFreezing } from "@/game/testing/time";
 import type { GameNotification, GameState, Pet } from "@/game/types";
 import { GrowthStage } from "@/game/types";
 import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { useGameNotifications } from "./useGameNotifications";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
+setupTimeFreezing();
 
 describe("useGameNotifications", () => {
-  beforeEach(() => setSystemTime(FROZEN_TIME));
-  afterEach(() => setSystemTime());
-
   const mockSetNotification = mock((_n: GameNotification | null) => {});
 
   const createMockState = (overrides: Partial<GameState> = {}): GameState => {

--- a/src/game/hooks/useGameNotifications.test.ts
+++ b/src/game/hooks/useGameNotifications.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { renderHook } from "@testing-library/react";
 import type { GameNotification, GameState, Pet } from "@/game/types";
 import { GrowthStage } from "@/game/types";
@@ -6,7 +14,13 @@ import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { useGameNotifications } from "./useGameNotifications";
 
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
 describe("useGameNotifications", () => {
+  beforeEach(() => setSystemTime(FROZEN_TIME));
+  afterEach(() => setSystemTime());
+
   const mockSetNotification = mock((_n: GameNotification | null) => {});
 
   const createMockState = (overrides: Partial<GameState> = {}): GameState => {

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -2,7 +2,7 @@
  * Tests for care actions including quest progress updates.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import {
   CLEANING_ITEMS,
   DRINK_ITEMS,
@@ -20,6 +20,12 @@ import type { QuestProgress } from "@/game/types/quest";
 import { QuestState } from "@/game/types/quest";
 import { createInitialSkills } from "@/game/types/skill";
 import { cleanPet, feedPet, playWithPet, waterPet } from "./care";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 function createTestState(quests: QuestProgress[] = []): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);

--- a/src/game/state/actions/care.test.ts
+++ b/src/game/state/actions/care.test.ts
@@ -2,7 +2,7 @@
  * Tests for care actions including quest progress updates.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
   CLEANING_ITEMS,
   DRINK_ITEMS,
@@ -14,6 +14,7 @@ import { tutorialFirstSteps } from "@/game/data/quests/tutorial";
 import { SPECIES } from "@/game/data/species";
 import { createNewPet } from "@/game/data/starting";
 import { createSleepingTestPet } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { CURRENT_SAVE_VERSION } from "@/game/types";
 import type { GameState } from "@/game/types/gameState";
 import type { QuestProgress } from "@/game/types/quest";
@@ -21,11 +22,7 @@ import { QuestState } from "@/game/types/quest";
 import { createInitialSkills } from "@/game/types/skill";
 import { cleanPet, feedPet, playWithPet, waterPet } from "./care";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 function createTestState(quests: QuestProgress[] = []): GameState {
   const pet = createNewPet("TestPet", SPECIES.FLORABIT.id);

--- a/src/game/state/actions/sleep.test.ts
+++ b/src/game/state/actions/sleep.test.ts
@@ -2,20 +2,17 @@
  * Tests for sleep state actions.
  */
 
-import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { createDefaultBonusMaxStats } from "@/game/core/petStats";
 import { createDefaultBattleStats } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 import type { GameState } from "@/game/types/gameState";
 import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { sleepPet, wakePet } from "./sleep";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 function createTestGameState(isSleeping: boolean): GameState {
   return {

--- a/src/game/state/actions/sleep.test.ts
+++ b/src/game/state/actions/sleep.test.ts
@@ -2,7 +2,7 @@
  * Tests for sleep state actions.
  */
 
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test";
 import { createDefaultBonusMaxStats } from "@/game/core/petStats";
 import { createDefaultBattleStats } from "@/game/testing/createTestPet";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
@@ -10,6 +10,12 @@ import type { GameState } from "@/game/types/gameState";
 import { createInitialSkills } from "@/game/types/skill";
 import { createDefaultResistances } from "@/game/types/stats";
 import { sleepPet, wakePet } from "./sleep";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 function createTestGameState(isSleeping: boolean): GameState {
   return {

--- a/src/game/state/actions/training.test.ts
+++ b/src/game/state/actions/training.test.ts
@@ -2,29 +2,19 @@
  * Tests for training state actions.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { strengthFacility } from "@/game/data/facilities/facilities";
 import {
   createTestGameState,
   createTestPet,
 } from "@/game/testing/createTestPet";
+import { setupTimeFreezing } from "@/game/testing/time";
 import { TrainingSessionType } from "@/game/types/activity";
 import { toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 import { cancelTraining, startTraining } from "./training";
 
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
-
-beforeEach(() => setSystemTime(FROZEN_TIME));
-afterEach(() => setSystemTime());
+setupTimeFreezing();
 
 describe("startTraining", () => {
   test("returns failure when no pet", () => {

--- a/src/game/state/actions/training.test.ts
+++ b/src/game/state/actions/training.test.ts
@@ -2,7 +2,14 @@
  * Tests for training state actions.
  */
 
-import { describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { strengthFacility } from "@/game/data/facilities/facilities";
 import {
   createTestGameState,
@@ -12,6 +19,12 @@ import { TrainingSessionType } from "@/game/types/activity";
 import { toMicro } from "@/game/types/common";
 import { ActivityState, GrowthStage } from "@/game/types/constants";
 import { cancelTraining, startTraining } from "./training";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
+
+beforeEach(() => setSystemTime(FROZEN_TIME));
+afterEach(() => setSystemTime());
 
 describe("startTraining", () => {
   test("returns failure when no pet", () => {

--- a/src/game/state/persistence.test.ts
+++ b/src/game/state/persistence.test.ts
@@ -11,6 +11,7 @@ import {
   test,
 } from "bun:test";
 import { createTestGameState } from "@/game/testing/createTestPet";
+import { FROZEN_TIME } from "@/game/testing/time";
 import {
   deleteSave,
   exportSave,
@@ -20,9 +21,6 @@ import {
   saveGame,
   validateGameState,
 } from "./persistence";
-
-// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
-const FROZEN_TIME = 1_733_400_000_000;
 
 // Mock localStorage for testing
 const localStorageData: Record<string, string> = {};

--- a/src/game/state/persistence.test.ts
+++ b/src/game/state/persistence.test.ts
@@ -2,7 +2,14 @@
  * Tests for persistence functions including save/load validation.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { createTestGameState } from "@/game/testing/createTestPet";
 import {
   deleteSave,
@@ -13,6 +20,9 @@ import {
   saveGame,
   validateGameState,
 } from "./persistence";
+
+// Frozen time for deterministic tests: 2024-12-05T12:00:00.000Z
+const FROZEN_TIME = 1_733_400_000_000;
 
 // Mock localStorage for testing
 const localStorageData: Record<string, string> = {};
@@ -39,10 +49,12 @@ Object.defineProperty(globalThis, "localStorage", {
 });
 
 beforeEach(() => {
+  setSystemTime(FROZEN_TIME);
   mockLocalStorage.clear();
 });
 
 afterEach(() => {
+  setSystemTime();
   mockLocalStorage.clear();
 });
 

--- a/src/game/testing/time.ts
+++ b/src/game/testing/time.ts
@@ -1,0 +1,43 @@
+/**
+ * Test time utilities for deterministic time-based tests.
+ *
+ * Use `setupTimeFreezing()` in test files that use `Date.now()` to ensure
+ * deterministic and reproducible test results.
+ */
+
+import { afterEach, beforeEach, setSystemTime } from "bun:test";
+
+/**
+ * Frozen time constant for deterministic tests: 2024-12-05T12:00:00.000Z (Thursday)
+ *
+ * This timestamp is chosen because:
+ * - It's a weekday (Thursday), useful for weekly reset tests
+ * - It's at noon, avoiding edge cases around midnight
+ * - It's a recent date that won't cause issues with age calculations
+ */
+export const FROZEN_TIME = 1_733_400_000_000;
+
+/**
+ * Sets up time freezing for the current test file using beforeEach/afterEach hooks.
+ *
+ * Call this function at the top level of a test file (after imports) to freeze
+ * `Date.now()` to `FROZEN_TIME` for all tests in that file.
+ *
+ * @example
+ * ```typescript
+ * import { setupTimeFreezing } from "@/game/testing/time";
+ *
+ * setupTimeFreezing();
+ *
+ * test("my test", () => {
+ *   // Date.now() will return FROZEN_TIME here
+ * });
+ * ```
+ *
+ * For tests that need a different frozen time, use `setSystemTime()` directly
+ * within a `describe` block with its own beforeEach/afterEach hooks.
+ */
+export function setupTimeFreezing(): void {
+  beforeEach(() => setSystemTime(FROZEN_TIME));
+  afterEach(() => setSystemTime());
+}


### PR DESCRIPTION
## Summary

This PR adds `setSystemTime()` with frozen timestamps to 15 test files that were using `Date.now()` without time freezing, which could cause non-deterministic test behavior.

## Changes

All test files now use a consistent frozen time pattern:

```typescript
const FROZEN_TIME = 1_733_400_000_000; // 2024-12-05T12:00:00.000Z

beforeEach(() => setSystemTime(FROZEN_TIME));
afterEach(() => setSystemTime());
```

### High priority fixes (time-sensitive logic):
- `src/game/core/sleep.test.ts`
- `src/game/core/growth.test.ts`
- `src/game/core/tick.test.ts`
- `src/game/core/care/poop.test.ts`
- `src/game/core/care/careStats.test.ts`
- `src/game/core/training.test.ts`

### Medium priority fixes (state initialization):
- `src/game/state/actions/sleep.test.ts`
- `src/game/state/actions/care.test.ts`
- `src/game/state/actions/training.test.ts`
- `src/game/core/items.test.ts`
- `src/game/core/petStats.test.ts`
- `src/game/core/integration.test.ts`

### Lower priority fixes (initialization only):
- `src/game/hooks/useGameNotifications.test.ts`
- `src/game/state/persistence.test.ts`
- `src/game/GameManager.test.ts`

## Testing

All 743 tests pass with the frozen time configuration.

## Related

Updated `investigate/bug_time.md` checklist to mark all items as complete.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze Date.now in tests using a shared setupTimeFreezing utility to eliminate flakiness and make time-dependent behavior deterministic. Stabilizes sleep, growth, tick, training, care, and persistence tests.

- **Bug Fixes**
  - Applied a frozen timestamp (2024-12-05T12:00:00Z) across 15 test files via setupTimeFreezing.
  - Standardized beforeEach/afterEach to set and reset time; persistence tests use setSystemTime directly.
  - Stabilizes time-sensitive logic and state/persistence; all 743 tests pass.

<sup>Written for commit 806e61378d8fe0805fe3ad8b0ad2c548278464fa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a testing utility that freezes system time to a fixed instant for deterministic, repeatable tests.

* **Tests**
  * Integrated deterministic time control across multiple test suites, improving reliability for time-dependent game mechanics (care, growth, sleep, training, items, notifications, persistence, etc.).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Applied frozen time using `setupTimeFreezing()` across 15 test files that use `Date.now()` to eliminate non-deterministic test behavior. All 743 tests pass.

- Created reusable `src/game/testing/time.ts` utility with `FROZEN_TIME` constant (2024-12-05T12:00:00Z) and `setupTimeFreezing()` helper
- High-priority fixes: time-sensitive logic in sleep, growth, tick, poop, care stats, and training tests
- Medium-priority fixes: state initialization in state action tests (sleep, care, training) and core tests (items, pet stats, integration)
- Lower-priority fixes: GameManager lifecycle tests and React hooks with timestamp initialization
- One exception: `persistence.test.ts` uses explicit `setSystemTime()` calls in its existing `beforeEach`/`afterEach` hooks to align with its localStorage mocking pattern

This change ensures consistent test results by freezing `Date.now()` during test execution, preventing flakiness from real-time progression.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are purely additive test infrastructure improvements that freeze time for deterministic test behavior. The implementation follows established patterns (Bun's `setSystemTime()` API), introduces a well-documented shared utility, and all 743 tests pass. No production code is modified.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/game/testing/time.ts | 5/5 | Introduces shared time freezing utility with well-documented `FROZEN_TIME` constant and `setupTimeFreezing()` helper |
| src/game/core/sleep.test.ts | 5/5 | Adds `setupTimeFreezing()` call to stabilize time-dependent sleep transition tests using `Date.now()` |
| src/game/core/growth.test.ts | 5/5 | Adds `setupTimeFreezing()` call to ensure deterministic growth stage and substage transition tests |
| src/game/core/tick.test.ts | 5/5 | Adds `setupTimeFreezing()` call to stabilize tick processing tests that track time-based stat changes |
| src/game/core/care/poop.test.ts | 5/5 | Adds `setupTimeFreezing()` call to ensure poop timer and state tracking tests are deterministic |
| src/game/core/care/careStats.test.ts | 5/5 | Adds `setupTimeFreezing()` call to stabilize care stat decay and poop happiness multiplier tests |
| src/game/core/training.test.ts | 5/5 | Adds `setupTimeFreezing()` call to ensure training session timing and completion logic tests are consistent |
| src/game/state/persistence.test.ts | 5/5 | Uses explicit `setSystemTime()` in hooks instead of `setupTimeFreezing()` to match existing test pattern with localStorage mocking |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test File
    participant Setup as setupTimeFreezing()
    participant Bun as Bun Test Runner
    participant SUT as System Under Test
    
    Test->>Setup: Import and call setupTimeFreezing()
    Setup->>Bun: Register beforeEach hook
    Setup->>Bun: Register afterEach hook
    
    loop For each test
        Bun->>Bun: Execute beforeEach
        Bun->>Bun: setSystemTime(FROZEN_TIME)
        Note over Bun: Date.now() = 1_733_400_000_000
        
        Test->>SUT: Call function using Date.now()
        SUT->>Bun: Date.now()
        Bun-->>SUT: Returns FROZEN_TIME
        SUT-->>Test: Deterministic result
        
        Bun->>Bun: Execute afterEach
        Bun->>Bun: setSystemTime()
        Note over Bun: Date.now() restored to real time
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->