### PR TITLE
fix(battle): sync HP bar updates with hit animations

### DIFF
--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -20,6 +20,8 @@ interface BattleArenaProps {
   enemyAttacking?: boolean;
   playerHit?: boolean;
   enemyHit?: boolean;
+  /** When true, immediately sync displayed HP with actual HP (used for DoT, etc.) */
+  syncHpNow?: boolean;
   className?: string;
 }
 
@@ -34,6 +36,7 @@ export function BattleArena({
   enemyAttacking = false,
   playerHit = false,
   enemyHit = false,
+  syncHpNow = false,
   className,
 }: BattleArenaProps) {
   // Visual state buffering: track displayed HP separately from actual HP
@@ -92,6 +95,20 @@ export function BattleArena({
     });
     prevEnemyMaxHpRef.current = enemy.derivedStats.maxHealth;
   }, [enemy.derivedStats.currentHealth, enemy.derivedStats.maxHealth]);
+
+  // Sync displayed HP for DoT damage and other non-animated HP changes
+  // DoT is applied during turnResolved phase which has no animation.
+  // BattleScreen signals this via syncHpNow prop.
+  useEffect(() => {
+    if (syncHpNow) {
+      setDisplayedPlayerHp(player.derivedStats.currentHealth);
+      setDisplayedEnemyHp(enemy.derivedStats.currentHealth);
+    }
+  }, [
+    syncHpNow,
+    player.derivedStats.currentHealth,
+    enemy.derivedStats.currentHealth,
+  ]);
 
   // Create display combatants with buffered HP values (memoized for performance)
   const displayPlayer = useMemo<Combatant>(

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -115,11 +115,15 @@ export function BattleScreen({
   // Trigger immediate HP sync for non-animated HP changes (DoT, etc.)
   const triggerHpSync = useCallback(() => {
     setAnimationState((prev) => ({ ...prev, syncHpNow: true }));
-    // Reset syncHpNow on next tick to allow future syncs
-    setTimeout(() => {
-      setAnimationState((prev) => ({ ...prev, syncHpNow: false }));
-    }, 0);
   }, []);
+
+  // Reset syncHpNow after it has been observed by BattleArena
+  // This avoids setTimeout race conditions with multiple rapid events
+  useEffect(() => {
+    if (animationState.syncHpNow) {
+      setAnimationState((prev) => ({ ...prev, syncHpNow: false }));
+    }
+  }, [animationState.syncHpNow]);
 
   // Consume battle events for animations
   // The game state is ALREADY updated - we just play animations to visualize what happened

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -48,6 +48,8 @@ interface AnimationState {
   enemyAttacking: boolean;
   playerHit: boolean;
   enemyHit: boolean;
+  /** Force immediate HP sync (for DoT damage, etc.) */
+  syncHpNow: boolean;
 }
 
 const initialAnimationState: AnimationState = {
@@ -55,6 +57,7 @@ const initialAnimationState: AnimationState = {
   enemyAttacking: false,
   playerHit: false,
   enemyHit: false,
+  syncHpNow: false,
 };
 
 /**
@@ -99,6 +102,7 @@ export function BattleScreen({
         enemyAttacking: !isPlayerAttack,
         playerHit: !isPlayerAttack,
         enemyHit: isPlayerAttack,
+        syncHpNow: false,
       });
 
       animationTimeoutRef.current = setTimeout(() => {
@@ -106,6 +110,15 @@ export function BattleScreen({
         resolve();
       }, ATTACK_ANIMATION_DURATION_MS);
     });
+  }, []);
+
+  // Trigger immediate HP sync for non-animated HP changes (DoT, etc.)
+  const triggerHpSync = useCallback(() => {
+    setAnimationState((prev) => ({ ...prev, syncHpNow: true }));
+    // Reset syncHpNow on next tick to allow future syncs
+    setTimeout(() => {
+      setAnimationState((prev) => ({ ...prev, syncHpNow: false }));
+    }, 0);
   }, []);
 
   // Consume battle events for animations
@@ -135,8 +148,11 @@ export function BattleScreen({
           await triggerAttackAnimation(true);
         } else if (event.action === "enemyAttack") {
           await triggerAttackAnimation(false);
+        } else if (event.action === "turnResolved") {
+          // turnResolved has no animation, but may include DoT damage
+          // Signal BattleArena to sync HP immediately
+          triggerHpSync();
         }
-        // turnResolved has no animation - it's a state transition event only
       }
 
       if (isMounted) setIsAnimating(false);
@@ -150,7 +166,7 @@ export function BattleScreen({
     return () => {
       isMounted = false;
     };
-  }, [battleEvents, triggerAttackAnimation]);
+  }, [battleEvents, triggerAttackAnimation, triggerHpSync]);
 
   // Handle player move selection
   // UI simply expresses intent via dispatch - logic runs in the engine
@@ -226,6 +242,7 @@ export function BattleScreen({
           enemyAttacking={animationState.enemyAttacking}
           playerHit={animationState.playerHit}
           enemyHit={animationState.enemyHit}
+          syncHpNow={animationState.syncHpNow}
         />
 
         {/* Battle log */}


### PR DESCRIPTION
## Summary
Implements visual state buffering in BattleArena to fix the HP/animation desync bug.

## Problem
HP bars updated instantly when `battleState` changed, before the attack animation played. This caused damage to appear **before** the attack visually 'landed', creating a jarring user experience.

## Solution
`BattleArena` now maintains displayed HP values separately from the actual game state:

1. **Visual state buffering**: `displayedPlayerHp` and `displayedEnemyHp` state variables hold the HP values shown in the UI
2. **Rising edge detection**: HP updates are triggered only when hit animations **start** (when `playerHit`/`enemyHit` transitions from false → true)
3. **Healing/reset handling**: HP increases (healing or new battle) sync immediately to avoid showing stale lower values
4. **Display combatants**: Buffered HP values are passed to `PetBattleCard` via spread copies of the combatants

## Testing
- Pre-commit hooks pass (linting, type checking, tests)
- Manual testing confirms HP bar now updates in sync with hit animations

Fixes the battle visual bug documented in `investigate/bug_battle_visual.md`











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HP bars now update when hit animations start, so damage appears when the attack lands. Fixes the BattleArena HP/animation desync.

- **Bug Fixes**
  - Added visual state buffering via displayedPlayerHp/displayedEnemyHp.
  - Trigger HP updates on hit animation rising edge, not immediate state change.
  - Sync on combatant change, healing, and DoT (via syncHpNow) to avoid stale values.

<sup>Written for commit 39f8841ae6327e6a8a6fe4829dd96ef9561ceb6f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HP visuals now use buffered display state so damage, healing and max‑HP changes animate smoothly with hit effects, preventing jarring jumps and visual glitches.
  * Reduced race conditions by resetting the immediate‑sync flag after use to avoid conflicts during rapid events.

* **New Features**
  * Added an immediate HP‑sync option to force instant UI updates for DoT/sudden changes.
  * Turn resolution now triggers an explicit HP sync to keep visuals consistent with game state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->