### PR TITLE
fix: sync HP bar animation with hit animation in battle

### DIFF
--- a/src/components/battle/PetBattleCard.tsx
+++ b/src/components/battle/PetBattleCard.tsx
@@ -2,8 +2,9 @@
  * Pet battle card showing HP, stamina, and status effects.
  *
  * Uses visual state buffering to sync HP changes with hit animations.
- * The displayed HP only updates when an attack animation completes,
- * preventing the jarring effect of HP dropping before the animation plays.
+ * The displayed HP only updates when the hit animation starts
+ * (when isHit transitions from false to true), preventing the jarring effect
+ * of HP dropping before the animation plays.
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -32,7 +33,7 @@ function clampPercent(value: number, max: number): number {
  * Displays a pet's battle status including HP bar, stamina, and effects.
  *
  * Uses visual state buffering: displayedHealth only updates when isHit
- * transitions to true, syncing the HP bar with the hit animation.
+ * transitions from false to true, syncing the HP bar with the hit animation.
  */
 export function PetBattleCard({
   combatant,
@@ -47,24 +48,42 @@ export function PetBattleCard({
     derivedStats.currentHealth,
   );
   const prevIsHitRef = useRef(isHit);
+  const prevCombatantRef = useRef(combatant);
 
-  // Sync displayed health with actual health when hit animation triggers
+  // Unified effect for syncing displayed health with actual health
+  // Handles: hit animations, healing, DoT damage, and combatant changes
   useEffect(() => {
     const wasHit = !prevIsHitRef.current && isHit;
+    const combatantChanged = prevCombatantRef.current !== combatant;
     prevIsHitRef.current = isHit;
+    prevCombatantRef.current = combatant;
 
+    // Reset state when combatant changes (new battle)
+    if (combatantChanged) {
+      setDisplayedHealth(derivedStats.currentHealth);
+      return;
+    }
+
+    // Update on hit animation start (attack damage)
     if (wasHit) {
-      // Update displayed health when hit animation starts
       setDisplayedHealth(derivedStats.currentHealth);
+      return;
     }
-  }, [isHit, derivedStats.currentHealth]);
 
-  // Also sync when health increases (healing) or on initial render
-  useEffect(() => {
-    if (derivedStats.currentHealth > displayedHealth) {
-      setDisplayedHealth(derivedStats.currentHealth);
-    }
-  }, [derivedStats.currentHealth, displayedHealth]);
+    // Handle healing or non-hit damage (e.g., DoT during turn resolution)
+    // Use functional update to avoid infinite loops
+    setDisplayedHealth((prev) => {
+      // Healing: immediately reflect increased health
+      if (derivedStats.currentHealth > prev) {
+        return derivedStats.currentHealth;
+      }
+      // Non-hit damage (DoT): sync when not animating a hit
+      if (derivedStats.currentHealth < prev && !isHit) {
+        return derivedStats.currentHealth;
+      }
+      return prev;
+    });
+  }, [isHit, derivedStats.currentHealth, combatant]);
 
   // Use displayed health for the visual HP bar
   const hpPercent = clampPercent(displayedHealth, derivedStats.maxHealth);


### PR DESCRIPTION
## Problem

When the player goes first in a battle, or generally when turn updates occur, the combatant's HP decreases *before* the corresponding attack animation plays. This creates a jarring visual experience where the damage is applied instantly, and the animation follows afterward.

## Root Cause

The battle system follows a "headless engine" pattern where logic and UI are strictly decoupled:
1. Game logic updates `battleState.player.currentHp` immediately when a turn is processed
2. React detects the change and re-renders `BattleArena` with the new HP value instantly
3. The `useEffect` that triggers attack animations runs *after* the render
4. Result: HP drops before the hit animation plays

## Solution

Implements **visual state buffering** in `PetBattleCard`:
- Maintains a local `displayedHealth` state separate from the actual `derivedStats.currentHealth`
- Only updates `displayedHealth` when the `isHit` animation triggers (false → true transition)
- Handles healing (HP increase) immediately for correct visual feedback
- The HP bar now syncs with the hit animation, showing damage at the moment of impact

## Testing

- All 743 existing tests pass
- Pre-commit hooks (biome check, typecheck, tests) all pass

Fixes the issue documented in `investigate/bug_battle_visual.md`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the HP bar with the hit animation in battle. Damage now appears at the moment of impact, not before.

- **Bug Fixes**
  - Added visual state buffering in PetBattleCard via displayedHealth.
  - Update displayedHealth only on isHit start; use it for HP bar and text.
  - Apply healing immediately to keep feedback accurate.
  - Reset displayed health on combatant change and support DoT damage that occurs without a hit animation.

<sup>Written for commit 868f429953eefe6195144971bf1b9eaf769516a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * **Pet Battle HP Display** - Health bar and HP text now buffer visual updates to align with hit and healing animations. HP values update smoothly after hit effects, preventing abrupt jumps and improving perceived timing between damage/healing and the displayed health for a more polished battle experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->